### PR TITLE
Main  condition nodes yay  human v bot  board refactor  editor polish

### DIFF
--- a/app/assets/stylesheets/node_editor.css
+++ b/app/assets/stylesheets/node_editor.css
@@ -845,15 +845,15 @@
 }
 
 .node.selected {
-  box-shadow: 0 0 15px rgba(168, 85, 247, 0.8), 0 0 30px rgba(168, 85, 247, 0.4);
-  border-color: #C084FC;
+  border-color: #F0ABFC;
+  box-shadow: 0 0 20px rgba(240, 171, 252, 0.9), 0 0 40px rgba(240, 171, 252, 0.4);
 }
 
 .node.root.selected {
-  border-color: #F6D77A;
+  border-color: #FDE68A;
   box-shadow:
-    0 0 18px rgba(252, 227, 143, 0.9),
-    0 0 34px rgba(252, 227, 143, 0.42),
+    0 0 20px rgba(253, 230, 138, 0.9),
+    0 0 40px rgba(253, 230, 138, 0.4),
     0 0 10px rgba(192, 132, 252, 0.2);
 }
 
@@ -870,13 +870,13 @@
 }
 
 .node.action.selected::before {
-  box-shadow: 0 0 15px var(--action-glow-strong), 0 0 30px rgba(24, 183, 207, 0.35);
-  border-color: var(--action-accent-strong);
+  border-color: #A5F3FC;
+  box-shadow: 0 0 20px rgba(165, 243, 252, 0.9), 0 0 40px rgba(165, 243, 252, 0.4);
 }
 
 .node.organizer.selected {
-  border-color: #60a5fa;
-  box-shadow: 0 0 14px rgba(59, 130, 246, 0.75), 0 0 28px rgba(59, 130, 246, 0.28);
+  border-color: #93C5FD;
+  box-shadow: 0 0 20px rgba(147, 197, 253, 0.9), 0 0 40px rgba(147, 197, 253, 0.4);
 }
 
 .node.dragging {

--- a/app/controllers/bot_nodes_controller.rb
+++ b/app/controllers/bot_nodes_controller.rb
@@ -1,7 +1,7 @@
 class BotNodesController < ApplicationController
   before_action :authenticate_registered_or_guest_user!
   before_action :set_bot
-  before_action :set_node, only: [:show, :edit, :update, :destroy, :update_position]
+  before_action :set_node, only: [:show, :edit, :update, :update_position]
 
   def show
     respond_to do |format|
@@ -29,16 +29,6 @@ class BotNodesController < ApplicationController
     else
       render json: @node.errors, status: :unprocessable_entity
     end
-  end
-
-  def destroy
-    # Prevent deletion of root nodes
-    if @node.root?
-      render json: { error: "Cannot delete root node" }, status: :unprocessable_entity
-      return
-    end
-    @node.destroy
-    head :no_content
   end
 
   def batch_destroy

--- a/app/controllers/bot_nodes_controller.rb
+++ b/app/controllers/bot_nodes_controller.rb
@@ -41,6 +41,31 @@ class BotNodesController < ApplicationController
     head :no_content
   end
 
+  def batch_destroy
+    node_ids = Array(params[:node_ids]).map(&:to_i).reject(&:zero?)
+    deletable_nodes = @bot.nodes
+      .where(id: node_ids)
+      .where.not(node_type: 'root')
+      .includes(:outgoing_connections, :incoming_connections)
+
+    deleted_node_ids = []
+    deleted_connection_ids = []
+
+    ApplicationRecord.transaction do
+      deletable_nodes.each do |node|
+        deleted_node_ids << node.id
+        node.outgoing_connections.each { |connection| deleted_connection_ids << connection.id }
+        node.incoming_connections.each { |connection| deleted_connection_ids << connection.id }
+        node.destroy!
+      end
+    end
+
+    render json: {
+      deleted_node_ids: deleted_node_ids,
+      deleted_connection_ids: deleted_connection_ids.uniq
+    }
+  end
+
   def update_position
     if @node.update(position_x: params[:position_x], position_y: params[:position_y])
       render json: @node

--- a/app/javascript/controllers/bot_guide_controller.js
+++ b/app/javascript/controllers/bot_guide_controller.js
@@ -39,20 +39,15 @@ export default class extends Controller {
 
   scrollToSection(event) {
     event.preventDefault()
-
     const sectionId = event.currentTarget.dataset.sectionId
     if (!sectionId || !this.hasContentTarget) return
-
     const section = this.contentTarget.querySelector(`#${sectionId}`)
     if (!section) return
-
     section.scrollIntoView({ behavior: "smooth", block: "start" })
   }
 
   handleKeydown(event) {
-    if (event.key === "Escape" && this.isOpen()) {
-      this.close()
-    }
+    if (event.key === "Escape" && this.isOpen()) { this.close() }
   }
 
   updateToggleState(expanded) {

--- a/app/javascript/controllers/editor_controller.js
+++ b/app/javascript/controllers/editor_controller.js
@@ -8,19 +8,14 @@ export default class extends Controller {
     const container = document.getElementById('nodes-canvas')
     const svgContainer = document.getElementById('connections-canvas')
     const editorPanel = document.getElementById('node-form-panel')
-    
     if (!container || !svgContainer) {
       console.error('Editor container elements not found')
       return
     }
-    
     initEditor(this.botIdValue, container, svgContainer, editorPanel)
       .then(api => {
         console.log('editorV2 initialized successfully')
-        // Expose API only in non-production environments
-        if (document.body.dataset.environment !== 'production') {
-          window.editorAPI = api
-        }
+        if (document.body.dataset.environment !== 'production') { window.editorAPI = api }
       })
       .catch(err => {
         console.error('Failed to initialize editorV2:', err)

--- a/app/javascript/controllers/hello_controller.js
+++ b/app/javascript/controllers/hello_controller.js
@@ -1,7 +1,0 @@
-import { Controller } from "@hotwired/stimulus"
-
-export default class extends Controller {
-  connect() {
-    this.element.textContent = "Hello World!"
-  }
-}

--- a/app/javascript/controllers/match_setup_controller.js
+++ b/app/javascript/controllers/match_setup_controller.js
@@ -4,19 +4,14 @@ export default class extends Controller {
   static targets = ["staleBotConfirmation"]
 
   confirmStaleCompile(event) {
-    if (this.staleBotConfirmationTarget.value === 'compile') return
-
+    if (this.staleBotConfirmationTarget.value === 'compile') { return }
     const staleOwnedBots = this.selectedStaleOwnedBots()
-    if (staleOwnedBots.length === 0) return
-
+    if (staleOwnedBots.length === 0) { return }
     event.preventDefault()
-
     const message = staleOwnedBots.length === 1
       ? `${staleOwnedBots[0].name} needs to be recompiled before match generation. Compile and continue?`
       : `${staleOwnedBots.map(bot => bot.name).join(' and ')} each need to be recompiled before match generation. Compile both and continue?`
-
-    if (!window.confirm(message)) return
-
+    if (!window.confirm(message)) { return }
     this.staleBotConfirmationTarget.value = 'compile'
     this.element.submit()
   }

--- a/app/javascript/controllers/sidebar_controller.js
+++ b/app/javascript/controllers/sidebar_controller.js
@@ -32,18 +32,14 @@ export default class extends Controller {
   open() {
     this.sidebarTarget.classList.add('sidebar--open')
     this.sidebarTarget.classList.remove('sidebar--closed')
-    if (this.hasOverlayTarget) {
-      this.overlayTarget.classList.add('sidebar-overlay--visible')
-    }
+    if (this.hasOverlayTarget) { this.overlayTarget.classList.add('sidebar-overlay--visible') }
     document.body.style.overflow = 'hidden'
   }
   
   close() {
     this.sidebarTarget.classList.remove('sidebar--open')
     this.sidebarTarget.classList.add('sidebar--closed')
-    if (this.hasOverlayTarget) {
-      this.overlayTarget.classList.remove('sidebar-overlay--visible')
-    }
+    if (this.hasOverlayTarget) { this.overlayTarget.classList.remove('sidebar-overlay--visible') }
     document.body.style.overflow = ''
   }
   

--- a/app/javascript/controllers/tournament_poll_controller.js
+++ b/app/javascript/controllers/tournament_poll_controller.js
@@ -12,7 +12,6 @@ export default class extends Controller {
 
   connect() {
     if (!this.activeValue) { return }
-
     this.poll()
     this.startPolling()
   }
@@ -28,7 +27,6 @@ export default class extends Controller {
 
   stopPolling() {
     if (!this.pollTimer) { return }
-
     window.clearInterval(this.pollTimer)
     this.pollTimer = null
   }
@@ -39,18 +37,13 @@ export default class extends Controller {
         headers: { Accept: "application/json" },
         credentials: "same-origin"
       })
-
       if (!response.ok) { return }
-
       const payload = await response.json()
       this.replaceSection(this.metaTarget, payload.meta_html)
       this.updateSectionFields(this.progressTarget, payload.progress_html)
       this.updateStandings(this.standingsTarget, payload.standings_html)
       this.updateSectionFields(this.matrixTarget, payload.matrix_html)
-
-      if (payload.polling_complete) {
-        this.stopPolling()
-      }
+      if (payload.polling_complete) { this.stopPolling() }
     } catch (_error) {
       this.stopPolling()
     }
@@ -58,7 +51,6 @@ export default class extends Controller {
 
   replaceSection(target, html) {
     if (target.innerHTML === html) { return }
-
     target.innerHTML = html
   }
 
@@ -68,25 +60,20 @@ export default class extends Controller {
     const currentFieldsByKey = new Map(
       Array.from(target.querySelectorAll("[data-tournament-field]")).map((element) => [element.dataset.tournamentField, element])
     )
-
     if (incomingFields.length === 0 || currentFieldsByKey.size === 0) {
       this.replaceSection(target, html)
       return
     }
-
     const incomingKeys = incomingFields.map((element) => element.dataset.tournamentField)
     const currentKeys = Array.from(currentFieldsByKey.keys())
-
     if (!this.sameKeys(currentKeys, incomingKeys)) {
       this.replaceSection(target, html)
       return
     }
-
     incomingFields.forEach((incomingField) => {
       const currentField = currentFieldsByKey.get(incomingField.dataset.tournamentField)
       if (!currentField) { return }
       if (currentField.innerHTML === incomingField.innerHTML) { return }
-
       currentField.innerHTML = incomingField.innerHTML
       this.flash(currentField)
     })
@@ -96,38 +83,30 @@ export default class extends Controller {
     const fragment = this.fragmentFor(html)
     const incomingBody = fragment.querySelector("tbody")
     const currentBody = target.querySelector("tbody")
-
     if (!incomingBody || !currentBody) {
       this.replaceSection(target, html)
       return
     }
-
     const incomingRows = Array.from(incomingBody.querySelectorAll("[data-tournament-row]"))
     const currentRowsByKey = new Map(
       Array.from(currentBody.querySelectorAll("[data-tournament-row]")).map((row) => [row.dataset.tournamentRow, row])
     )
-
     if (incomingRows.length === 0 || currentRowsByKey.size === 0) {
       this.replaceSection(target, html)
       return
     }
-
     const incomingKeys = incomingRows.map((row) => row.dataset.tournamentRow)
     const currentKeys = Array.from(currentRowsByKey.keys())
-
     if (!this.sameMembers(currentKeys, incomingKeys)) {
       this.replaceSection(target, html)
       return
     }
-
     incomingRows.forEach((incomingRow, index) => {
       const key = incomingRow.dataset.tournamentRow
       const currentRow = currentRowsByKey.get(key)
       if (!currentRow) { return }
-
       currentBody.appendChild(currentRow)
       this.updateRowFields(currentRow, incomingRow)
-
       if (currentKeys[index] !== key) {
         this.flash(currentRow)
       }
@@ -139,12 +118,10 @@ export default class extends Controller {
     const currentFieldsByKey = new Map(
       Array.from(currentRow.querySelectorAll("[data-tournament-field]")).map((element) => [element.dataset.tournamentField, element])
     )
-
     incomingFields.forEach((incomingField) => {
       const currentField = currentFieldsByKey.get(incomingField.dataset.tournamentField)
       if (!currentField) { return }
       if (currentField.innerHTML === incomingField.innerHTML) { return }
-
       currentField.innerHTML = incomingField.innerHTML
       this.flash(currentField)
     })
@@ -158,13 +135,11 @@ export default class extends Controller {
 
   sameKeys(left, right) {
     if (left.length !== right.length) { return false }
-
     return left.every((key, index) => key === right[index])
   }
 
   sameMembers(left, right) {
     if (left.length !== right.length) { return false }
-
     const leftSet = new Set(left)
     return right.every((key) => leftSet.has(key))
   }
@@ -173,7 +148,6 @@ export default class extends Controller {
     element.classList.remove("tournament-poll-updated")
     void element.offsetWidth
     element.classList.add("tournament-poll-updated")
-
     window.setTimeout(() => {
       element.classList.remove("tournament-poll-updated")
     }, FLASH_DURATION_MS)

--- a/app/javascript/editorV2/__tests__/ClickHandler.test.js
+++ b/app/javascript/editorV2/__tests__/ClickHandler.test.js
@@ -43,6 +43,7 @@ function dispatchClick(element, overrides = {}) {
 describe('ClickHandler', () => {
   let store
   let history
+  let syncManager
   let editorPanel
   let clickHandler
   let rootNode
@@ -68,7 +69,12 @@ describe('ClickHandler', () => {
     conditionElement = buildNodeElement(conditionNode.clientId)
     actionElement = buildNodeElement(actionNode.clientId)
 
+    syncManager = {
+      deleteNodes: vi.fn().mockResolvedValue({})
+    }
+
     clickHandler = new ClickHandler(store, history, editorPanel)
+    clickHandler.setSyncManager(syncManager)
     clickHandler.attach(rootElement, rootNode.clientId)
     clickHandler.attach(conditionElement, conditionNode.clientId)
     clickHandler.attach(actionElement, actionNode.clientId)
@@ -130,6 +136,23 @@ describe('ClickHandler', () => {
 
     expect(store.getSelectedNodeIds()).toEqual([])
     expect(store.getEditingNode()).toBe(null)
+    expect(editorPanel.classList.contains('hidden')).toBe(true)
+  })
+
+  it('deletes the selected node set with one confirmation and closes the editor when needed', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    dispatchClick(conditionElement)
+    dispatchClick(actionElement, { shiftKey: true })
+
+    expect(store.getSelectedNodeIds()).toEqual([conditionNode.clientId, actionNode.clientId])
+    expect(store.getEditingNode()).toBe(conditionNode.clientId)
+
+    await clickHandler.deleteSelectedNodes()
+
+    expect(confirmSpy).toHaveBeenCalledWith('Delete 2 selected nodes?')
+    expect(syncManager.deleteNodes).toHaveBeenCalledWith([conditionNode.clientId, actionNode.clientId])
+    expect(store.getSelectedNodeIds()).toEqual([])
+    expect(clickHandler.getEditingNodeId()).toBe(null)
     expect(editorPanel.classList.contains('hidden')).toBe(true)
   })
 })

--- a/app/javascript/editorV2/__tests__/ClickHandler.test.js
+++ b/app/javascript/editorV2/__tests__/ClickHandler.test.js
@@ -1,0 +1,135 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
+import ClickHandler from '../handlers/ClickHandler.js'
+import Store from '../state/Store.js'
+import Node from '../models/Node.js'
+
+vi.mock('../panels/ConditionForm', () => ({
+  default: class {
+    attach() {}
+    detach() {}
+    populate() {}
+  }
+}))
+
+function buildNodeElement(clientId) {
+  const element = document.createElement('div')
+  element.className = 'node'
+  element.dataset.clientId = clientId
+  return element
+}
+
+function buildEditorPanel() {
+  const panel = document.createElement('div')
+  panel.id = 'node-form-panel'
+  panel.className = 'node-form-panel hidden'
+  panel.innerHTML = `
+    <span id="edit-node-type"></span>
+    <div id="condition-form" class="hidden"></div>
+    <div id="action-form" class="hidden"></div>
+    <div id="organizer-form" class="hidden"></div>
+  `
+  document.body.appendChild(panel)
+  return panel
+}
+
+function dispatchClick(element, overrides = {}) {
+  element.dispatchEvent(new MouseEvent('click', {
+    bubbles: true,
+    cancelable: true,
+    ...overrides
+  }))
+}
+
+describe('ClickHandler', () => {
+  let store
+  let history
+  let editorPanel
+  let clickHandler
+  let rootNode
+  let conditionNode
+  let actionNode
+  let rootElement
+  let conditionElement
+  let actionElement
+
+  beforeEach(() => {
+    store = new Store()
+    history = {}
+    editorPanel = buildEditorPanel()
+
+    rootNode = new Node({ clientId: 'root', type: 'root', position: { x: 0, y: 0 } })
+    conditionNode = new Node({ clientId: 'condition', type: 'condition', position: { x: 100, y: 100 } })
+    actionNode = new Node({ clientId: 'action', type: 'action', position: { x: 200, y: 100 } })
+    store.addNode(rootNode)
+    store.addNode(conditionNode)
+    store.addNode(actionNode)
+
+    rootElement = buildNodeElement(rootNode.clientId)
+    conditionElement = buildNodeElement(conditionNode.clientId)
+    actionElement = buildNodeElement(actionNode.clientId)
+
+    clickHandler = new ClickHandler(store, history, editorPanel)
+    clickHandler.attach(rootElement, rootNode.clientId)
+    clickHandler.attach(conditionElement, conditionNode.clientId)
+    clickHandler.attach(actionElement, actionNode.clientId)
+    clickHandler.setupGlobalHandlers()
+  })
+
+  afterEach(() => {
+    clickHandler.destroy()
+    editorPanel.remove()
+    vi.restoreAllMocks()
+  })
+
+  it('opens the editor on a plain single-click on a non-root node', () => {
+    dispatchClick(conditionElement)
+
+    expect(store.getSelectedNodeIds()).toEqual([conditionNode.clientId])
+    expect(store.getEditingNode()).toBe(conditionNode.clientId)
+    expect(editorPanel.classList.contains('hidden')).toBe(false)
+    expect(editorPanel.classList.contains('node-form-panel--condition')).toBe(true)
+  })
+
+  it('does not open the editor on a root node click', () => {
+    dispatchClick(rootElement)
+
+    expect(store.getSelectedNodeIds()).toEqual([rootNode.clientId])
+    expect(store.getEditingNode()).toBe(null)
+    expect(editorPanel.classList.contains('hidden')).toBe(true)
+  })
+
+  it('does not open the editor for shift-click or alt-click selection', () => {
+    dispatchClick(conditionElement, { shiftKey: true })
+
+    expect(store.getSelectedNodeIds()).toEqual([conditionNode.clientId])
+    expect(store.getEditingNode()).toBe(null)
+    expect(editorPanel.classList.contains('hidden')).toBe(true)
+
+    store.selectOnlyNode(conditionNode.clientId)
+    dispatchClick(actionElement, { altKey: true })
+
+    expect(store.getSelectedNodeIds()).toEqual([actionNode.clientId])
+    expect(store.getEditingNode()).toBe(null)
+    expect(editorPanel.classList.contains('hidden')).toBe(true)
+  })
+
+  it('keeps the editor open when clicking inside it and closes it on background clicks', () => {
+    dispatchClick(conditionElement)
+
+    const editorButton = document.createElement('button')
+    editorButton.type = 'button'
+    editorPanel.appendChild(editorButton)
+
+    dispatchClick(editorButton)
+
+    expect(store.getSelectedNodeIds()).toEqual([conditionNode.clientId])
+    expect(store.getEditingNode()).toBe(conditionNode.clientId)
+    expect(editorPanel.classList.contains('hidden')).toBe(false)
+
+    dispatchClick(document.body)
+
+    expect(store.getSelectedNodeIds()).toEqual([])
+    expect(store.getEditingNode()).toBe(null)
+    expect(editorPanel.classList.contains('hidden')).toBe(true)
+  })
+})

--- a/app/javascript/editorV2/__tests__/DragHandler.test.js
+++ b/app/javascript/editorV2/__tests__/DragHandler.test.js
@@ -318,6 +318,23 @@ describe('DragHandler', () => {
       expect(store.getNode('child').position).toEqual({ x: 200, y: 150 })
     })
 
+    it('updates the recent placement anchor after a successful single-node drag', async () => {
+      addNode(store, { clientId: 'node-1', type: 'condition', x: 100, y: 100 })
+      const anchorSpy = vi.spyOn(store, 'setRecentPlacementAnchor')
+
+      const startEvent = buildMouseEvent({ clientX: 100, clientY: 100 })
+      const moveEvent = buildMouseEvent({ clientX: 150, clientY: 160 })
+      const endEvent = buildMouseEvent({ clientX: 150, clientY: 160 })
+
+      beginDrag(dragHandler, 'node-1', mockElement, startEvent)
+      dragHandler.handleMouseMove(moveEvent)
+      dragHandler.handleMouseUp(endEvent)
+
+      await vi.waitFor(() => {
+        expect(anchorSpy).toHaveBeenCalledWith({ x: 150, y: 160 })
+      })
+    })
+
   })
 
   describe('cancelDrag', () => {

--- a/app/javascript/editorV2/__tests__/KeyboardHandler.test.js
+++ b/app/javascript/editorV2/__tests__/KeyboardHandler.test.js
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import KeyboardHandler from '../handlers/KeyboardHandler.js'
+import Store from '../state/Store.js'
+import Node from '../models/Node.js'
+import { findAnchoredNodePlacement } from '../utils/nodePlacement.js'
+
+vi.mock('../utils/nodePlacement.js', () => ({
+  findAnchoredNodePlacement: vi.fn(() => ({ x: 640, y: 480 }))
+}))
+
+describe('KeyboardHandler', () => {
+  let store
+  let history
+  let syncManager
+  let keyboardHandler
+
+  beforeEach(() => {
+    store = new Store()
+    history = {
+      canUndo: vi.fn(() => true),
+      canRedo: vi.fn(() => true)
+    }
+    syncManager = {
+      isUndoRedoPending: false,
+      undo: vi.fn().mockResolvedValue({}),
+      redo: vi.fn().mockResolvedValue({}),
+      createNode: vi.fn().mockResolvedValue('copied-node')
+    }
+    store.addNode(new Node({ clientId: 'root', type: 'root', position: { x: 0, y: 0 } }))
+    store.addNode(new Node({
+      clientId: 'condition',
+      type: 'condition',
+      position: { x: 300, y: 300 },
+      data: {
+        nested: { value: 1 }
+      }
+    }))
+
+    keyboardHandler = new KeyboardHandler(store, history, syncManager)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('does not copy when nothing, multiple nodes, or a root node is selected', () => {
+    expect(keyboardHandler.copySelectedNode()).toBe(false)
+    expect(keyboardHandler.clipboard).toBe(null)
+
+    store.setSelectedNodeIds(['root', 'condition'])
+    expect(keyboardHandler.copySelectedNode()).toBe(false)
+    expect(keyboardHandler.clipboard).toBe(null)
+
+    store.selectOnlyNode('root')
+    expect(keyboardHandler.copySelectedNode()).toBe(false)
+    expect(keyboardHandler.clipboard).toBe(null)
+  })
+
+  it('copies a single non-root node as a deep clone', () => {
+    store.selectOnlyNode('condition')
+
+    expect(keyboardHandler.copySelectedNode()).toBe(true)
+    expect(keyboardHandler.clipboard).toEqual({
+      type: 'condition',
+      data: { nested: { value: 1 } },
+      position: { x: 300, y: 300 }
+    })
+
+    keyboardHandler.clipboard.data.nested.value = 99
+
+    expect(store.getNode('condition').data.nested.value).toBe(1)
+  })
+
+  it('pastes the copied node near the recent placement anchor and selects it', async () => {
+    store.setSelectedNodeIds(['condition'])
+    keyboardHandler.copySelectedNode()
+    store.setRecentPlacementAnchor({ x: 680, y: 540 })
+
+    await keyboardHandler.pasteCopiedNode()
+
+    expect(vi.mocked(findAnchoredNodePlacement)).toHaveBeenCalledWith(
+      store,
+      'condition',
+      { x: 680, y: 540 }
+    )
+    expect(syncManager.createNode).toHaveBeenCalledWith(
+      'condition',
+      { x: 640, y: 480 },
+      { nested: { value: 1 } }
+    )
+    expect(store.getSelectedNodeIds()).toEqual(['copied-node'])
+  })
+
+  it('falls back to the copied node position when no recent anchor exists', async () => {
+    store.selectOnlyNode('condition')
+    keyboardHandler.copySelectedNode()
+
+    await keyboardHandler.pasteCopiedNode()
+
+    expect(vi.mocked(findAnchoredNodePlacement)).toHaveBeenCalledWith(
+      store,
+      'condition',
+      { x: 300, y: 300 }
+    )
+  })
+
+  it('ignores copy/paste shortcuts inside form fields and preserves undo/redo', () => {
+    const inputTarget = { tagName: 'INPUT' }
+    keyboardHandler.handleKeyDown({ target: inputTarget, ctrlKey: true, key: 'c', preventDefault: vi.fn() })
+    keyboardHandler.handleKeyDown({ target: inputTarget, ctrlKey: true, key: 'v', preventDefault: vi.fn() })
+    expect(keyboardHandler.clipboard).toBe(null)
+
+    const editableTarget = { tagName: 'DIV', isContentEditable: true }
+    keyboardHandler.handleKeyDown({ target: editableTarget, ctrlKey: true, key: 'c', preventDefault: vi.fn() })
+    expect(keyboardHandler.clipboard).toBe(null)
+
+    keyboardHandler.handleKeyDown({ target: document.body, ctrlKey: true, key: 'z', preventDefault: vi.fn() })
+    keyboardHandler.handleKeyDown({ target: document.body, ctrlKey: true, shiftKey: true, key: 'z', preventDefault: vi.fn() })
+
+    expect(syncManager.undo).toHaveBeenCalled()
+    expect(syncManager.redo).toHaveBeenCalled()
+  })
+})

--- a/app/javascript/editorV2/__tests__/KeyboardHandler.test.js
+++ b/app/javascript/editorV2/__tests__/KeyboardHandler.test.js
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import KeyboardHandler from '../handlers/KeyboardHandler.js'
 import Store from '../state/Store.js'
 import Node from '../models/Node.js'
+import Connection from '../models/Connection.js'
 import { findAnchoredNodePlacement } from '../utils/nodePlacement.js'
 
 vi.mock('../utils/nodePlacement.js', () => ({
@@ -24,16 +25,14 @@ describe('KeyboardHandler', () => {
       isUndoRedoPending: false,
       undo: vi.fn().mockResolvedValue({}),
       redo: vi.fn().mockResolvedValue({}),
-      createNode: vi.fn().mockResolvedValue('copied-node')
+      insertNodeSet: vi.fn().mockResolvedValue({ clientIds: ['pasted-1'] })
     }
     store.addNode(new Node({ clientId: 'root', type: 'root', position: { x: 0, y: 0 } }))
     store.addNode(new Node({
       clientId: 'condition',
       type: 'condition',
       position: { x: 300, y: 300 },
-      data: {
-        nested: { value: 1 }
-      }
+      data: { nested: { value: 1 } }
     }))
 
     keyboardHandler = new KeyboardHandler(store, history, syncManager)
@@ -43,65 +42,134 @@ describe('KeyboardHandler', () => {
     vi.restoreAllMocks()
   })
 
-  it('does not copy when nothing, multiple nodes, or a root node is selected', () => {
-    expect(keyboardHandler.copySelectedNode()).toBe(false)
-    expect(keyboardHandler.clipboard).toBe(null)
-
-    store.setSelectedNodeIds(['root', 'condition'])
-    expect(keyboardHandler.copySelectedNode()).toBe(false)
-    expect(keyboardHandler.clipboard).toBe(null)
-
-    store.selectOnlyNode('root')
-    expect(keyboardHandler.copySelectedNode()).toBe(false)
-    expect(keyboardHandler.clipboard).toBe(null)
-  })
-
-  it('copies a single non-root node as a deep clone', () => {
-    store.selectOnlyNode('condition')
-
-    expect(keyboardHandler.copySelectedNode()).toBe(true)
-    expect(keyboardHandler.clipboard).toEqual({
-      type: 'condition',
-      data: { nested: { value: 1 } },
-      position: { x: 300, y: 300 }
+  describe('copySelectedNodes', () => {
+    it('returns false when nothing is selected', () => {
+      expect(keyboardHandler.copySelectedNodes()).toBe(false)
+      expect(keyboardHandler.clipboard).toBe(null)
     })
 
-    keyboardHandler.clipboard.data.nested.value = 99
+    it('returns false when only root nodes are selected', () => {
+      store.selectOnlyNode('root')
+      expect(keyboardHandler.copySelectedNodes()).toBe(false)
+      expect(keyboardHandler.clipboard).toBe(null)
+    })
 
-    expect(store.getNode('condition').data.nested.value).toBe(1)
+    it('copies a single non-root node with deep-cloned data', () => {
+      store.selectOnlyNode('condition')
+
+      expect(keyboardHandler.copySelectedNodes()).toBe(true)
+      expect(keyboardHandler.clipboard.nodes).toHaveLength(1)
+      expect(keyboardHandler.clipboard.nodes[0].type).toBe('condition')
+      expect(keyboardHandler.clipboard.nodes[0].data).toEqual({ nested: { value: 1 } })
+      expect(keyboardHandler.clipboard.connections).toEqual([])
+      expect(keyboardHandler.clipboard.anchorPosition).toEqual({ x: 300, y: 300 })
+
+      keyboardHandler.clipboard.nodes[0].data.nested.value = 99
+      expect(store.getNode('condition').data.nested.value).toBe(1)
+    })
+
+    it('copies multiple non-root nodes and their internal connections', () => {
+      const node2 = new Node({ clientId: 'action', type: 'action', position: { x: 500, y: 300 } })
+      store.addNode(node2)
+      store.addConnection(new Connection({ clientId: 'conn-1', sourceId: 'condition', targetId: 'action' }))
+
+      store.setSelectedNodeIds(['condition', 'action'])
+      expect(keyboardHandler.copySelectedNodes()).toBe(true)
+
+      expect(keyboardHandler.clipboard.nodes).toHaveLength(2)
+      expect(keyboardHandler.clipboard.connections).toHaveLength(1)
+      expect(keyboardHandler.clipboard.connections[0].sourceIndex).toBe(0)
+      expect(keyboardHandler.clipboard.connections[0].targetIndex).toBe(1)
+    })
+
+    it('excludes connections to nodes outside the selection', () => {
+      const node2 = new Node({ clientId: 'action', type: 'action', position: { x: 500, y: 300 } })
+      store.addNode(node2)
+      store.addConnection(new Connection({ clientId: 'conn-1', sourceId: 'condition', targetId: 'action' }))
+
+      store.selectOnlyNode('condition')
+      expect(keyboardHandler.copySelectedNodes()).toBe(true)
+
+      expect(keyboardHandler.clipboard.nodes).toHaveLength(1)
+      expect(keyboardHandler.clipboard.connections).toHaveLength(0)
+    })
+
+    it('stores relative positions from the anchor node', () => {
+      const node2 = new Node({ clientId: 'action', type: 'action', position: { x: 500, y: 350 } })
+      store.addNode(node2)
+
+      store.setSelectedNodeIds(['condition', 'action'])
+      keyboardHandler.copySelectedNodes()
+
+      const nodes = keyboardHandler.clipboard.nodes
+      expect(nodes[0].relativeX).toBe(0)
+      expect(nodes[0].relativeY).toBe(0)
+      expect(nodes[1].relativeX).toBe(200)
+      expect(nodes[1].relativeY).toBe(50)
+    })
   })
 
-  it('pastes the copied node near the recent placement anchor and selects it', async () => {
-    store.setSelectedNodeIds(['condition'])
-    keyboardHandler.copySelectedNode()
-    store.setRecentPlacementAnchor({ x: 680, y: 540 })
+  describe('pasteCopiedNodes', () => {
+    it('pastes a single node near the recent placement anchor and selects it', async () => {
+      syncManager.insertNodeSet.mockResolvedValue({ clientIds: ['pasted-1'] })
 
-    await keyboardHandler.pasteCopiedNode()
+      store.setSelectedNodeIds(['condition'])
+      keyboardHandler.copySelectedNodes()
+      store.setRecentPlacementAnchor({ x: 680, y: 540 })
 
-    expect(vi.mocked(findAnchoredNodePlacement)).toHaveBeenCalledWith(
-      store,
-      'condition',
-      { x: 680, y: 540 }
-    )
-    expect(syncManager.createNode).toHaveBeenCalledWith(
-      'condition',
-      { x: 640, y: 480 },
-      { nested: { value: 1 } }
-    )
-    expect(store.getSelectedNodeIds()).toEqual(['copied-node'])
-  })
+      await keyboardHandler.pasteCopiedNodes()
 
-  it('falls back to the copied node position when no recent anchor exists', async () => {
-    store.selectOnlyNode('condition')
-    keyboardHandler.copySelectedNode()
+      expect(vi.mocked(findAnchoredNodePlacement)).toHaveBeenCalledWith(
+        store,
+        'condition',
+        { x: 680, y: 540 }
+      )
+      expect(syncManager.insertNodeSet).toHaveBeenCalledTimes(1)
+      const [nodeModels, connectionModels, description] = syncManager.insertNodeSet.mock.calls[0]
+      expect(nodeModels).toHaveLength(1)
+      expect(nodeModels[0].type).toBe('condition')
+      expect(connectionModels).toHaveLength(0)
+      expect(description).toBe('Paste nodes')
+      expect(store.getSelectedNodeIds()).toEqual(['pasted-1'])
+    })
 
-    await keyboardHandler.pasteCopiedNode()
+    it('falls back to the clipboard anchor position when no recent anchor exists', async () => {
+      store.selectOnlyNode('condition')
+      keyboardHandler.copySelectedNodes()
 
-    expect(vi.mocked(findAnchoredNodePlacement)).toHaveBeenCalledWith(
-      store,
-      'condition',
-      { x: 300, y: 300 }
-    )
+      await keyboardHandler.pasteCopiedNodes()
+
+      expect(vi.mocked(findAnchoredNodePlacement)).toHaveBeenCalledWith(
+        store,
+        'condition',
+        { x: 300, y: 300 }
+      )
+    })
+
+    it('pastes multiple nodes with connections', async () => {
+      syncManager.insertNodeSet.mockResolvedValue({ clientIds: ['pasted-1', 'pasted-2'] })
+
+      const node2 = new Node({ clientId: 'action', type: 'action', position: { x: 500, y: 350 } })
+      store.addNode(node2)
+      store.addConnection(new Connection({ clientId: 'conn-1', sourceId: 'condition', targetId: 'action' }))
+
+      store.setSelectedNodeIds(['condition', 'action'])
+      keyboardHandler.copySelectedNodes()
+      store.setRecentPlacementAnchor({ x: 680, y: 540 })
+
+      await keyboardHandler.pasteCopiedNodes()
+
+      const [nodeModels, connectionModels] = syncManager.insertNodeSet.mock.calls[0]
+      expect(nodeModels).toHaveLength(2)
+      expect(connectionModels).toHaveLength(1)
+      expect(store.getSelectedNodeIds()).toEqual(['pasted-1', 'pasted-2'])
+    })
+
+    it('does nothing when clipboard is empty', async () => {
+      await keyboardHandler.pasteCopiedNodes()
+
+      expect(syncManager.insertNodeSet).not.toHaveBeenCalled()
+    })
   })
 
   it('ignores copy/paste shortcuts inside form fields and preserves undo/redo', () => {

--- a/app/javascript/editorV2/__tests__/Store.test.js
+++ b/app/javascript/editorV2/__tests__/Store.test.js
@@ -511,6 +511,18 @@ describe('Store', () => {
       expect(store.getPrimarySelectedNode()).toBe('node-1')
     })
 
+    it('emits selection changes when selected node ids are set directly', () => {
+      const callback = vi.fn()
+      store.subscribe(callback)
+
+      store.setSelectedNodeIds(['node-1', 'node-2'])
+
+      expect(callback).toHaveBeenCalledWith(EVENTS.SELECTION_CHANGE, {
+        selectedNodeIds: ['node-1', 'node-2'],
+        primarySelectedNodeId: 'node-1'
+      })
+    })
+
     it('tracks marquee state', () => {
       store.startMarquee({ x: 10, y: 20 })
       expect(store.getMarqueeState()).toEqual({

--- a/app/javascript/editorV2/__tests__/Store.test.js
+++ b/app/javascript/editorV2/__tests__/Store.test.js
@@ -29,6 +29,23 @@ describe('Store', () => {
       expect(store.viewState.panY).toBe(0)
       expect(store.viewState.selectedNodeIds).toEqual([])
       expect(store.viewState.primarySelectedNodeId).toBe(null)
+      expect(store.getRecentPlacementAnchor()).toBe(null)
+    })
+  })
+
+  describe('recent placement anchor', () => {
+    it('sets, clones, and clears the anchor', () => {
+      store.setRecentPlacementAnchor({ x: 120, y: 240 })
+
+      expect(store.getRecentPlacementAnchor()).toEqual({ x: 120, y: 240 })
+
+      const anchor = store.getRecentPlacementAnchor()
+      anchor.x = 999
+
+      expect(store.getRecentPlacementAnchor()).toEqual({ x: 120, y: 240 })
+
+      store.clearRecentPlacementAnchor()
+      expect(store.getRecentPlacementAnchor()).toBe(null)
     })
   })
 

--- a/app/javascript/editorV2/__tests__/SyncManager.test.js
+++ b/app/javascript/editorV2/__tests__/SyncManager.test.js
@@ -364,6 +364,7 @@ describe('SyncManager', () => {
       expect(store.getNode(clientId)).toBeDefined()
       expect(store.getNode(clientId).type).toBe('condition')
       expect(store.getNode(clientId).data).toEqual(DEFAULT_CONDITION_DATA)
+      expect(store.getRecentPlacementAnchor()).toEqual({ x: 100, y: 100 })
     })
 
     it('optimistically adds node to store', async () => {
@@ -443,6 +444,7 @@ describe('SyncManager', () => {
 
       expect(store.getNode('n1').position.x).toBe(100)
       expect(store.getNode('n1').position.y).toBe(200)
+      expect(store.getRecentPlacementAnchor()).toEqual({ x: 100, y: 200 })
     })
 
     it('calls API with correct params', async () => {
@@ -493,6 +495,7 @@ describe('SyncManager', () => {
 
       expect(store.getNode('n1').data.foo).toBe('bar')
       expect(store.getNode('n1').data.baz).toBe('qux')
+      expect(store.getRecentPlacementAnchor()).toEqual({ x: 0, y: 0 })
     })
 
     it('pushes to history after success', async () => {
@@ -526,6 +529,7 @@ describe('SyncManager', () => {
       await syncManager.deleteNode('n1')
 
       expect(store.getNodes()).toHaveLength(0)
+      expect(store.getRecentPlacementAnchor()).toEqual({ x: 0, y: 0 })
     })
 
     it('stores node data for history', async () => {
@@ -576,6 +580,7 @@ describe('SyncManager', () => {
 
       expect(clientId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i)
       expect(store.getConnection(clientId)).toBeDefined()
+      expect(store.getRecentPlacementAnchor()).toEqual({ x: 100, y: 100 })
     })
 
     it('optimistically adds connection to store', async () => {
@@ -632,6 +637,7 @@ describe('SyncManager', () => {
       await syncManager.deleteConnection('c1')
 
       expect(store.getConnections()).toHaveLength(0)
+      expect(store.getRecentPlacementAnchor()).toEqual({ x: 100, y: 100 })
     })
 
     it('pushes to history after success', async () => {

--- a/app/javascript/editorV2/__tests__/SyncManager.test.js
+++ b/app/javascript/editorV2/__tests__/SyncManager.test.js
@@ -20,6 +20,7 @@ describe('SyncManager', () => {
     mockApi = {
       createNode: vi.fn(),
       deleteNode: vi.fn(),
+      deleteNodes: vi.fn(),
       updateNodePosition: vi.fn(),
       updateNode: vi.fn(),
       batchUpdatePositions: vi.fn(),
@@ -563,6 +564,97 @@ describe('SyncManager', () => {
         .rejects.toThrow('Network error')
 
       expect(store.getNodes()).toHaveLength(1)
+    })
+  })
+
+  describe('deleteNodes', () => {
+    beforeEach(() => {
+      const root = new Node({ clientId: 'root', type: 'root', position: { x: 0, y: 0 } })
+      const node1 = new Node({ clientId: 'n1', type: 'condition', position: { x: 100, y: 100 } })
+      const node2 = new Node({ clientId: 'n2', type: 'action', position: { x: 200, y: 100 } })
+      const rootConnection = new Connection({ clientId: 'c-root', sourceId: 'root', targetId: 'n1' })
+      const internalConnection = new Connection({ clientId: 'c-internal', sourceId: 'n1', targetId: 'n2' })
+
+      store.addNode(root)
+      store.addNode(node1)
+      store.addNode(node2)
+      store.addConnection(rootConnection)
+      store.addConnection(internalConnection)
+
+      mockApi.deleteNodes.mockResolvedValue({ deleted_node_ids: [1, 2], deleted_connection_ids: [10, 11] })
+    })
+
+    it('deletes a selected node set with one history entry and ignores root nodes', async () => {
+      await syncManager.deleteNodes(['root', 'n1', 'n2'])
+
+      expect(mockApi.deleteNodes).toHaveBeenCalledWith(['n1', 'n2'])
+      expect(store.getNodes().map(node => node.clientId)).toEqual(['root'])
+      expect(store.getConnections()).toHaveLength(0)
+
+      const snapshot = history.getCurrentSnapshot()
+      expect(snapshot.description).toBe('Delete 2 selected nodes')
+      expect(snapshot.operation.type).toBe('deleteNodes')
+      expect(snapshot.operation.nodes).toHaveLength(2)
+      expect(snapshot.operation.connections).toHaveLength(2)
+      expect(snapshot.operation.connections.map(connection => connection.clientId)).toEqual(
+        expect.arrayContaining(['c-root', 'c-internal'])
+      )
+    })
+
+    it('no-ops when only root nodes are selected', async () => {
+      await syncManager.deleteNodes(['root'])
+
+      expect(mockApi.deleteNodes).not.toHaveBeenCalled()
+      expect(history.getCurrentSnapshot()).toBeNull()
+      expect(store.getNodes()).toHaveLength(3)
+      expect(store.getConnections()).toHaveLength(2)
+    })
+
+    it('restores all deleted nodes and connections when the API call fails', async () => {
+      mockApi.deleteNodes.mockRejectedValue(new Error('Network error'))
+
+      await expect(syncManager.deleteNodes(['n1', 'n2']))
+        .rejects.toThrow('Network error')
+
+      expect(store.getNodes()).toHaveLength(3)
+      expect(store.getConnections()).toHaveLength(2)
+    })
+
+    it('restores nodes before connections during undo', async () => {
+      const callOrder = []
+      mockApi.createNode.mockImplementation(async () => {
+        callOrder.push('createNode')
+        return { id: callOrder.length }
+      })
+      mockApi.createConnection.mockImplementation(async () => {
+        callOrder.push('createConnection')
+        return { id: callOrder.length }
+      })
+
+      await syncManager.executeInverseOperation({
+        type: 'deleteNodes',
+        nodes: [
+          { clientId: 'n1', type: 'condition', position: { x: 100, y: 100 }, data: {} },
+          { clientId: 'n2', type: 'action', position: { x: 200, y: 100 }, data: {} }
+        ],
+        connections: [
+          { clientId: 'c-internal', sourceId: 'n1', targetId: 'n2' }
+        ]
+      })
+
+      expect(callOrder).toEqual(['createNode', 'createNode', 'createConnection'])
+    })
+
+    it('deletes the same node set again during redo', async () => {
+      await syncManager.executeOperation({
+        type: 'deleteNodes',
+        nodes: [
+          { clientId: 'n1', type: 'condition', position: { x: 100, y: 100 }, data: {} },
+          { clientId: 'n2', type: 'action', position: { x: 200, y: 100 }, data: {} }
+        ]
+      })
+
+      expect(mockApi.deleteNodes).toHaveBeenCalledWith(['n1', 'n2'])
     })
   })
 

--- a/app/javascript/editorV2/__tests__/SyncManager.test.js
+++ b/app/javascript/editorV2/__tests__/SyncManager.test.js
@@ -19,7 +19,6 @@ describe('SyncManager', () => {
     
     mockApi = {
       createNode: vi.fn(),
-      deleteNode: vi.fn(),
       deleteNodes: vi.fn(),
       updateNodePosition: vi.fn(),
       updateNode: vi.fn(),
@@ -102,7 +101,7 @@ describe('SyncManager', () => {
     })
 
     it('calls executeInverseOperation for createNode', async () => {
-      mockApi.deleteNode.mockResolvedValue({})
+      mockApi.deleteNodes.mockResolvedValue({ deleted_node_ids: [], deleted_connection_ids: [] })
 
       const node = new Node({ clientId: 'n1', type: 'condition', position: { x: 100, y: 100 } })
       store.addNode(node)
@@ -114,7 +113,7 @@ describe('SyncManager', () => {
 
       const result = await syncManager.undo()
 
-      expect(mockApi.deleteNode).toHaveBeenCalledWith('n1')
+      expect(mockApi.deleteNodes).toHaveBeenCalledWith(['n1'])
       expect(result.success).toBe(true)
     })
 
@@ -139,7 +138,7 @@ describe('SyncManager', () => {
 
     it('shows error dialog on failure', async () => {
       const error = new Error('Network error')
-      mockApi.deleteNode.mockRejectedValue(error)
+      mockApi.deleteNodes.mockRejectedValue(error)
 
       // Mock showErrorDialog to return 'cancel'
       vi.mock('../utils/ErrorDialog.js', () => ({
@@ -215,14 +214,14 @@ describe('SyncManager', () => {
 
   describe('executeInverseOperation', () => {
     it('handles createNode', async () => {
-      mockApi.deleteNode.mockResolvedValue({})
+      mockApi.deleteNodes.mockResolvedValue({ deleted_node_ids: [], deleted_connection_ids: [] })
 
       await syncManager.executeInverseOperation({
         type: 'createNode',
         clientId: 'n1'
       })
 
-      expect(mockApi.deleteNode).toHaveBeenCalledWith('n1')
+      expect(mockApi.deleteNodes).toHaveBeenCalledWith(['n1'])
     })
 
     it('handles deleteNode', async () => {
@@ -324,14 +323,14 @@ describe('SyncManager', () => {
     })
 
     it('handles deleteNode', async () => {
-      mockApi.deleteNode.mockResolvedValue({})
+      mockApi.deleteNodes.mockResolvedValue({ deleted_node_ids: [], deleted_connection_ids: [] })
 
       await syncManager.executeOperation({
         type: 'deleteNode',
         clientId: 'n1'
       })
 
-      expect(mockApi.deleteNode).toHaveBeenCalledWith('n1')
+      expect(mockApi.deleteNodes).toHaveBeenCalledWith(['n1'])
     })
 
     it('handles createConnection', async () => {
@@ -519,22 +518,22 @@ describe('SyncManager', () => {
     })
   })
 
-  describe('deleteNode', () => {
+  describe('deleteNodes (single node)', () => {
     beforeEach(() => {
       const node = new Node({ clientId: 'n1', type: 'condition', position: { x: 0, y: 0 } })
       store.addNode(node)
-      mockApi.deleteNode.mockResolvedValue({})
+      mockApi.deleteNodes.mockResolvedValue({ deleted_node_ids: [1], deleted_connection_ids: [] })
     })
 
     it('removes node from store optimistically', async () => {
-      await syncManager.deleteNode('n1')
+      await syncManager.deleteNodes(['n1'])
 
       expect(store.getNodes()).toHaveLength(0)
       expect(store.getRecentPlacementAnchor()).toEqual({ x: 0, y: 0 })
     })
 
     it('stores node data for history', async () => {
-      await syncManager.deleteNode('n1')
+      await syncManager.deleteNodes(['n1'])
 
       const snapshot = history.getCurrentSnapshot()
       expect(snapshot.description).toContain('Delete')
@@ -542,7 +541,6 @@ describe('SyncManager', () => {
     })
 
     it('handles cascade-deleted connections', async () => {
-      const errorSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
       const root = new Node({ clientId: 'root', type: 'root', position: { x: 0, y: 0 } })
       const node = new Node({ clientId: 'n1', type: 'condition', position: { x: 100, y: 100 } })
       const conn = new Connection({ clientId: 'c1', sourceId: 'root', targetId: 'n1' })
@@ -550,17 +548,16 @@ describe('SyncManager', () => {
       store.addNode(node)
       store.addConnection(conn)
 
-      await syncManager.deleteNode('n1')
+      await syncManager.deleteNodes(['n1'])
 
       expect(store.getNodes()).toHaveLength(1)
       expect(store.getConnections()).toHaveLength(0)
     })
 
     it('rolls back on failure', async () => {
-      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
-      mockApi.deleteNode.mockRejectedValue(new Error('Network error'))
+      mockApi.deleteNodes.mockRejectedValue(new Error('Network error'))
 
-      await expect(syncManager.deleteNode('n1'))
+      await expect(syncManager.deleteNodes(['n1']))
         .rejects.toThrow('Network error')
 
       expect(store.getNodes()).toHaveLength(1)

--- a/app/javascript/editorV2/__tests__/TemplatePlacement.test.js
+++ b/app/javascript/editorV2/__tests__/TemplatePlacement.test.js
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from 'vitest'
+import { findTemplateAnchor } from '../templates/TemplatePlacement.js'
+import { TEMPLATES } from '../templates/TemplateRegistry.js'
+import Store from '../state/Store.js'
+
+describe('TemplatePlacement', () => {
+  it('places templates near the recent anchor when provided', () => {
+    const store = new Store()
+    const template = TEMPLATES.find(entry => entry.id === 'winning-capture')
+
+    expect(findTemplateAnchor(template, null, store, { x: 500, y: 400 })).toEqual({ x: 430, y: 344 })
+  })
+
+  it('falls back to the visible center when no recent anchor exists', () => {
+    const store = new Store()
+    const template = TEMPLATES.find(entry => entry.id === 'winning-capture')
+    const viewport = {
+      getVisibleCanvasCenter: vi.fn(() => ({ x: 400, y: 300 })),
+      container: {
+        getBoundingClientRect: vi.fn(() => ({ left: 0, top: 0, right: 800, bottom: 600 }))
+      },
+      screenToGraphPoint: vi.fn((x, y) => ({ x, y }))
+    }
+
+    expect(findTemplateAnchor(template, viewport, store)).toEqual({ x: 330, y: 244 })
+  })
+})

--- a/app/javascript/editorV2/__tests__/ToolbarHandler.test.js
+++ b/app/javascript/editorV2/__tests__/ToolbarHandler.test.js
@@ -54,4 +54,31 @@ describe('ToolbarHandler', () => {
     expect(position.x).toBeGreaterThanOrEqual(0)
     expect(position.y).toBeGreaterThanOrEqual(0)
   })
+
+  it('enables the delete button when at least one selected node is deletable', () => {
+    const deleteBtn = document.createElement('button')
+    deleteBtn.className = 'btn-delete-node'
+    document.body.appendChild(deleteBtn)
+
+    addNode(store, { clientId: 'root', type: 'root', x: 0, y: 0 })
+    addNode(store, { clientId: 'child', type: 'condition', x: 100, y: 100 })
+    store.setSelectedNodeIds(['root', 'child'])
+
+    toolbarHandler.updateDeleteButton()
+
+    expect(deleteBtn.disabled).toBe(false)
+  })
+
+  it('disables the delete button when only root nodes are selected', () => {
+    const deleteBtn = document.createElement('button')
+    deleteBtn.className = 'btn-delete-node'
+    document.body.appendChild(deleteBtn)
+
+    addNode(store, { clientId: 'root', type: 'root', x: 0, y: 0 })
+    store.setSelectedNodeIds(['root'])
+
+    toolbarHandler.updateDeleteButton()
+
+    expect(deleteBtn.disabled).toBe(true)
+  })
 })

--- a/app/javascript/editorV2/__tests__/ToolbarHandler.test.js
+++ b/app/javascript/editorV2/__tests__/ToolbarHandler.test.js
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import ToolbarHandler from '../handlers/ToolbarHandler.js'
+import Store from '../state/Store.js'
+import Node from '../models/Node.js'
+
+function buildViewport() {
+  return {
+    getVisibleCanvasCenter: vi.fn(() => ({ x: 400, y: 300 }))
+  }
+}
+
+function addNode(store, { clientId, type, x, y }) {
+  store.addNode(new Node({ clientId, type, position: { x, y } }))
+}
+
+describe('ToolbarHandler', () => {
+  let store
+  let history
+  let syncManager
+  let viewport
+  let toolbarHandler
+
+  beforeEach(() => {
+    document.body.innerHTML = '<div class="bot-editor"></div>'
+    store = new Store()
+    history = { canUndo: () => false, canRedo: () => false }
+    syncManager = { setPersistedMutationCallback: vi.fn() }
+    viewport = buildViewport()
+    toolbarHandler = new ToolbarHandler(store, history, syncManager, document.createElement('div'), null, viewport)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    document.body.innerHTML = ''
+  })
+
+  it('places add-node inserts near the recent placement anchor', () => {
+    store.setRecentPlacementAnchor({ x: 500, y: 400 })
+
+    expect(toolbarHandler.findPlacementPosition('condition')).toEqual({ x: 450, y: 336 })
+  })
+
+  it('falls back to the visible canvas center when no anchor exists', () => {
+    expect(toolbarHandler.findPlacementPosition('action')).toEqual({ x: 346, y: 246 })
+  })
+
+  it('searches around the recent anchor when the direct placement is blocked', () => {
+    store.setRecentPlacementAnchor({ x: 500, y: 400 })
+    addNode(store, { clientId: 'blocker', type: 'condition', x: 450, y: 336 })
+
+    const position = toolbarHandler.findPlacementPosition('condition')
+
+    expect(position).not.toEqual({ x: 450, y: 336 })
+    expect(position.x).toBeGreaterThanOrEqual(0)
+    expect(position.y).toBeGreaterThanOrEqual(0)
+  })
+})

--- a/app/javascript/editorV2/api.js
+++ b/app/javascript/editorV2/api.js
@@ -145,28 +145,80 @@ class API {
    * @returns {Promise<null>}
    */
   async deleteNode(clientId) {
-    const serverId = this.nodeClientToServer.get(clientId)
-    if (!serverId) {
-      console.warn(`No server ID for node client ID ${clientId}, skipping delete`)
-      return null
+    return this.deleteNodes([clientId])
+  }
+
+  /**
+   * Delete multiple nodes from the server
+   * @param {string[]} clientIds - Node client IDs
+   * @returns {Promise<Object>} Server response
+   */
+  async deleteNodes(clientIds) {
+    const uniqueClientIds = [...new Set((clientIds || []).filter(Boolean))]
+    const deletableIds = uniqueClientIds
+      .map(clientId => ({
+        clientId,
+        serverId: this.nodeClientToServer.get(clientId)
+      }))
+      .filter(({ serverId }) => serverId)
+
+    if (deletableIds.length === 0) {
+      return { deleted_node_ids: [], deleted_connection_ids: [] }
     }
-    
-    const response = await fetch(`${this.baseUrl}/nodes/${serverId}`, {
+
+    const response = await fetch(`${this.baseUrl}/nodes/batch_destroy`, {
       method: 'DELETE',
-      headers: this.getHeaders()
+      headers: this.getHeaders(),
+      body: JSON.stringify({
+        node_ids: deletableIds.map(({ serverId }) => serverId)
+      })
     })
-    
-    // 404 is OK (already deleted)
-    if (!response.ok && response.status !== 404) {
+
+    if (!response.ok) {
       const errorText = await response.text()
-      throw new Error(`Failed to delete node: ${response.status} - ${errorText}`)
+      throw new Error(`Failed to delete nodes: ${response.status} - ${errorText}`)
     }
-    
-    // Clean up mapping
-    this.nodeClientToServer.delete(clientId)
+
+    const json = await response.json()
+    const deletedNodeIds = json.deleted_node_ids || []
+    const deletedConnectionIds = json.deleted_connection_ids || []
+
+    deletedNodeIds.forEach(serverId => this.removeNodeMappingByServerId(serverId))
+    deletedConnectionIds.forEach(serverId => this.removeConnectionMappingByServerId(serverId))
+
+    return json
+  }
+
+  removeNodeMappingByServerId(serverId) {
+    const clientId = this.nodeServerToClient.get(serverId)
+    if (clientId) {
+      this.nodeClientToServer.delete(clientId)
+    }
     this.nodeServerToClient.delete(serverId)
-    
-    return null
+  }
+
+  removeConnectionMappingByServerId(serverId) {
+    const clientId = this.connectionServerToClient.get(serverId)
+    if (clientId) {
+      this.connectionClientToServer.delete(clientId)
+    }
+    this.connectionServerToClient.delete(serverId)
+  }
+
+  removeNodeMappingByClientId(clientId) {
+    const serverId = this.nodeClientToServer.get(clientId)
+    if (serverId) {
+      this.nodeServerToClient.delete(serverId)
+    }
+    this.nodeClientToServer.delete(clientId)
+  }
+
+  removeConnectionMappingByClientId(clientId) {
+    const serverConnectionId = this.connectionClientToServer.get(clientId)
+    if (serverConnectionId) {
+      this.connectionServerToClient.delete(serverConnectionId)
+    }
+    this.connectionClientToServer.delete(clientId)
   }
   
   // ===== Connection Operations =====

--- a/app/javascript/editorV2/api.js
+++ b/app/javascript/editorV2/api.js
@@ -144,15 +144,6 @@ class API {
    * @param {string} clientId - Node client ID
    * @returns {Promise<null>}
    */
-  async deleteNode(clientId) {
-    return this.deleteNodes([clientId])
-  }
-
-  /**
-   * Delete multiple nodes from the server
-   * @param {string[]} clientIds - Node client IDs
-   * @returns {Promise<Object>} Server response
-   */
   async deleteNodes(clientIds) {
     const uniqueClientIds = [...new Set((clientIds || []).filter(Boolean))]
     const deletableIds = uniqueClientIds
@@ -183,13 +174,13 @@ class API {
     const deletedNodeIds = json.deleted_node_ids || []
     const deletedConnectionIds = json.deleted_connection_ids || []
 
-    deletedNodeIds.forEach(serverId => this.removeNodeMappingByServerId(serverId))
-    deletedConnectionIds.forEach(serverId => this.removeConnectionMappingByServerId(serverId))
+    deletedNodeIds.forEach(serverId => this._removeNodeMappingByServerId(serverId))
+    deletedConnectionIds.forEach(serverId => this._removeConnectionMappingByServerId(serverId))
 
     return json
   }
 
-  removeNodeMappingByServerId(serverId) {
+  _removeNodeMappingByServerId(serverId) {
     const clientId = this.nodeServerToClient.get(serverId)
     if (clientId) {
       this.nodeClientToServer.delete(clientId)
@@ -197,30 +188,14 @@ class API {
     this.nodeServerToClient.delete(serverId)
   }
 
-  removeConnectionMappingByServerId(serverId) {
+  _removeConnectionMappingByServerId(serverId) {
     const clientId = this.connectionServerToClient.get(serverId)
     if (clientId) {
       this.connectionClientToServer.delete(clientId)
     }
     this.connectionServerToClient.delete(serverId)
-  }
+}
 
-  removeNodeMappingByClientId(clientId) {
-    const serverId = this.nodeClientToServer.get(clientId)
-    if (serverId) {
-      this.nodeServerToClient.delete(serverId)
-    }
-    this.nodeClientToServer.delete(clientId)
-  }
-
-  removeConnectionMappingByClientId(clientId) {
-    const serverConnectionId = this.connectionClientToServer.get(clientId)
-    if (serverConnectionId) {
-      this.connectionServerToClient.delete(serverConnectionId)
-    }
-    this.connectionClientToServer.delete(clientId)
-  }
-  
   // ===== Connection Operations =====
   
   /**

--- a/app/javascript/editorV2/api.js
+++ b/app/javascript/editorV2/api.js
@@ -194,7 +194,7 @@ class API {
       this.connectionClientToServer.delete(clientId)
     }
     this.connectionServerToClient.delete(serverId)
-}
+  }
 
   // ===== Connection Operations =====
   

--- a/app/javascript/editorV2/constants.js
+++ b/app/javascript/editorV2/constants.js
@@ -58,6 +58,7 @@ export const EVENTS = {
   CONNECTION_ADD: 'connection:add',
   CONNECTION_UPDATE: 'connection:update',
   CONNECTION_REMOVE: 'connection:remove',
+  SELECTION_CHANGE: 'selection:change',
   GRAPH_REPLACE: 'graph:replace',
   GRAPH_RESTORE: 'graph:restore'
 }

--- a/app/javascript/editorV2/handlers/ClickHandler.js
+++ b/app/javascript/editorV2/handlers/ClickHandler.js
@@ -189,6 +189,8 @@ class ClickHandler {
     if (node.type === 'root') {
       return
     }
+
+    this.store.setRecentPlacementAnchor(node.position)
     
     this.editingNodeId = clientId
     this.store.setEditingNode(clientId)

--- a/app/javascript/editorV2/handlers/ClickHandler.js
+++ b/app/javascript/editorV2/handlers/ClickHandler.js
@@ -24,32 +24,22 @@ class ClickHandler {
     this.onNodeDeselected = null
     this.onNodeEdit = null
 
-    if (this.editorPanel) {
-      this.attachEditorPanelHandlers()
-    }
+    if (this.editorPanel) { this.attachEditorPanelHandlers() }
     this.unsubscribeStore = this.store.subscribe(this.boundHandleStoreUpdate)
   }
   
   attach(element, clientId) {
-    // Prevent duplicate attachments
-    if (this.attachedElements.has(element)) {
-      return
-    }
+    if (this.attachedElements.has(element)) { return }
     this.attachedElements.set(element, clientId)
     element.addEventListener('click', (e) => {
       if (e.target.classList.contains('node-connector')) { return }
       if (this.store.shouldSuppressClicks()) { return }
       this.selectNode(clientId, element, { additive: this.isShiftSelection(e) })
-      if (this.isPlainClick(e)) {
-        this.openEditor(clientId)
-      }
+      if (this.isPlainClick(e)) { this.openEditor(clientId) }
     })
     
     element.addEventListener('dblclick', (e) => {
-      // Don't edit if clicking on connector
-      if (e.target.classList.contains('node-connector')) { 
-        return 
-      }
+      if (e.target.classList.contains('node-connector')) {  return  }
       this.openEditor(clientId)  
     })
   }
@@ -83,7 +73,6 @@ class ClickHandler {
 
   syncSelectionClasses() {
     const selectedIds = new Set(this.store.getSelectedNodeIds())
-
     document.querySelectorAll('.node').forEach(el => {
       const clientId = el.dataset?.clientId
       el.classList.toggle('selected', selectedIds.has(clientId))
@@ -100,7 +89,6 @@ class ClickHandler {
 
   handleClick(event) {
     if (this.store.shouldSuppressClicks()) { return }
-
     const clickedOnNode = event.target.closest('.node')
     const clickedOnEditor = this.editorPanel?.contains(event.target)
     if (!clickedOnNode && !clickedOnEditor) {
@@ -120,13 +108,10 @@ class ClickHandler {
   }
 
   handleKeyDown(event) {
-    // Delete key or backspace: delete selected node
     if (event.key === 'Delete' || event.key === 'Backspace') {
-      // Only if not in an input field
       if (event.target.tagName === 'INPUT' || event.target.tagName === 'TEXTAREA') {
         return
       }
-      
       if (this.getDeletableSelectedNodeIds().length > 0) {
         this.deleteSelectedNodes()
       }
@@ -140,7 +125,6 @@ class ClickHandler {
   selectNode(clientId, element, { additive = false } = {}) {
     if (additive) {
       this.store.toggleNodeSelection(clientId)
-
       if (this.store.isNodeSelected(clientId)) {
         if (this.onNodeSelected) {
           this.onNodeSelected(clientId)
@@ -148,12 +132,9 @@ class ClickHandler {
       } else if (this.onNodeDeselected) {
         this.onNodeDeselected()
       }
-
       return
     }
-
     this.store.selectOnlyNode(clientId)
-
     if (this.onNodeSelected) {
       this.onNodeSelected(clientId)
     }
@@ -161,17 +142,13 @@ class ClickHandler {
 
   selectNodeById(clientId) {
     const element = document.querySelector(`.node[data-client-id="${clientId}"]`)
-    if (!element) {
-      return
-    }
-
+    if (!element) { return }
     this.selectNode(clientId, element)
   }
 
 
   deselectAll() {
     this.store.clearSelection()
-
     if (this.onNodeDeselected) {
       this.onNodeDeselected()
     }
@@ -186,12 +163,8 @@ class ClickHandler {
     }
     
     // Don't edit root nodes
-    if (node.type === 'root') {
-      return
-    }
-
+    if (node.type === 'root') { return }
     this.store.setRecentPlacementAnchor(node.position)
-    
     this.editingNodeId = clientId
     this.store.setEditingNode(clientId)
     
@@ -207,20 +180,15 @@ class ClickHandler {
     }
   }
   
-  /**
-   * Close editor panel
-   */
   closeEditor() {
     this.editingNodeId = null
     this.store.setEditingNode(null)
-    
     if (this.editorPanel) {
       this.editorPanel.classList.add('hidden')
     }
   }
 
   // ===== Editor Panel Population =====
-
   populateEditorPanel(node) {
     if (!this.editorPanel) {
       return
@@ -237,7 +205,6 @@ class ClickHandler {
     const actionEditor = this.editorPanel.querySelector('#action-form')
     const organizerEditor = this.editorPanel.querySelector('#organizer-form')
     this.editorPanel.classList.toggle('node-form-panel--condition', node.type === 'condition')
-
     if (conditionForm) {
       conditionForm.classList.toggle('hidden', node.type !== 'condition')
     }
@@ -247,7 +214,6 @@ class ClickHandler {
     if (organizerEditor) {
       organizerEditor.classList.toggle('hidden', node.type !== 'organizer')
     }
-
     this.populateEditorByType(node)
   }
 
@@ -274,7 +240,6 @@ class ClickHandler {
 
 
   // ===== Action Editor =====
-
   buildActionDataPayload() {
     return {
       actionType: this.editorPanel.querySelector('#action-type')?.value || 'add',
@@ -283,7 +248,6 @@ class ClickHandler {
   }
 
   // ===== Organizer Editor =====
-
   buildOrganizerDataPayload() {
     return {
       title: this.editorPanel.querySelector('#organizer-title')?.value?.trim() || 'Organizer',
@@ -292,37 +256,19 @@ class ClickHandler {
   }
 
   populateActionEditor(node) {
-    if (!this.editorPanel) {
-      return
-    }
-
+    if (!this.editorPanel) { return }
     const actionType = this.editorPanel.querySelector('#action-type')
     const actionValue = this.editorPanel.querySelector('#action-value')
-
-    if (actionType) {
-      actionType.value = node.data.actionType || node.data.action_type || 'add'
-    }
-
-    if (actionValue) {
-      actionValue.value = node.data.value || 1
-    }
+    if (actionType) { actionType.value = node.data.actionType || node.data.action_type || 'add' }
+    if (actionValue) { actionValue.value = node.data.value || 1 }
   }
 
   populateOrganizerEditor(node) {
-    if (!this.editorPanel) {
-      return
-    }
-
+    if (!this.editorPanel) { return }
     const organizerTitle = this.editorPanel.querySelector('#organizer-title')
     const organizerNotes = this.editorPanel.querySelector('#organizer-notes')
-
-    if (organizerTitle) {
-      organizerTitle.value = node.data.title || 'Organizer'
-    }
-
-    if (organizerNotes) {
-      organizerNotes.value = node.data.notes || ''
-    }
+    if (organizerTitle) { organizerTitle.value = node.data.title || 'Organizer' }
+    if (organizerNotes) { organizerNotes.value = node.data.notes || '' }
   }
 
   // ===== Save Helpers =====
@@ -345,27 +291,19 @@ class ClickHandler {
   }
 
   async handleSave() {
-    if (!this.editingNodeId) {
-      return
-    }
-
+    if (!this.editingNodeId) { return }
     const node = this.store.getNode(this.editingNodeId)
-    if (!node || !this.syncManager) {
-      return
-    }
-
+    if (!node || !this.syncManager) { return }
     try {
       const payload = this.buildDataPayloadByType(node)
       if (payload) {
         await this.syncManager.updateNodeData(this.editingNodeId, payload)
       }
-
       this.closeEditor()
     } catch (error) {
       console.error('Failed to save node:', error)
     }
   }
-  
 
   getSelectedNodeIds() {
     return this.store.getSelectedNodeIds()
@@ -381,21 +319,13 @@ class ClickHandler {
   async deleteSelectedNodes() {
     const selectedNodeIds = this.getSelectedNodeIds()
     const deletableNodeIds = this.getDeletableSelectedNodeIds()
-    if (deletableNodeIds.length === 0) {
-      return
-    }
-
+    if (deletableNodeIds.length === 0) { return }
     const confirmationMessage = deletableNodeIds.length === 1
       ? 'Delete 1 selected node?'
       : `Delete ${deletableNodeIds.length} selected nodes?`
-
-    if (!confirm(confirmationMessage)) {
-      return
-    }
-
+    if (!confirm(confirmationMessage)) { return }
     try {
-      await this.syncManager?.deleteNodes(deletableNodeIds)
-
+      await this.syncManager?.deleteNodes(deletableNodeIds) 
       const remainingSelectedIds = selectedNodeIds.filter(clientId => !deletableNodeIds.includes(clientId))
       this.store.setSelectedNodeIds(remainingSelectedIds)
       this.syncSelectionClasses()

--- a/app/javascript/editorV2/handlers/ClickHandler.js
+++ b/app/javascript/editorV2/handlers/ClickHandler.js
@@ -40,6 +40,9 @@ class ClickHandler {
       if (e.target.classList.contains('node-connector')) { return }
       if (this.store.shouldSuppressClicks()) { return }
       this.selectNode(clientId, element, { additive: this.isShiftSelection(e) })
+      if (this.isPlainClick(e)) {
+        this.openEditor(clientId)
+      }
     })
     
     element.addEventListener('dblclick', (e) => {
@@ -91,6 +94,10 @@ class ClickHandler {
     return event.shiftKey
   }
 
+  isPlainClick(event) {
+    return !event.shiftKey && !event.metaKey && !event.ctrlKey && !event.altKey
+  }
+
   handleClick(event) {
     if (this.store.shouldSuppressClicks()) { return }
 
@@ -98,6 +105,7 @@ class ClickHandler {
     const clickedOnEditor = this.editorPanel?.contains(event.target)
     if (!clickedOnNode && !clickedOnEditor) {
       this.deselectAll()
+      this.closeEditor()
     }
   }
 

--- a/app/javascript/editorV2/handlers/ClickHandler.js
+++ b/app/javascript/editorV2/handlers/ClickHandler.js
@@ -127,8 +127,8 @@ class ClickHandler {
         return
       }
       
-      if (this.store.getPrimarySelectedNode()) {
-        this.deleteSelectedNode()
+      if (this.getDeletableSelectedNodeIds().length > 0) {
+        this.deleteSelectedNodes()
       }
     }
     // Escape: close editor panel
@@ -367,44 +367,55 @@ class ClickHandler {
   }
   
 
-  async deleteSelectedNode() {
-    const selectedNodeId = this.store.getPrimarySelectedNode()
-    if (!selectedNodeId) {
+  getSelectedNodeIds() {
+    return this.store.getSelectedNodeIds()
+  }
+
+  getDeletableSelectedNodeIds() {
+    return this.getSelectedNodeIds().filter(clientId => {
+      const node = this.store.getNode(clientId)
+      return node && node.type !== 'root'
+    })
+  }
+
+  async deleteSelectedNodes() {
+    const selectedNodeIds = this.getSelectedNodeIds()
+    const deletableNodeIds = this.getDeletableSelectedNodeIds()
+    if (deletableNodeIds.length === 0) {
       return
     }
 
-    const node = this.store.getNode(selectedNodeId)
-    if (!node) {
+    const confirmationMessage = deletableNodeIds.length === 1
+      ? 'Delete 1 selected node?'
+      : `Delete ${deletableNodeIds.length} selected nodes?`
+
+    if (!confirm(confirmationMessage)) {
       return
     }
-    
-    // Don't delete root nodes
-    if (node.type === 'root') {
-      console.warn('Cannot delete root node')
-      return
-    }
-    
-    // Confirm deletion
-    if (!confirm('Delete this node?')) {
-      return
-    }
-    
-    const clientId = selectedNodeId
-    
-    // Deselect first
-    this.deselectAll()
-    
-    // Close editor if editing this node
-    if (this.editingNodeId === clientId) {
-      this.closeEditor()
-    }
-    
-    // SyncManager handles: optimistic delete, server sync, history push
+
     try {
-      await this.syncManager?.deleteNode(clientId)
+      await this.syncManager?.deleteNodes(deletableNodeIds)
+
+      const remainingSelectedIds = selectedNodeIds.filter(clientId => !deletableNodeIds.includes(clientId))
+      this.store.setSelectedNodeIds(remainingSelectedIds)
+      this.syncSelectionClasses()
+
+      if (this.editingNodeId && deletableNodeIds.includes(this.editingNodeId)) {
+        this.closeEditor()
+      }
+
+      if (remainingSelectedIds.length > 0) {
+        this.onNodeSelected?.(remainingSelectedIds[0])
+      } else {
+        this.onNodeDeselected?.()
+      }
     } catch (error) {
       console.error('Failed to delete node:', error)
     }
+  }
+
+  async deleteSelectedNode() {
+    return this.deleteSelectedNodes()
   }
   
 

--- a/app/javascript/editorV2/handlers/ConnectionHandler.js
+++ b/app/javascript/editorV2/handlers/ConnectionHandler.js
@@ -1,25 +1,9 @@
-// handlers/ConnectionHandler.js
-// Handles connection creation and deletion
-
 /**
- * ConnectionHandler
- * 
- * Handles:
- * - Mouse down on output connector to start connection
- * - Mouse move during connection drag
- * - Mouse up on input connector to create connection
- * - Click on delete button to remove connection
- * 
  * IMPORTANT: This handler never calls history.push() directly.
  * SyncManager handles history push after successful server sync.
  */
 class ConnectionHandler {
-  /**
-   * Create ConnectionHandler
-   * @param {Store} store - Store instance
-   * @param {SyncManager} syncManager - SyncManager instance
-   * @param {ConnectionRenderer} connectionRenderer - ConnectionRenderer instance
-   */
+  
   constructor(store, syncManager, connectionRenderer, viewport = null) {
     this.store = store
     this.syncManager = syncManager
@@ -40,52 +24,28 @@ class ConnectionHandler {
     this.attachedElements = new WeakMap()
   }
   
-  /**
-   * Attach connection handlers to a node element
-   * @param {HTMLElement} element - Node element
-   * @param {string} clientId - Node client ID
-   */
   attach(element, clientId) {
-    // Prevent duplicate attachments
-    if (this.attachedElements.has(element)) {
-      return
-    }
-    
+    if (this.attachedElements.has(element)) { return }
     this.attachedElements.set(element, clientId)
-    
-    // Find connector elements
     const outputConnector = element.querySelector('.node-connector.output')
-    
-    // Output connector: start new connection
     if (outputConnector) {
       outputConnector.addEventListener('mousedown', (e) => {
         this.startConnection(e, clientId, outputConnector)
       })
     }
-    
     // Handle delete button clicks (delegated from node canvas)
     // Note: Delete buttons are created by ConnectionRenderer
   }
   
-  /**
-   * Start creating a connection
-   * @param {MouseEvent} event
-   * @param {string} clientId - Source node client ID
-   * @param {HTMLElement} sourceConnector - Output connector element
-   */
   startConnection(event, clientId, sourceConnector) {
     event.preventDefault()
     event.stopPropagation()
-    
     const node = this.store.getNode(clientId)
-    if (!node) {
-      return
-    }
-    
+    if (!node) { return }
     this.isConnecting = true
     this.sourceClientId = clientId
     this.sourceElement = sourceConnector
-    
+
     // Create temporary line for visual feedback
     const svgContainer = document.getElementById('connections-canvas')
     if (!svgContainer) {
@@ -121,29 +81,17 @@ class ConnectionHandler {
     }
   }
   
-  /**
-   * Handle mouse move during connection drag
-   * @param {MouseEvent} event
-   */
   handleMouseMove(event) {
-    if (!this.isConnecting || !this.tempLine) {
-      return
-    }
-    
+    if (!this.isConnecting || !this.tempLine) { return }
     const pointer = this.viewport?.screenToGraphPoint(event.clientX, event.clientY) || {
       x: event.clientX,
       y: event.clientY
-    }
-    
+    }  
     // Update temp line endpoint
     this.tempLine.setAttribute('x2', pointer.x)
     this.tempLine.setAttribute('y2', pointer.y)
   }
   
-  /**
-   * Handle mouse up to end connection
-   * @param {MouseEvent} event
-   */
   handleMouseUp(event) {
     // Remove handlers immediately
     document.removeEventListener('mousemove', this.boundHandleMouseMove)
@@ -181,11 +129,6 @@ class ConnectionHandler {
     this.sourceElement = null
   }
   
-  /**
-   * Finish creating a connection
-   * @param {string} sourceClientId - Source node client ID
-   * @param {string} targetClientId - Target node client ID
-   */
   async finishConnection(sourceClientId, targetClientId) {
     // Validate
     if (sourceClientId === targetClientId) {
@@ -208,10 +151,6 @@ class ConnectionHandler {
     }
   }
   
-  /**
-   * Delete a connection
-   * @param {string} clientId - Connection client ID
-   */
   async deleteConnection(clientId) {
     try {
       await this.syncManager.deleteConnection(clientId)
@@ -220,19 +159,10 @@ class ConnectionHandler {
     }
   }
   
-  /**
-   * Get connector position relative to canvas
-   * @param {HTMLElement} connector - Connector element
-   * @returns {{ x: number, y: number }}
-   */
   getConnectorPosition(connector) {
     return this.viewport?.getElementCenterGraphPoint(connector) || { x: 0, y: 0 }
   }
   
-  /**
-   * Setup delegated delete button handler on canvas
-   * @param {HTMLElement} canvas - Nodes canvas element
-   */
   setupDeleteHandler(canvas) {
     canvas.addEventListener('click', (e) => {
       const deleteBtn = e.target.closest('.connection-delete-btn')
@@ -245,9 +175,6 @@ class ConnectionHandler {
     })
   }
   
-  /**
-   * Cancel current connection (for external use)
-   */
   cancelConnection() {
     if (this.isConnecting) {
       // Remove handlers
@@ -275,17 +202,10 @@ class ConnectionHandler {
     }
   }
   
-  /**
-   * Check if currently creating a connection
-   * @returns {boolean}
-   */
   isCurrentlyConnecting() {
     return this.isConnecting
   }
   
-  /**
-   * Cleanup on destroy
-   */
   destroy() {
     this.cancelConnection()
     this.attachedElements = new WeakMap()

--- a/app/javascript/editorV2/handlers/DragHandler.js
+++ b/app/javascript/editorV2/handlers/DragHandler.js
@@ -325,6 +325,7 @@ class DragHandler {
     // Sync with server if we moved
     if (this.hasMoved && this.draggedClientId && this.draggedNode) {
       const node = this.store.getNode(this.draggedClientId)
+      const anchorPoint = node ? { x: node.position.x, y: node.position.y } : null
       if (node) {
         if (this.draggedClientIds.length > 1) {
           // Multi-node drag: use batch update
@@ -337,6 +338,11 @@ class DragHandler {
           const description = `Move ${this.draggedNode.type} node (+ ${additionalCount} selected)`
           
           this.syncManager.batchUpdatePositions(positions, description)
+            .then(() => {
+              if (anchorPoint) {
+                this.store.setRecentPlacementAnchor(anchorPoint)
+              }
+            })
             .catch(err => {
               console.error('Failed to sync drag positions:', err)
             })
@@ -346,7 +352,11 @@ class DragHandler {
             this.draggedClientId,
             node.position.x,
             node.position.y
-          ).catch(err => {
+          ).then(() => {
+            if (anchorPoint) {
+              this.store.setRecentPlacementAnchor(anchorPoint)
+            }
+          }).catch(err => {
             console.error('Failed to sync drag position:', err)
           })
         }

--- a/app/javascript/editorV2/handlers/DragHandler.js
+++ b/app/javascript/editorV2/handlers/DragHandler.js
@@ -9,28 +9,11 @@ import {
 } from '../constants.js'
 
 /**
- * DragHandler
- * 
- * Handles:
- * - Mouse down on nodes to start drag
- * - Mouse move during drag
- * - Mouse up to end drag and sync
- * 
- * Selection dragging:
- * - Dragging a selected node moves the current selection
- * - Dragging an unselected node selects it, then drags it
- * - Shift-drag extends selection, then drags the selection
- * - Option-drag moves only the grabbed node
- * 
- * IMPORTANT: This handler never calls history.push() directly.
+ * * IMPORTANT: This handler never calls history.push() directly.
  * SyncManager handles history push after successful server sync.
  */
 class DragHandler {
-  /**
-   * Create DragHandler
-   * @param {Store} store - Store instance
-   * @param {SyncManager} syncManager - SyncManager instance
-   */
+  
   constructor(store, syncManager, viewport = null) {
     this.store = store
     this.syncManager = syncManager
@@ -79,45 +62,25 @@ class DragHandler {
     })
   }
   
-  /**
-   * Attach drag handlers to a node element
-   * @param {HTMLElement} element - Node element
-   * @param {string} clientId - Node client ID
-   */
   attach(element, clientId) {
     // Prevent duplicate attachments
-    if (this.attachedElements.has(element)) {
-      return
-    }
-    
+    if (this.attachedElements.has(element)) { return }
     this.attachedElements.set(element, clientId)
     
     // Mouse down starts potential drag
     element.addEventListener('mousedown', (e) => this.handleMouseDown(e, clientId, element))
   }
   
-  /**
-   * Handle mouse down on a node
-   * @param {MouseEvent} event
-   * @param {string} clientId
-   * @param {HTMLElement} element
-   */
   handleMouseDown(event, clientId, element) {
     // Only left click
-    if (event.button !== 0) {
-      return
-    }
+    if (event.button !== 0) { return }
     
     // Don't interfere with connector clicks
-    if (event.target.classList.contains('node-connector')) {
-      return
-    }
+    if (event.target.classList.contains('node-connector')) { return }
     
     const node = this.store.getNode(clientId)
     // this seems like overkill?
-    if (!node) {
-      return
-    }
+    if (!node) { return }
     
     event.preventDefault()
     event.stopPropagation()
@@ -163,7 +126,6 @@ class DragHandler {
       if (selectedIds.length > 1) {
         return selectedIds
       }
-
       return [clientId, ...this.store.getDescendantIds(clientId)]
     }
 
@@ -172,10 +134,7 @@ class DragHandler {
   }
 
   handleBackgroundMouseDown(event) {
-    if (event.button !== 0) {
-      return
-    }
-
+    if (event.button !== 0) { return }
     if (event.target.closest('.node') || event.target.closest('.node-connector')) {
       return
     }
@@ -199,10 +158,6 @@ class DragHandler {
     document.addEventListener('mouseup', this.boundHandleMouseUp)
   }
   
-  /**
-   * Handle mouse move during drag
-   * @param {MouseEvent} event
-   */
   handleMouseMove(event) {
     if (this.isMarqueeSelecting) {
       const point = this.viewport?.screenToGraphPoint(event.clientX, event.clientY) || {
@@ -290,10 +245,6 @@ class DragHandler {
     this.renderMarquee()
   }
   
-  /**
-   * Handle mouse up to end drag
-   * @param {MouseEvent} event
-   */
   handleMouseUp(event) {
     if (this.pendingDrag) {
       document.removeEventListener('mousemove', this.boundHandleMouseMove)
@@ -457,7 +408,6 @@ class DragHandler {
     if (this.marqueeElement || !this.viewport?.nodesLayer) {
       return this.marqueeElement
     }
-
     this.marqueeElement = document.createElement('div')
     this.marqueeElement.className = 'selection-marquee'
     this.viewport.nodesLayer.appendChild(this.marqueeElement)
@@ -467,8 +417,7 @@ class DragHandler {
   renderMarquee() {
     const { isMarqueeSelecting, marqueeStart, marqueeCurrent } = this.store.getMarqueeState()
     const marqueeEl = this.ensureMarqueeElement()
-    if (!marqueeEl) return
-
+    if (!marqueeEl) { return }
     if (!isMarqueeSelecting || !marqueeStart || !marqueeCurrent) {
       marqueeEl.classList.add('hidden')
       return
@@ -502,10 +451,7 @@ class DragHandler {
   }
 
   startAutoPanLoop() {
-    if (!this.viewport?.container || this.autoPanFrameId) {
-      return
-    }
-
+    if (!this.viewport?.container || this.autoPanFrameId) { return }
     this.autoPanFrameId = requestAnimationFrame(this.boundAutoPanStep)
   }
 
@@ -572,30 +518,18 @@ class DragHandler {
   extractScrollDelta(axis) {
     const remainder = this.autoPanRemainder[axis]
     const delta = remainder > 0 ? Math.floor(remainder) : Math.ceil(remainder)
-
     this.autoPanRemainder[axis] = remainder - delta
     return delta
   }
-
-  /**
-   * Check if currently dragging
-   * @returns {boolean}
-   */
+  
   isCurrentlyDragging() {
     return this.isDragging
   }
   
-  /**
-   * Get the currently dragged node's client ID
-   * @returns {string|null}
-   */
   getDraggedNodeId() {
     return this.draggedClientId
   }
   
-  /**
-   * Cancel current drag (for external use)
-   */
   cancelDrag() {
     this.pendingDrag = null
 
@@ -653,9 +587,6 @@ class DragHandler {
     }
   }
   
-  /**
-   * Cleanup on destroy
-   */
   destroy() {
     // Cancel any active drag
     this.cancelDrag()

--- a/app/javascript/editorV2/handlers/KeyboardHandler.js
+++ b/app/javascript/editorV2/handlers/KeyboardHandler.js
@@ -1,71 +1,49 @@
-// handlers/KeyboardHandler.js
-// Handles keyboard shortcuts for undo/redo and other actions
+import { findAnchoredNodePlacement } from '../utils/nodePlacement.js'
 
-/**
- * KeyboardHandler
- * 
- * Handles:
- * - Undo: Ctrl+Z / Cmd+Z
- * - Redo: Ctrl+Shift+Z / Cmd+Shift+Z / Ctrl+Y
- * - Delete: Delete key / Backspace (handled by ClickHandler)
- * 
- * IMPORTANT: Receives History directly (not via Store.history) to avoid circular dependency.
- */
 class KeyboardHandler {
-  /**
-   * Create KeyboardHandler
-   * @param {Store} store - Store instance
-   * @param {History} history - History instance (passed directly)
-   * @param {SyncManager} syncManager - SyncManager instance (for undo/redo)
-   */
-  constructor(store, history, syncManager) {
+  constructor(store, history, syncManager, clickHandler = null) {
     this.store = store
     this.history = history
     this.syncManager = syncManager
-    
-    // Pre-bound handler
+    this.clickHandler = clickHandler
+    this.clipboard = null
     this.boundHandleKeyDown = this.handleKeyDown.bind(this)
-    
-    // Attached state
     this.isAttached = false
   }
   
-  /**
-   * Attach keyboard listeners
-   */
   attach() {
-    if (this.isAttached) {
-      return
-    }
-    
+    if (this.isAttached) { return }
     document.addEventListener('keydown', this.boundHandleKeyDown)
     this.isAttached = true
   }
   
-  /**
-   * Detach keyboard listeners
-   */
   detach() {
-    if (!this.isAttached) {
-      return
-    }
-    
+    if (!this.isAttached) { return }
     document.removeEventListener('keydown', this.boundHandleKeyDown)
     this.isAttached = false
   }
-  
-  /**
-   * Handle keydown events
-   * @param {KeyboardEvent} event
-   */
+
   handleKeyDown(event) {
     // Ignore if in input field
-    if (this.isInputElement(event.target)) {
+    if (this.isInputElement(event.target)) { return }
+    const key = event.key?.toLowerCase()
+    // Copy: Ctrl/Cmd+C
+    if ((event.ctrlKey || event.metaKey) && key === 'c') {
+      event.preventDefault()
+      this.copySelectedNode()
+      return
+    }
+    // Paste: Ctrl/Cmd+V
+    if ((event.ctrlKey || event.metaKey) && key === 'v') {
+      event.preventDefault()
+      this.pasteCopiedNode().catch(error => {
+        console.error('Failed to paste node:', error)
+      })
       return
     }
     
     // Undo: Ctrl+Z / Cmd+Z
-    if ((event.ctrlKey || event.metaKey) && event.key === 'z' && !event.shiftKey) {
+    if ((event.ctrlKey || event.metaKey) && key === 'z' && !event.shiftKey) {
       event.preventDefault()
       this.undo()
       return
@@ -73,58 +51,37 @@ class KeyboardHandler {
     
     // Redo: Ctrl+Shift+Z / Cmd+Shift+Z / Ctrl+Y
     if ((event.ctrlKey || event.metaKey) && 
-        ((event.key === 'z' && event.shiftKey) || event.key === 'y')) {
+        ((key === 'z' && event.shiftKey) || key === 'y')) {
       event.preventDefault()
       this.redo()
       return
     }
   }
-  
-  /**
-   * Check if target is an input element
-   * @param {EventTarget} target
-   * @returns {boolean}
-   */
+
   isInputElement(target) {
-    if (!target || !target.tagName) {
-      return false
-    }
-    
+    if (!target || !target.tagName) { return false }
     const tag = target.tagName.toLowerCase()
     const isEditable = target.isContentEditable
-    
     return tag === 'input' || tag === 'textarea' || tag === 'select' || isEditable
   }
   
-  /**
-   * Perform undo (async - syncs with server)
-   */
   async undo() {
     if (!this.history.canUndo()) return
-    if (this.syncManager.isUndoRedoPending) return
-    
+    if (this.syncManager.isUndoRedoPending) return  
     await this.syncManager.undo()
     this.updateUndoRedoUI()
   }
   
-  /**
-   * Perform redo (async - syncs with server)
-   */
   async redo() {
     if (!this.history.canRedo()) return
-    if (this.syncManager.isUndoRedoPending) return
-    
+    if (this.syncManager.isUndoRedoPending) return  
     await this.syncManager.redo()
     this.updateUndoRedoUI()
   }
   
-  /**
-   * Update undo/redo button UI
-   */
   updateUndoRedoUI() {
     const undoBtn = document.querySelector('.btn-undo')
-    const redoBtn = document.querySelector('.btn-redo')
-    
+    const redoBtn = document.querySelector('.btn-redo')  
     if (undoBtn) {
       undoBtn.disabled = !this.history.canUndo() || this.syncManager.isUndoRedoPending
       undoBtn.classList.toggle('loading', this.syncManager.isUndoRedoPending)
@@ -135,25 +92,51 @@ class KeyboardHandler {
     }
   }
   
-  /**
-   * Get undo availability
-   * @returns {boolean}
-   */
   canUndo() {
     return this.history.canUndo() && !this.syncManager.isUndoRedoPending
   }
   
-  /**
-   * Get redo availability
-   * @returns {boolean}
-   */
   canRedo() {
     return this.history.canRedo() && !this.syncManager.isUndoRedoPending
   }
+
+  deepClone(value) {
+    if (typeof structuredClone === 'function') { return structuredClone(value) }
+    return JSON.parse(JSON.stringify(value))
+  }
+
+  getCopyableSelectedNode() {
+    const selectedIds = this.store.getSelectedNodeIds()
+    if (selectedIds.length !== 1) { return null }
+    const node = this.store.getNode(selectedIds[0])
+    if (!node || node.type === 'root') { return null }
+    return node
+  }
+
+  copySelectedNode() {
+    const node = this.getCopyableSelectedNode()
+    if (!node) { return false }
+    this.clipboard = {
+      type: node.type,
+      data: this.deepClone(node.data),
+      position: { ...node.position }
+    }
+    return true
+  }
+
+  async pasteCopiedNode() {
+    if (!this.clipboard || !this.syncManager) { return null }
+    const origin = this.store.getRecentPlacementAnchor() || this.clipboard.position
+    const position = findAnchoredNodePlacement(this.store, this.clipboard.type, origin)
+    const clientId = await this.syncManager.createNode(
+      this.clipboard.type,
+      position,
+      this.deepClone(this.clipboard.data)
+    )
+    if (clientId) { this.store.selectOnlyNode(clientId) }
+    return clientId
+  }
   
-  /**
-   * Cleanup on destroy
-   */
   destroy() {
     this.detach()
   }

--- a/app/javascript/editorV2/handlers/KeyboardHandler.js
+++ b/app/javascript/editorV2/handlers/KeyboardHandler.js
@@ -1,4 +1,7 @@
 import { findAnchoredNodePlacement } from '../utils/nodePlacement.js'
+import generateUUID from '../utils/uuid.js'
+import Node from '../models/Node.js'
+import Connection from '../models/Connection.js'
 
 class KeyboardHandler {
   constructor(store, history, syncManager, clickHandler = null) {
@@ -30,14 +33,14 @@ class KeyboardHandler {
     // Copy: Ctrl/Cmd+C
     if ((event.ctrlKey || event.metaKey) && key === 'c') {
       event.preventDefault()
-      this.copySelectedNode()
+      this.copySelectedNodes()
       return
     }
     // Paste: Ctrl/Cmd+V
     if ((event.ctrlKey || event.metaKey) && key === 'v') {
       event.preventDefault()
-      this.pasteCopiedNode().catch(error => {
-        console.error('Failed to paste node:', error)
+      this.pasteCopiedNodes().catch(error => {
+        console.error('Failed to paste nodes:', error)
       })
       return
     }
@@ -105,36 +108,72 @@ class KeyboardHandler {
     return JSON.parse(JSON.stringify(value))
   }
 
-  getCopyableSelectedNode() {
+  getCopyableSelectedNodes() {
     const selectedIds = this.store.getSelectedNodeIds()
-    if (selectedIds.length !== 1) { return null }
-    const node = this.store.getNode(selectedIds[0])
-    if (!node || node.type === 'root') { return null }
-    return node
+    if (selectedIds.length === 0) { return [] }
+    return selectedIds
+      .map(clientId => this.store.getNode(clientId))
+      .filter(node => node && node.type !== 'root')
   }
 
-  copySelectedNode() {
-    const node = this.getCopyableSelectedNode()
-    if (!node) { return false }
+  copySelectedNodes() {
+    const nodes = this.getCopyableSelectedNodes()
+    if (nodes.length === 0) { return false }
+
+    const anchorPosition = { x: nodes[0].position.x, y: nodes[0].position.y }
+    const nodeIdToIndex = new Map()
+    nodes.forEach((node, index) => { nodeIdToIndex.set(node.clientId, index) })
+
+    const connections = this.store.getInternalConnections(nodes.map(n => n.clientId))
+      .map(conn => ({
+        sourceIndex: nodeIdToIndex.get(conn.sourceId),
+        targetIndex: nodeIdToIndex.get(conn.targetId)
+      }))
+
     this.clipboard = {
-      type: node.type,
-      data: this.deepClone(node.data),
-      position: { ...node.position }
+      nodes: nodes.map(node => ({
+        type: node.type,
+        data: this.deepClone(node.data),
+        relativeX: node.position.x - anchorPosition.x,
+        relativeY: node.position.y - anchorPosition.y
+      })),
+      connections,
+      anchorPosition
     }
     return true
   }
 
-  async pasteCopiedNode() {
+  async pasteCopiedNodes() {
     if (!this.clipboard || !this.syncManager) { return null }
-    const origin = this.store.getRecentPlacementAnchor() || this.clipboard.position
-    const position = findAnchoredNodePlacement(this.store, this.clipboard.type, origin)
-    const clientId = await this.syncManager.createNode(
-      this.clipboard.type,
-      position,
-      this.deepClone(this.clipboard.data)
-    )
-    if (clientId) { this.store.selectOnlyNode(clientId) }
-    return clientId
+    if (this.clipboard.nodes.length === 0) { return null }
+
+    const anchorType = this.clipboard.nodes[0].type
+    const origin = this.store.getRecentPlacementAnchor() || this.clipboard.anchorPosition
+    const anchorPosition = findAnchoredNodePlacement(this.store, anchorType, origin)
+
+    const newClientIdMap = this.clipboard.nodes.map(() => generateUUID())
+
+    const nodeModels = this.clipboard.nodes.map((nodeData, index) => new Node({
+      clientId: newClientIdMap[index],
+      type: nodeData.type,
+      position: {
+        x: anchorPosition.x + nodeData.relativeX,
+        y: anchorPosition.y + nodeData.relativeY
+      },
+      data: this.deepClone(nodeData.data)
+    }))
+
+    const connectionModels = this.clipboard.connections.map(connData => new Connection({
+      clientId: generateUUID(),
+      sourceId: newClientIdMap[connData.sourceIndex],
+      targetId: newClientIdMap[connData.targetIndex]
+    }))
+
+    const result = await this.syncManager.insertNodeSet(nodeModels, connectionModels, 'Paste nodes')
+    if (result.clientIds.length > 0) {
+      this.store.setSelectedNodeIds(result.clientIds)
+    }
+    return result
   }
   
   destroy() {

--- a/app/javascript/editorV2/handlers/ToolbarHandler.js
+++ b/app/javascript/editorV2/handlers/ToolbarHandler.js
@@ -107,7 +107,7 @@ class ToolbarHandler {
 
     this.templatePicker = new TemplatePicker(modal, {
       onInsert: async (template) => {
-        const organizerAnchor = findTemplateAnchor(template, this.viewport, this.store)
+        const organizerAnchor = findTemplateAnchor(template, this.viewport, this.store, this.store.getRecentPlacementAnchor())
         const result = await this.syncManager.insertTemplate(template, organizerAnchor)
 
         if (result?.organizerClientId) {
@@ -125,11 +125,11 @@ class ToolbarHandler {
   }
 
   findPlacementPosition(type) {
-    const center = this.viewport?.getVisibleCanvasCenter() || { x: 200, y: 200 }
     const dims = NODE_DIMENSIONS[type] || NODE_DIMENSIONS.default
+    const origin = this.store.getRecentPlacementAnchor() || this.viewport?.getVisibleCanvasCenter() || { x: 200, y: 200 }
     const anchor = {
-      x: Math.max(0, center.x - (dims.width / 2)),
-      y: Math.max(0, center.y - (dims.height / 2))
+      x: Math.max(0, Math.round(origin.x - (dims.width / 2))),
+      y: Math.max(0, Math.round(origin.y - (dims.height / 2)))
     }
 
     if (this.isPositionClear(anchor, dims)) {

--- a/app/javascript/editorV2/handlers/ToolbarHandler.js
+++ b/app/javascript/editorV2/handlers/ToolbarHandler.js
@@ -225,7 +225,12 @@ class ToolbarHandler {
    * Handle delete node button click
    */
   handleDeleteClick() {
-    this.clickHandler?.deleteSelectedNode()
+    if (this.clickHandler?.deleteSelectedNodes) {
+      this.clickHandler.deleteSelectedNodes()
+      return
+    }
+
+    this.clickHandler?.deleteSelectedNode?.()
   }
   
   /**
@@ -235,11 +240,13 @@ class ToolbarHandler {
     const deleteBtn = document.querySelector('.btn-delete-node')
     if (!deleteBtn) return
     
-    const selectedId = this.clickHandler?.getSelectedNodeId()
-    const node = selectedId ? this.store.getNode(selectedId) : null
-    
-    // Disable if: no selection OR root node
-    const isDisabled = !selectedId || (node && node.type === 'root')
+    const selectedIds = this.clickHandler?.getDeletableSelectedNodeIds?.() || this.store.getSelectedNodeIds().filter(clientId => {
+      const node = this.store.getNode(clientId)
+      return node && node.type !== 'root'
+    })
+
+    // Disable if: no deletable selection
+    const isDisabled = selectedIds.length === 0
     deleteBtn.disabled = isDisabled
   }
 

--- a/app/javascript/editorV2/handlers/ToolbarHandler.js
+++ b/app/javascript/editorV2/handlers/ToolbarHandler.js
@@ -1,32 +1,9 @@
-// handlers/ToolbarHandler.js
-// Handles toolbar buttons: Add Node, Undo, Redo
-
-import { NODE_DIMENSIONS } from '../constants.js'
 import TemplatePicker from '../templates/TemplatePicker.js'
 import { findTemplateAnchor } from '../templates/TemplatePlacement.js'
+import { findAnchoredNodePlacement } from '../utils/nodePlacement.js'
 
-const NODE_PLACEMENT_PADDING = 40
-const NODE_PLACEMENT_STEP = 36
-const NODE_PLACEMENT_RING_STEPS = 10
-const NODE_PLACEMENT_MAX_RINGS = 12
 
-/**
- * ToolbarHandler
- * 
- * Handles:
- * - Add Node buttons (+ Condition, + Action)
- * - Undo/Redo buttons
- * - Delete button (if not handled by ClickHandler)
- */
 class ToolbarHandler {
-  /**
-   * Create ToolbarHandler
-   * @param {Store} store - Store instance
-   * @param {History} history - History instance
-   * @param {SyncManager} syncManager - SyncManager instance
-   * @param {HTMLElement} container - Nodes canvas container (for positioning)
-   * @param {ClickHandler} clickHandler - ClickHandler instance (for node selection)
-   */
   constructor(store, history, syncManager, container, clickHandler, viewport = null) {
     this.store = store
     this.history = history
@@ -38,21 +15,16 @@ class ToolbarHandler {
     this.editorRoot = document.querySelector('.bot-editor')
     this.templatePicker = null
   }
-  
-/**
-    * Attach toolbar event listeners
-    */
+
   attach() {
     // Add Node buttons
     document.querySelectorAll('.btn-add-node').forEach(btn => {
       btn.addEventListener('click', (e) => this.handleAddNode(e))
     })
-
     const templatesBtn = document.querySelector('.btn-open-templates')
     if (templatesBtn) {
       templatesBtn.addEventListener('click', () => this.openTemplatePicker())
     }
-    
     // Undo button
     const undoBtn = document.querySelector('.btn-undo')
     if (undoBtn) {
@@ -61,7 +33,6 @@ class ToolbarHandler {
         this.updateButtons()
       })
     }
-    
     // Redo button
     const redoBtn = document.querySelector('.btn-redo')
     if (redoBtn) {
@@ -70,28 +41,20 @@ class ToolbarHandler {
         this.updateButtons()
       })
     }
-    
     // Delete node button
     const deleteBtn = document.querySelector('.btn-delete-node')
     if (deleteBtn) {
       deleteBtn.addEventListener('click', () => this.handleDeleteClick())
     }
-
     this.syncManager.setPersistedMutationCallback(() => this.markBotStale())
     this.updateCompileAction()
     this.attachTemplatePicker()
   }
   
-  /**
-   * Handle Add Node button click
-   * @param {Event} e - Click event
-   */
   async handleAddNode(e) {
     const type = e.target.dataset.type
     if (!type) return
-
     const position = this.findPlacementPosition(type)
-    
     try {
       await this.syncManager.createNode(type, position, {})
     } catch (err) {
@@ -101,22 +64,17 @@ class ToolbarHandler {
 
   attachTemplatePicker() {
     const modal = document.getElementById('template-picker-modal')
-    if (!modal) {
-      return
-    }
-
+    if (!modal) { return }
     this.templatePicker = new TemplatePicker(modal, {
       onInsert: async (template) => {
         const organizerAnchor = findTemplateAnchor(template, this.viewport, this.store, this.store.getRecentPlacementAnchor())
         const result = await this.syncManager.insertTemplate(template, organizerAnchor)
-
         if (result?.organizerClientId) {
           this.clickHandler?.selectNodeById(result.organizerClientId)
           this.updateButtons()
         }
       }
     })
-
     this.templatePicker.attach()
   }
 
@@ -125,89 +83,25 @@ class ToolbarHandler {
   }
 
   findPlacementPosition(type) {
-    const dims = NODE_DIMENSIONS[type] || NODE_DIMENSIONS.default
     const origin = this.store.getRecentPlacementAnchor() || this.viewport?.getVisibleCanvasCenter() || { x: 200, y: 200 }
-    const anchor = {
-      x: Math.max(0, Math.round(origin.x - (dims.width / 2))),
-      y: Math.max(0, Math.round(origin.y - (dims.height / 2)))
-    }
-
-    if (this.isPositionClear(anchor, dims)) {
-      return anchor
-    }
-
-    for (let ring = 1; ring <= NODE_PLACEMENT_MAX_RINGS; ring += 1) {
-      const radius = ring * NODE_PLACEMENT_STEP
-
-      for (let step = 0; step < NODE_PLACEMENT_RING_STEPS; step += 1) {
-        const angle = (Math.PI * 2 * step) / NODE_PLACEMENT_RING_STEPS
-        const candidate = {
-          x: Math.max(0, Math.round(anchor.x + (Math.cos(angle) * radius))),
-          y: Math.max(0, Math.round(anchor.y + (Math.sin(angle) * radius)))
-        }
-
-        if (this.isPositionClear(candidate, dims)) {
-          return candidate
-        }
-      }
-    }
-
-    return anchor
+    return findAnchoredNodePlacement(this.store, type, origin)
   }
 
-  isPositionClear(candidate, candidateDims) {
-    const candidateBounds = {
-      left: candidate.x,
-      right: candidate.x + candidateDims.width,
-      top: candidate.y,
-      bottom: candidate.y + candidateDims.height
-    }
-
-    return this.store.getNodes().every(node => {
-      const dims = NODE_DIMENSIONS[node.type] || NODE_DIMENSIONS.default
-      const nodeBounds = {
-        left: node.position.x - NODE_PLACEMENT_PADDING,
-        right: node.position.x + dims.width + NODE_PLACEMENT_PADDING,
-        top: node.position.y - NODE_PLACEMENT_PADDING,
-        bottom: node.position.y + dims.height + NODE_PLACEMENT_PADDING
-      }
-
-      return (
-        candidateBounds.right <= nodeBounds.left ||
-        candidateBounds.left >= nodeBounds.right ||
-        candidateBounds.bottom <= nodeBounds.top ||
-        candidateBounds.top >= nodeBounds.bottom
-      )
-    })
-  }
-  
-  /**
-   * Perform undo (async - syncs with server)
-   */
   async undo() {
     if (!this.history.canUndo()) return
-    if (this.syncManager.isUndoRedoPending) return
-    
+    if (this.syncManager.isUndoRedoPending) return   
     await this.syncManager.undo()
   }
-  
-  /**
-   * Perform redo (async - syncs with server)
-   */
+
   async redo() {
     if (!this.history.canRedo()) return
     if (this.syncManager.isUndoRedoPending) return
-    
     await this.syncManager.redo()
   }
   
-/**
-    * Update undo/redo button states
-    */
   updateButtons() {
     const undoBtn = document.querySelector('.btn-undo')
     const redoBtn = document.querySelector('.btn-redo')
-    
     if (undoBtn) {
       undoBtn.disabled = !this.history.canUndo() || this.syncManager.isUndoRedoPending
       undoBtn.classList.toggle('loading', this.syncManager.isUndoRedoPending)
@@ -216,30 +110,21 @@ class ToolbarHandler {
       redoBtn.disabled = !this.history.canRedo() || this.syncManager.isUndoRedoPending
       redoBtn.classList.toggle('loading', this.syncManager.isUndoRedoPending)
     }
-    
     this.updateDeleteButton()
     this.updateCompileAction()
   }
   
-  /**
-   * Handle delete node button click
-   */
   handleDeleteClick() {
     if (this.clickHandler?.deleteSelectedNodes) {
       this.clickHandler.deleteSelectedNodes()
       return
     }
-
     this.clickHandler?.deleteSelectedNode?.()
   }
   
-  /**
-   * Update delete button state based on selection
-   */
   updateDeleteButton() {
     const deleteBtn = document.querySelector('.btn-delete-node')
     if (!deleteBtn) return
-    
     const selectedIds = this.clickHandler?.getDeletableSelectedNodeIds?.() || this.store.getSelectedNodeIds().filter(clientId => {
       const node = this.store.getNode(clientId)
       return node && node.type !== 'root'
@@ -255,25 +140,19 @@ class ToolbarHandler {
   }
 
   markBotStale() {
-    if (this.editorRoot) {
-      this.editorRoot.dataset.editorBotStaleValue = 'true'
-    }
-
+    if (this.editorRoot) { this.editorRoot.dataset.editorBotStaleValue = 'true' }
     this.updateCompileAction()
   }
 
   updateCompileAction() {
     if (!this.compileAndExitLink) return
-
     this.compileAndExitLink.classList.toggle('hidden', !this.isBotStale())
   }
   
-  /**
-   * Cleanup
-   */
-  destroy() {
-    // Event listeners are on document elements, cleaned up automatically
-  }
+
+  // destroy() {
+  //   // Event listeners are on document elements, cleaned up automatically
+  // }
 }
 
 export default ToolbarHandler

--- a/app/javascript/editorV2/index.js
+++ b/app/javascript/editorV2/index.js
@@ -106,7 +106,7 @@ export async function initEditor(botId, container, svgContainer, editorPanel = n
     
     // Convenience methods
     createNode: (type, position, data) => syncManager.createNode(type, position, data),
-    deleteNode: (clientId) => syncManager.deleteNode(clientId),
+    deleteNode: (clientId) => syncManager.deleteNodes([clientId]),
     createConnection: (sourceId, targetId) => syncManager.createConnection(sourceId, targetId),
     deleteConnection: (clientId) => syncManager.deleteConnection(clientId),
     updateNodeData: (clientId, data) => syncManager.updateNodeData(clientId, data),

--- a/app/javascript/editorV2/index.js
+++ b/app/javascript/editorV2/index.js
@@ -52,7 +52,6 @@ export async function initEditor(botId, container, svgContainer, editorPanel = n
   const dragHandler = new DragHandler(store, syncManager, canvasViewport)
   const connectionHandler = new ConnectionHandler(store, syncManager, connectionRenderer, canvasViewport)
   const clickHandler = new ClickHandler(store, history, editorPanel)
-  const keyboardHandler = new KeyboardHandler(store, history, syncManager)
   const toolbarHandler = new ToolbarHandler(store, history, syncManager, container, clickHandler, canvasViewport)
   function attachHandlersToNode(element, clientId) {
     dragHandler.attach(element, clientId)
@@ -73,6 +72,7 @@ export async function initEditor(botId, container, svgContainer, editorPanel = n
   
   // 6. Attach Global UI handlers
   clickHandler.setSyncManager(syncManager)
+  const keyboardHandler = new KeyboardHandler(store, history, syncManager, clickHandler)
   clickHandler.setupGlobalHandlers()
   keyboardHandler.attach()
   toolbarHandler.attach()

--- a/app/javascript/editorV2/index.js
+++ b/app/javascript/editorV2/index.js
@@ -14,20 +14,13 @@ import { showError } from './utils/errors.js'
 import ToolbarHandler from './handlers/ToolbarHandler.js'
 
 export async function initEditor(botId, container, svgContainer, editorPanel = null) {
-  if (!container) {
-    throw new Error('Container element is required')
-  }
-  if (!svgContainer) {
-    throw new Error('SVG container element is required')
-  }
-
+  if (!container) { throw new Error('Container element is required') }
+  if (!svgContainer) { throw new Error('SVG container element is required') }
   const workspace = document.getElementById('canvas-workspace')
   const scene = document.getElementById('canvas-scene')
   const canvasContainer = container.closest('.canvas-container')
 
-  if (!workspace || !scene || !canvasContainer) {
-    throw new Error('Canvas viewport elements are required')
-  }
+  if (!workspace || !scene || !canvasContainer) { throw new Error('Canvas viewport elements are required') }
   
   // 1. Initialize core state/services
   const api = new API(botId)
@@ -154,13 +147,7 @@ function updateUndoRedoUI(history) {
   const redoBtn = document.querySelector('.btn-redo')
   const countDisplay = document.querySelector('.undo-count')
   
-  if (undoBtn) {
-    undoBtn.disabled = !history.canUndo()
-  }
-  if (redoBtn) {
-    redoBtn.disabled = !history.canRedo()
-  }
-  if (countDisplay) {
-    countDisplay.textContent = history.getHistoryDisplay()
-  }
+  if (undoBtn)      { undoBtn.disabled = !history.canUndo() }
+  if (redoBtn)      { redoBtn.disabled = !history.canRedo() }
+  if (countDisplay) { countDisplay.textContent = history.getHistoryDisplay() }
 }

--- a/app/javascript/editorV2/index.js
+++ b/app/javascript/editorV2/index.js
@@ -9,7 +9,7 @@ import DragHandler from './handlers/DragHandler.js'
 import ConnectionHandler from './handlers/ConnectionHandler.js'
 import ClickHandler from './handlers/ClickHandler.js'
 import KeyboardHandler from './handlers/KeyboardHandler.js'
-import { MAX_HISTORY } from './constants.js'
+import { EVENTS, MAX_HISTORY } from './constants.js'
 import { showError } from './utils/errors.js'
 import ToolbarHandler from './handlers/ToolbarHandler.js'
 
@@ -78,6 +78,11 @@ export async function initEditor(botId, container, svgContainer, editorPanel = n
   toolbarHandler.attach()
   clickHandler.onNodeSelected = () => toolbarHandler.updateButtons()
   clickHandler.onNodeDeselected = () => toolbarHandler.updateButtons()
+  const unsubscribeToolbarSelection = store.subscribe((event) => {
+    if (event === EVENTS.SELECTION_CHANGE) {
+      toolbarHandler.updateButtons()
+    }
+  })
   const deleteButtonContainer = svgContainer.parentElement
   connectionHandler.setupDeleteHandler(deleteButtonContainer)
 
@@ -138,6 +143,7 @@ export async function initEditor(botId, container, svgContainer, editorPanel = n
       connectionHandler.destroy()
       clickHandler.destroy()
       keyboardHandler.destroy()
+      unsubscribeToolbarSelection()
       store.destroy()
     }
   }

--- a/app/javascript/editorV2/models/Connection.js
+++ b/app/javascript/editorV2/models/Connection.js
@@ -1,39 +1,16 @@
-// models/Connection.js
-// Immutable Connection model with client-side UUID
-
 import generateUUID from '../utils/uuid.js'
 
-/**
- * Immutable Connection model
- * Represents a directed edge from source node to target node
- * Create new instances for updates - do not mutate directly
- */
 class Connection {
-  /**
-   * Create a new Connection
-   * @param {Object} params
-   * @param {string} [params.clientId] - Client-side UUID (generated if not provided)
-   * @param {number|null} [params.serverId] - Server/database ID (null for new connections)
-   * @param {string} params.sourceId - Source node clientId
-   * @param {string} params.targetId - Target node clientId
-   */
+  
   constructor({ clientId, serverId = null, sourceId, targetId }) {
-    // Generate clientId if not provided
     this.clientId = clientId || generateUUID()
-    
     // serverId may be null for new connections until synced
     this.serverId = serverId
     
     // Validate required fields
-    if (!sourceId) {
-      throw new Error('sourceId is required')
-    }
-    if (!targetId) {
-      throw new Error('targetId is required')
-    }
-    if (sourceId === targetId) {
-      throw new Error('sourceId and targetId cannot be the same (no self-connections)')
-    }
+    if (!sourceId) { throw new Error('sourceId is required') }
+    if (!targetId) { throw new Error('targetId is required') }
+    if (sourceId === targetId) { throw new Error('sourceId and targetId cannot be the same (no self-connections)') }
     
     this.sourceId = sourceId
     this.targetId = targetId
@@ -42,11 +19,6 @@ class Connection {
     Object.freeze(this)
   }
   
-  /**
-   * Create a new Connection with updated properties
-   * @param {Object} updates - Properties to update
-   * @returns {Connection} New Connection instance
-   */
   update(updates) {
     return new Connection({
       clientId: this.clientId,
@@ -56,48 +28,23 @@ class Connection {
     })
   }
   
-  /**
-   * Check if this connection involves a specific node
-   * @param {string} nodeId - Node clientId to check
-   * @returns {boolean} True if connection involves this node
-   */
   involvesNode(nodeId) {
     return this.sourceId === nodeId || this.targetId === nodeId
   }
   
-  /**
-   * Check if this is the same connection (by clientId)
-   * @param {Connection} other - Another connection
-   * @returns {boolean} True if same clientId
-   */
   equals(other) {
     return other instanceof Connection && this.clientId === other.clientId
   }
-  
-  /**
-   * Check if this connects the same nodes as another connection
-   * (regardless of direction or clientId)
-   * @param {Connection} other - Another connection
-   * @returns {boolean} True if same source and target
-   */
+
   connectsSameNodes(other) {
     if (!(other instanceof Connection)) return false
     return this.sourceId === other.sourceId && this.targetId === other.targetId
   }
   
-  /**
-   * Get a unique key for this connection
-   * Format: "sourceId-targetId"
-   * @returns {string} Connection key
-   */
   getKey() {
     return `${this.sourceId}-${this.targetId}`
   }
   
-  /**
-   * Serialize to JSON
-   * @returns {Object} JSON representation
-   */
   toJSON() {
     return {
       clientId: this.clientId,
@@ -107,11 +54,6 @@ class Connection {
     }
   }
   
-  /**
-   * Create Connection from JSON
-   * @param {Object} json - JSON representation
-   * @returns {Connection} New Connection instance
-   */
   static fromJSON(json) {
     return new Connection({
       clientId: json.clientId,
@@ -121,14 +63,6 @@ class Connection {
     })
   }
   
-  /**
-   * Create Connection from server response
-   * @param {Object} serverConnection - Server connection object
-   * @param {string} sourceClientId - Source node clientId
-   * @param {string} targetClientId - Target node clientId
-   * @param {string} [clientId] - Client-side UUID
-   * @returns {Connection} New Connection instance
-   */
   static fromServer(serverConnection, sourceClientId, targetClientId, clientId) {
     return new Connection({
       clientId: clientId,

--- a/app/javascript/editorV2/models/Graph.js
+++ b/app/javascript/editorV2/models/Graph.js
@@ -1,21 +1,9 @@
-// models/Graph.js
-// Graph container with nodes and connections
-
 import Node from './Node.js'
 import Connection from './Connection.js'
 import generateUUID from '../utils/uuid.js'
 
-/**
- * Graph container
- * Holds nodes and connections in Maps keyed by clientId
- * All mutation methods return new Graph instances (immutable)
- */
 class Graph {
-  /**
-   * Create a new Graph
-   * @param {Node[]} [nodes=[]] - Initial nodes
-   * @param {Connection[]} [connections=[]] - Initial connections
-   */
+  
   constructor(nodes = [], connections = []) {
     // Store as Maps for O(1) lookup
     this.nodes = new Map()
@@ -42,47 +30,22 @@ class Graph {
   }
   
   // ===== Node Operations =====
-  
-  /**
-   * Get a node by clientId
-   * @param {string} clientId - Node clientId
-   * @returns {Node|undefined} Node or undefined if not found
-   */
   getNode(clientId) {
     return this.nodes.get(clientId)
   }
   
-  /**
-   * Check if a node exists
-   * @param {string} clientId - Node clientId
-   * @returns {boolean} True if node exists
-   */
   hasNode(clientId) {
     return this.nodes.has(clientId)
   }
   
-  /**
-   * Get all nodes as an array
-   * @returns {Node[]} Array of all nodes
-   */
   getNodes() {
     return Array.from(this.nodes.values())
   }
   
-  /**
-   * Get nodes by type
-   * @param {string} type - Node type (root, condition, action, organizer)
-   * @returns {Node[]} Array of matching nodes
-   */
   getNodesByType(type) {
     return this.getNodes().filter(node => node.type === type)
   }
   
-  /**
-   * Add a new node, returns new Graph
-   * @param {Node} node - Node to add
-   * @returns {Graph} New Graph with node added
-   */
   addNode(node) {
     if (this.nodes.has(node.clientId)) {
       console.warn(`Node with clientId ${node.clientId} already exists, replacing`)
@@ -97,12 +60,6 @@ class Graph {
     )
   }
   
-  /**
-   * Update a node, returns new Graph
-   * @param {string} clientId - Node clientId to update
-   * @param {Object} updates - Properties to update
-   * @returns {Graph} New Graph with updated node
-   */
   updateNode(clientId, updates) {
     const existingNode = this.nodes.get(clientId)
     if (!existingNode) {
@@ -120,11 +77,6 @@ class Graph {
     )
   }
   
-  /**
-   * Remove a node and all its connections, returns new Graph
-   * @param {string} clientId - Node clientId to remove
-   * @returns {Graph} New Graph with node removed
-   */
   removeNode(clientId) {
     if (!this.nodes.has(clientId)) {
       console.warn(`Node ${clientId} not found, cannot remove`)
@@ -150,39 +102,18 @@ class Graph {
   }
   
   // ===== Connection Operations =====
-  
-  /**
-   * Get a connection by clientId
-   * @param {string} clientId - Connection clientId
-   * @returns {Connection|undefined} Connection or undefined if not found
-   */
   getConnection(clientId) {
     return this.connections.get(clientId)
   }
   
-  /**
-   * Check if a connection exists
-   * @param {string} clientId - Connection clientId
-   * @returns {boolean} True if connection exists
-   */
   hasConnection(clientId) {
     return this.connections.has(clientId)
   }
   
-  /**
-   * Get all connections as an array
-   * @returns {Connection[]} Array of all connections
-   */
   getConnections() {
     return Array.from(this.connections.values())
   }
   
-  /**
-   * Find connection between two nodes
-   * @param {string} sourceClientId - Source node clientId
-   * @param {string} targetClientId - Target node clientId
-   * @returns {Connection|undefined} Connection or undefined if not found
-   */
   findConnection(sourceClientId, targetClientId) {
     for (const conn of this.connections.values()) {
       if (conn.sourceId === sourceClientId && conn.targetId === targetClientId) {
@@ -192,11 +123,6 @@ class Graph {
     return undefined
   }
   
-  /**
-   * Get all connections for a node (both incoming and outgoing)
-   * @param {string} clientId - Node clientId
-   * @returns {Object} { outgoing: Connection[], incoming: Connection[] }
-   */
   getConnectionsFor(clientId) {
     const outgoing = []
     const incoming = []
@@ -209,11 +135,6 @@ class Graph {
     return { outgoing, incoming }
   }
   
-  /**
-   * Get outgoing connections for a node
-   * @param {string} clientId - Node clientId
-   * @returns {Connection[]} Array of outgoing connections
-   */
   getOutgoingConnections(clientId) {
     const result = []
     this.connections.forEach(conn => {
@@ -222,11 +143,6 @@ class Graph {
     return result
   }
   
-  /**
-   * Get incoming connections for a node
-   * @param {string} clientId - Node clientId
-   * @returns {Connection[]} Array of incoming connections
-   */
   getIncomingConnections(clientId) {
     const result = []
     this.connections.forEach(conn => {
@@ -235,12 +151,6 @@ class Graph {
     return result
   }
   
-  /**
-   * Get descendant node IDs (children, grandchildren, etc.)
-   * Uses BFS to traverse the tree
-   * @param {string} clientId - Starting node clientId
-   * @returns {Set<string>} Set of descendant clientIds
-   */
   getDescendantIds(clientId) {
     const descendants = new Set()
     const queue = [clientId]
@@ -265,11 +175,6 @@ class Graph {
     return descendants
   }
   
-  /**
-   * Add a connection, returns new Graph
-   * @param {Connection} connection - Connection to add
-   * @returns {Graph} New Graph with connection added
-   */
   addConnection(connection) {
     // Validate that both source and target nodes exist
     if (!this.nodes.has(connection.sourceId)) {
@@ -297,12 +202,6 @@ class Graph {
     )
   }
   
-  /**
-   * Update a connection, returns new Graph
-   * @param {string} clientId - Connection clientId to update
-   * @param {Object} updates - Properties to update
-   * @returns {Graph} New Graph with updated connection
-   */
   updateConnection(clientId, updates) {
     const existingConn = this.connections.get(clientId)
     if (!existingConn) {
@@ -320,11 +219,6 @@ class Graph {
     )
   }
   
-  /**
-   * Remove a connection, returns new Graph
-   * @param {string} clientId - Connection clientId to remove
-   * @returns {Graph} New Graph with connection removed
-   */
   removeConnection(clientId) {
     if (!this.connections.has(clientId)) {
       console.warn(`Connection ${clientId} not found, cannot remove`)
@@ -341,11 +235,6 @@ class Graph {
   }
   
   // ===== Serialization =====
-  
-  /**
-   * Serialize to JSON
-   * @returns {Object} JSON representation
-   */
   toJSON() {
     return {
       nodes: this.getNodes().map(n => n.toJSON()),
@@ -353,11 +242,6 @@ class Graph {
     }
   }
   
-  /**
-   * Create Graph from JSON
-   * @param {Object} json - JSON representation
-   * @returns {Graph} New Graph instance
-   */
   static fromJSON(json) {
     const nodes = json.nodes.map(n => Node.fromJSON(n))
     const connections = json.connections.map(c => Connection.fromJSON(c))
@@ -365,11 +249,6 @@ class Graph {
   }
   
   // ===== Utility Methods =====
-  
-  /**
-   * Get total count of nodes and connections
-   * @returns {Object} { nodes: number, connections: number }
-   */
   getSize() {
     return {
       nodes: this.nodes.size,
@@ -377,18 +256,10 @@ class Graph {
     }
   }
   
-  /**
-   * Check if graph is empty
-   * @returns {boolean} True if no nodes or connections
-   */
   isEmpty() {
     return this.nodes.size === 0 && this.connections.size === 0
   }
   
-  /**
-   * Create a deep clone of this graph
-   * @returns {Graph} New Graph instance with same data
-   */
   clone() {
     return Graph.fromJSON(this.toJSON())
   }

--- a/app/javascript/editorV2/models/Node.js
+++ b/app/javascript/editorV2/models/Node.js
@@ -1,33 +1,14 @@
-// models/Node.js
-// Immutable Node model with client-side UUID
-
 import generateUUID from '../utils/uuid.js'
 
-/**
- * Immutable Node model
- * Create new instances for updates - do not mutate directly
- */
 class Node {
-  /**
-   * Create a new Node
-   * @param {Object} params
-   * @param {string} [params.clientId] - Client-side UUID (generated if not provided)
-   * @param {number|null} [params.serverId] - Server/database ID (null for new nodes)
-   * @param {string} params.type - Node type (root, condition, action, organizer)
-   * @param {Object} params.position - Position { x, y }
-   * @param {Object} [params.data={}] - Node configuration data
-   */
   constructor({ clientId, serverId = null, type, position, data = {} }) {
-    // Generate clientId if not provided
     this.clientId = clientId || generateUUID()
     
     // serverId may be null for new nodes until synced
     this.serverId = serverId
     
     // Validate required fields
-    if (!type) {
-      throw new Error('Node type is required')
-    }
+    if (!type) { throw new Error('Node type is required') }
     if (!position || typeof position.x !== 'number' || typeof position.y !== 'number') {
       throw new Error('Valid position { x, y } is required')
     }
@@ -42,11 +23,6 @@ class Node {
     Object.freeze(this.data)
   }
   
-  /**
-   * Create a new Node with updated properties
-   * @param {Object} updates - Properties to update
-   * @returns {Node} New Node instance
-   */
   update(updates) {
     return new Node({
       clientId: this.clientId,
@@ -57,12 +33,6 @@ class Node {
     })
   }
   
-  /**
-   * Update position only
-   * @param {number} x - New X position
-   * @param {number} y - New Y position
-   * @returns {Node} New Node instance
-   */
   updatePosition(x, y) {
     return new Node({
       clientId: this.clientId,
@@ -73,11 +43,6 @@ class Node {
     })
   }
   
-  /**
-   * Update data only
-   * @param {Object} newData - New data (merged with existing)
-   * @returns {Node} New Node instance
-   */
   updateData(newData) {
     return new Node({
       clientId: this.clientId,
@@ -88,10 +53,6 @@ class Node {
     })
   }
   
-  /**
-   * Serialize to JSON
-   * @returns {Object} JSON representation
-   */
   toJSON() {
     return {
       clientId: this.clientId,
@@ -102,11 +63,6 @@ class Node {
     }
   }
   
-  /**
-   * Create Node from JSON
-   * @param {Object} json - JSON representation
-   * @returns {Node} New Node instance
-   */
   static fromJSON(json) {
     return new Node({
       clientId: json.clientId,
@@ -117,12 +73,6 @@ class Node {
     })
   }
   
-  /**
-   * Create Node from server response
-   * @param {Object} serverNode - Server node object (has database ID)
-   * @param {string} clientId - Client-side UUID
-   * @returns {Node} New Node instance
-   */
   static fromServer(serverNode, clientId) {
     return new Node({
       clientId: clientId,

--- a/app/javascript/editorV2/rendering/ConnectionRenderer.js
+++ b/app/javascript/editorV2/rendering/ConnectionRenderer.js
@@ -38,6 +38,9 @@ class ConnectionRenderer {
     // Map: clientId → { line, hitArea, deleteBtn }
     this.elements = new Map()
     
+    // Map: clientId → { sourceX, sourceY, targetX, targetY } — lightweight snapshot for diffing on GRAPH_RESTORE
+    this.connectionSnapshot = new Map()
+    
     // Subscribe to store updates
     this.unsubscribe = this.store.subscribe(this.handleChange.bind(this))
     this.unsubscribeViewport = this.viewport?.subscribe(() => this.updateDeleteButtonPositions())
@@ -98,8 +101,11 @@ class ConnectionRenderer {
         break
       
       case EVENTS.GRAPH_REPLACE:
-      case EVENTS.GRAPH_RESTORE:
         this.renderAllConnections()
+        break
+      
+      case EVENTS.GRAPH_RESTORE:
+        this.handleGraphRestore(data.graph)
         break
     }
   }
@@ -119,21 +125,8 @@ class ConnectionRenderer {
     const sourceNode = this.store.getNode(connection.sourceId)
     const targetNode = this.store.getNode(connection.targetId)
     
-    // if (!sourceNode || !targetNode) {
-    //   console.warn(`Cannot render connection: missing nodes`)
-    //   return
-    // }
-    //********** above is original, below is debugging 
     if (!sourceNode || !targetNode) {
-      console.warn('Cannot render connection: missing nodes', {
-        connectionClientId: connection.clientId,
-        sourceClientId: connection.sourceId,
-        targetClientId: connection.targetId,
-        sourceNodeInStore: !!sourceNode,
-        targetNodeInStore: !!targetNode,
-        storeNodeCount: this.store.getNodes().length,
-        storeNodeClientIds: this.store.getNodes().map(n => n.clientId).slice(0, 5)
-      })
+      console.warn(`Cannot render connection ${connection.clientId}: missing node`, connection.sourceId, connection.targetId)
       return
     }
     
@@ -142,7 +135,7 @@ class ConnectionRenderer {
     const targetEl = this.container.querySelector(`[data-client-id="${connection.targetId}"]`)
     
     if (!sourceEl || !targetEl) {
-      console.warn(`Cannot render connection: missing node elements`)
+      console.warn(`Cannot render connection ${connection.clientId}: missing node element`, connection.sourceId, connection.targetId)
       return
     }
     
@@ -169,6 +162,12 @@ class ConnectionRenderer {
     
     // Store references
     this.elements.set(connection.clientId, { line, hitArea, deleteBtn })
+    this.connectionSnapshot.set(connection.clientId, {
+      sourceX: sourceNode.position.x,
+      sourceY: sourceNode.position.y,
+      targetX: targetNode.position.x,
+      targetY: targetNode.position.y
+    })
   }
   
   /**
@@ -335,6 +334,14 @@ class ConnectionRenderer {
     elements.deleteBtn.style.left = `${sceneMidpoint.x}px`
     elements.deleteBtn.style.top = `${sceneMidpoint.y}px`
     this.applyInteractiveSizing(elements)
+
+    // Update snapshot
+    this.connectionSnapshot.set(clientId, {
+      sourceX: sourceNode.position.x,
+      sourceY: sourceNode.position.y,
+      targetX: targetNode.position.x,
+      targetY: targetNode.position.y
+    })
   }
 
   updateDeleteButtonPositions() {
@@ -371,6 +378,7 @@ class ConnectionRenderer {
       this.removeConnectionElements(elements)
       this.elements.delete(clientId)
     }
+    this.connectionSnapshot.delete(clientId)
   }
   
   /**
@@ -388,19 +396,59 @@ class ConnectionRenderer {
    * @param {string} clientId - Node client ID
    */
   removeConnectionsForNode(clientId) {
-    // Note: This is called when a node is removed
-    // The Store already removes connections cascade-style
-    // This is a safety cleanup for any remaining elements
     this.elements.forEach((elements, connClientId) => {
       const conn = this.store.getConnection(connClientId)
       if (!conn) {
-        // Connection was removed from store, clean up
         this.removeConnectionElements(elements)
         this.elements.delete(connClientId)
+        this.connectionSnapshot.delete(connClientId)
       }
     })
   }
   
+  handleGraphRestore(graph) {
+    const newConnectionIds = new Set()
+    const newConnections = new Map()
+    for (const conn of graph.getConnections()) {
+      newConnectionIds.add(conn.clientId)
+      newConnections.set(conn.clientId, conn)
+    }
+
+    for (const id of this.elements.keys()) {
+      if (!newConnectionIds.has(id)) this.removeConnection(id)
+    }
+
+    for (const conn of newConnections.values()) {
+      this.reconcileConnection(conn)
+    }
+  }
+
+  reconcileConnection(conn) {
+    const existing = this.elements.get(conn.clientId)
+    if (!existing) {
+      this.renderConnection(conn)
+      return
+    }
+
+    const sourceNode = this.store.getNode(conn.sourceId)
+    const targetNode = this.store.getNode(conn.targetId)
+    // Safety net: nodes should always exist by this point (NodeRenderer processes GRAPH_RESTORE
+    // first), but if a connection references a missing node, rebuild it from scratch.
+    if (!sourceNode || !targetNode) {
+      this.removeConnection(conn.clientId)
+      this.renderConnection(conn)
+      return
+    }
+
+    const snapshot = this.connectionSnapshot.get(conn.clientId)
+    const sourceMoved = !snapshot || sourceNode.position.x !== snapshot.sourceX || sourceNode.position.y !== snapshot.sourceY
+    const targetMoved = !snapshot || targetNode.position.x !== snapshot.targetX || targetNode.position.y !== snapshot.targetY
+
+    if (sourceMoved || targetMoved) {
+      this.updateConnectionPosition(conn.clientId)
+    }
+  }
+
   /**
    * Render all connections
    */
@@ -421,6 +469,7 @@ class ConnectionRenderer {
       this.removeConnectionElements(elements)
     })
     this.elements.clear()
+    this.connectionSnapshot.clear()
   }
   
   /**

--- a/app/javascript/editorV2/rendering/NodeRenderer.js
+++ b/app/javascript/editorV2/rendering/NodeRenderer.js
@@ -25,6 +25,9 @@ class NodeRenderer {
     // Map: clientId → DOM element
     this.elements = new Map()
     
+    // Map: clientId → { x, y, type, dataKey } — lightweight snapshot for diffing on GRAPH_RESTORE
+    this.nodeSnapshot = new Map()
+    
     // Pending preview fetch controllers (for cancellation)
     this.previewControllers = new Map()
     
@@ -56,8 +59,11 @@ class NodeRenderer {
         break
       
       case EVENTS.GRAPH_REPLACE:
-      case EVENTS.GRAPH_RESTORE:
         this.renderAllNodes()
+        break
+      
+      case EVENTS.GRAPH_RESTORE:
+        this.handleGraphRestore(data.graph)
         break
     }
   }
@@ -71,6 +77,12 @@ class NodeRenderer {
     const element = this.createNodeElement(node)
     this.container.appendChild(element)
     this.elements.set(node.clientId, element)
+    this.nodeSnapshot.set(node.clientId, {
+      x: node.position.x,
+      y: node.position.y,
+      type: node.type,
+      dataKey: JSON.stringify(node.data)
+    })
     this.onRender?.(node, element)
     this.fetchPreview(node.clientId)
   }
@@ -124,17 +136,24 @@ class NodeRenderer {
       return
     }
     
-    // Update position
+    const snapshot = this.nodeSnapshot.get(clientId)
+
     if (updates.position) {
       element.style.left = `${updates.position.x}px`
       element.style.top = `${updates.position.y}px`
+      if (snapshot) {
+        this.nodeSnapshot.set(clientId, { ...snapshot, x: updates.position.x, y: updates.position.y })
+      }
     }
-    
+
     // Refetch preview when data changes or when the server ID arrives.
     // Newly created nodes render optimistically before they have a server ID,
     // so the first preview fetch can only succeed after sync completes.
     if (updates.data !== undefined || updates.serverId !== undefined) {
       this.fetchPreview(clientId)
+      if (updates.data !== undefined && snapshot) {
+        this.nodeSnapshot.set(clientId, { ...snapshot, dataKey: JSON.stringify(updates.data) })
+      }
     }
   }
   
@@ -149,6 +168,8 @@ class NodeRenderer {
       this.elements.delete(clientId)
     }
     
+    this.nodeSnapshot.delete(clientId)
+
     // Cancel any pending preview fetch
     const controller = this.previewControllers.get(clientId)
     if (controller) {
@@ -204,6 +225,50 @@ class NodeRenderer {
     }
   }
   
+  handleGraphRestore(graph) {
+    const newNodeIds = new Set()
+    const newNodes = new Map()
+    for (const node of graph.getNodes()) {
+      newNodeIds.add(node.clientId)
+      newNodes.set(node.clientId, node)
+    }
+
+    for (const id of this.elements.keys()) {
+      if (!newNodeIds.has(id)) this.removeNode(id)
+    }
+
+    for (const node of newNodes.values()) {
+      this.reconcileNode(node)
+    }
+  }
+
+  reconcileNode(node) {
+    const existing = this.elements.get(node.clientId)
+    if (!existing) {
+      this.renderNode(node)
+      return
+    }
+
+    const snapshot = this.nodeSnapshot.get(node.clientId)
+    const typeChanged = node.type !== snapshot?.type
+    const dataChanged = JSON.stringify(node.data) !== snapshot?.dataKey
+    const positionChanged = node.position.x !== snapshot?.x || node.position.y !== snapshot?.y
+
+    if (typeChanged || dataChanged) {
+      this.removeNode(node.clientId)
+      this.renderNode(node)
+    } else if (positionChanged) {
+      existing.style.left = `${node.position.x}px`
+      existing.style.top = `${node.position.y}px`
+      this.nodeSnapshot.set(node.clientId, {
+        ...snapshot,
+        x: node.position.x,
+        y: node.position.y
+      })
+      this.onContentRender?.(node.clientId)
+    }
+  }
+
   renderAllNodes() {
     // Clear existing
     this.clear()
@@ -224,6 +289,7 @@ class NodeRenderer {
     // Remove all elements
     this.elements.forEach(element => element.remove())
     this.elements.clear()
+    this.nodeSnapshot.clear()
   }
   
   /**

--- a/app/javascript/editorV2/state/History.js
+++ b/app/javascript/editorV2/state/History.js
@@ -1,25 +1,6 @@
-// state/History.js
-// Snapshot-based undo/redo manager
-
 import { MAX_HISTORY } from '../constants.js'
 
-/**
- * History manager for undo/redo
- * 
- * Uses snapshot-based approach: entire graph state captured as JSON.
- * 
- * CRITICAL: Only SyncManager calls history.push() after successful server sync.
- * Handlers never call history.push() directly.
- * 
- * History is passed explicitly to components that need it, NOT stored in Store
- * (avoids circular dependency).
- */
 class History {
-  /**
-   * Create history manager
-   * @param {Store} store - Store instance for state snapshots
-   * @param {number} [maxHistory=MAX_HISTORY] - Maximum snapshots to store
-   */
   constructor(store, maxHistory = MAX_HISTORY) {
     this.store = store
     
@@ -35,55 +16,31 @@ class History {
     this.batchDescription = null
     
     // Flag to prevent history operations during restore
-    this.isRestoring = false
-    
-    // UI update callback
+    this.isRestoring = false 
     this.updateUICallback = null
   }
   
   // ===== Core Operations =====
   
-  /**
-   * Push a snapshot to history
-   * Called by SyncManager after successful server sync.
-   * 
-   * @param {string} description - Human-readable description
-   * @param {Object|null} [operation=null] - Operation metadata for undo/redo sync
-   */
   push(description, operation = null) {
-    // Don't push during restore
-    if (this.isRestoring) {
-      return
-    }
-    
-    // If in batch, don't push yet
-    if (this.batchDepth > 0) {
-      return
-    }
-    
+    if (this.isRestoring) { return }
+    if (this.batchDepth > 0) { return }
     // Truncate any redo snapshots (we're creating a new branch)
     if (this.currentIndex < this.snapshots.length - 1) {
       this.snapshots = this.snapshots.slice(0, this.currentIndex + 1)
     }
-    
-    // Create snapshot with operation metadata
     const snapshot = {
       description,
       timestamp: Date.now(),
       state: this.store.getState(),
       operation
     }
-    
-    // Add to stack
     this.snapshots.push(snapshot)
-    
-    // Enforce max history
     if (this.snapshots.length > this.maxHistory) {
       this.snapshots.shift()
     } else {
       this.currentIndex++
     }
-    
     this.updateUI()
   }
   
@@ -92,12 +49,8 @@ class History {
    * Restores state from previous snapshot
    */
   undo() {
-    if (!this.canUndo()) {
-      return
-    }
-    
-    this.isRestoring = true
-    
+    if (!this.canUndo()) { return }     
+    this.isRestoring = true     
     try {
       this.currentIndex--
       const snapshot = this.snapshots[this.currentIndex]
@@ -112,12 +65,8 @@ class History {
    * Redo a previously undone operation (local only - SyncManager handles server sync)
    */
   redo() {
-    if (!this.canRedo()) {
-      return
-    }
-    
-    this.isRestoring = true
-    
+    if (!this.canRedo()) { return }     
+    this.isRestoring = true 
     try {
       this.currentIndex++
       const snapshot = this.snapshots[this.currentIndex]
@@ -128,16 +77,9 @@ class History {
     }
   }
   
-  /**
-   * Local-only undo (called by SyncManager after server sync completes)
-   */
   undoLocal() {
-    if (!this.canUndo()) {
-      return
-    }
-    
+    if (!this.canUndo()) { return }
     this.isRestoring = true
-    
     try {
       this.currentIndex--
       const snapshot = this.snapshots[this.currentIndex]
@@ -148,16 +90,9 @@ class History {
     }
   }
   
-  /**
-   * Local-only redo (called by SyncManager after server sync completes)
-   */
   redoLocal() {
-    if (!this.canRedo()) {
-      return
-    }
-    
+    if (!this.canRedo()) { return }
     this.isRestoring = true
-    
     try {
       this.currentIndex++
       const snapshot = this.snapshots[this.currentIndex]
@@ -169,70 +104,37 @@ class History {
   }
   
   // ===== Query Methods =====
-  
-  /**
-   * Check if undo is available
-   * @returns {boolean}
-   */
   canUndo() {
     return this.currentIndex > 0
   }
   
-  /**
-   * Check if redo is available
-   * @returns {boolean}
-   */
   canRedo() {
     return this.currentIndex < this.snapshots.length - 1
   }
   
-  /**
-   * Get current history position
-   * @returns {number}
-   */
   getCurrentIndex() {
     return this.currentIndex
   }
   
-  /**
-   * Get total snapshots
-   * @returns {number}
-   */
   getTotalSnapshots() {
     return this.snapshots.length
   }
   
-  /**
-   * Get history display string (e.g., "5/50")
-   * @returns {string}
-   */
   getHistoryDisplay() {
     if (this.snapshots.length === 0) return `(0/${this.maxHistory})`
     return `(${this.currentIndex + 1}/${this.maxHistory})`
   }
   
-  /**
-   * Get current description
-   * @returns {string|null}
-   */
   getCurrentDescription() {
     if (this.currentIndex < 0) return null
     return this.snapshots[this.currentIndex]?.description || null
   }
   
-  /**
-   * Get current snapshot (for SyncManager to access operation metadata)
-   * @returns {Object|null}
-   */
   getCurrentSnapshot() {
     if (this.currentIndex < 0) return null
     return this.snapshots[this.currentIndex]
   }
   
-  /**
-   * Get next snapshot (for redo operations)
-   * @returns {Object|null}
-   */
   getNextSnapshot() {
     if (this.currentIndex < 0) return null
     if (this.currentIndex >= this.snapshots.length - 1) return null
@@ -240,41 +142,23 @@ class History {
   }
   
   // ===== Batch Operations =====
-  
-  /**
-   * Start a batch operation
-   * History won't be pushed until endBatch()
-   */
   startBatch() {
-    if (this.batchDepth === 0) {
-      this.batchDescription = null
-    }
+    if (this.batchDepth === 0) { this.batchDescription = null }
     this.batchDepth++
   }
   
-  /**
-   * End a batch operation and push to history
-   * @param {string} description - Description for the batch
-   */
   endBatch(description) {
     this.batchDepth--
-    
     if (this.batchDepth < 0) {
       console.error('endBatch() called without matching startBatch()')
       this.batchDepth = 0
       return
     }
-    
     if (this.batchDepth === 0 && description) {
       this.push(description)
     }
   }
   
-  /**
-   * Execute a function as a batch
-   * @param {string} description - Description for the batch
-   * @param {Function} fn - Function to execute
-   */
   batch(description, fn) {
     this.startBatch()
     try {
@@ -283,20 +167,13 @@ class History {
       this.endBatch(description)
     }
   }
-  
-  /**
-   * Reset batch state (cleanup after errors)
-   */
+
   resetBatch() {
     this.batchDepth = 0
     this.batchDescription = null
   }
   
   // ===== Utility Methods =====
-  
-  /**
-   * Clear all history
-   */
   clear() {
     this.snapshots = []
     this.currentIndex = -1
@@ -305,17 +182,10 @@ class History {
     this.updateUI()
   }
   
-  /**
-   * Set UI update callback
-   * @param {Function} callback - Called after push/undo/redo/clear
-   */
   setUpdateUICallback(callback) {
     this.updateUICallback = callback
   }
   
-  /**
-   * Trigger UI update
-   */
   updateUI() {
     if (this.updateUICallback) {
       try {
@@ -327,11 +197,6 @@ class History {
   }
   
   // ===== Debugging =====
-  
-  /**
-   * Get debug info
-   * @returns {Object}
-   */
   getDebugInfo() {
     return {
       currentIndex: this.currentIndex,

--- a/app/javascript/editorV2/state/Store.js
+++ b/app/javascript/editorV2/state/Store.js
@@ -1,6 +1,3 @@
-// state/Store.js
-// Central state container with subscriber pattern
-
 import { EVENTS } from '../constants.js'
 import Graph from '../models/Graph.js'
 import Node from '../models/Node.js'
@@ -33,15 +30,9 @@ class Store {
       isMarqueeSelecting: false,
       marqueeStart: null,
       marqueeCurrent: null
-    }
-    
-    // Subscribers: Array of { event, callback }
-    this.subscribers = []
-    
-    // Flag to prevent recursive updates
-    this.isUpdating = false
-    
-    // Flag to prevent updates after destruction
+    } 
+    this.subscribers = [] 
+    this.isUpdating = false 
     this.destroyed = false
 
     // Transient click suppression used to prevent post-drag/post-marquee clicks
@@ -50,15 +41,8 @@ class Store {
   }
   
   // ===== Subscriber Pattern =====
-  
-  /**
-   * Subscribe to store events
-   * @param {Function} callback - Called with (event, data)
-   * @returns {Function} Unsubscribe function
-   */
   subscribe(callback) {
-    this.subscribers.push(callback)
-    
+    this.subscribers.push(callback) 
     // Return unsubscribe function
     return () => {
       const index = this.subscribers.indexOf(callback)
@@ -68,23 +52,12 @@ class Store {
     }
   }
   
-/**
-    * Emit an event to all subscribers
-    * @param {string} event - Event name (use EVENTS constant)
-    * @param {Object} data - Event data
-    */
   emit(event, data) {
-    // Don't emit if store is destroyed
-    if (this.destroyed) {
-      return
-    }
-    
-    // Prevent recursive updates
+    if (this.destroyed) { return }
     if (this.isUpdating) {
       console.warn(`Recursive emit prevented: ${event}`)
       return
-    }
-    
+    } 
     this.isUpdating = true
     try {
       this.subscribers.forEach(callback => {
@@ -100,126 +73,68 @@ class Store {
   }
   
   // ===== Graph State Operations =====
-  
-  /**
-   * Replace the entire graph (used by History for undo/redo)
-   * @param {Graph} newGraph - New Graph instance
-   */
   replaceGraph(newGraph) {
     this.graph = newGraph
     this.emit(EVENTS.GRAPH_REPLACE, { graph: newGraph })
   }
   
   // --- Node Operations ---
-  
-  /**
-   * Add a node
-   * @param {Node} node - Node instance to add
-   */
   addNode(node) {
-    if (!(node instanceof Node)) {
-      throw new Error('addNode requires a Node instance')
-    }
-    
+    if (!(node instanceof Node)) { throw new Error('addNode requires a Node instance') }
     this.graph = this.graph.addNode(node)
     this.emit(EVENTS.NODE_ADD, { node, clientId: node.clientId })
   }
   
-  /**
-   * Update a node
-   * @param {string} clientId - Node clientId
-   * @param {Object} updates - Properties to update
-   */
   updateNode(clientId, updates) {
     const existingNode = this.graph.getNode(clientId)
     if (!existingNode) {
       console.warn(`Node ${clientId} not found, cannot update`)
       return
     }
-    
     this.graph = this.graph.updateNode(clientId, updates)
     const updatedNode = this.graph.getNode(clientId)
     this.emit(EVENTS.NODE_UPDATE, { node: updatedNode, clientId, updates })
   }
   
-  /**
-   * Remove a node and all its connections
-   * @param {string} clientId - Node clientId
-   */
   removeNode(clientId) {
     if (!this.graph.hasNode(clientId)) {
       console.warn(`Node ${clientId} not found, cannot remove`)
       return
     }
-    
     // Get connections before removal (for emit)
     const { outgoing, incoming } = this.graph.getConnectionsFor(clientId)
-    
     this.graph = this.graph.removeNode(clientId)
     this.emit(EVENTS.NODE_REMOVE, { clientId })
-    
     // Emit connection removal events
-    outgoing.forEach(conn => {
-      this.emit(EVENTS.CONNECTION_REMOVE, { clientId: conn.clientId })
-    })
-    incoming.forEach(conn => {
-      this.emit(EVENTS.CONNECTION_REMOVE, { clientId: conn.clientId })
-    })
+    outgoing.forEach(conn => { this.emit(EVENTS.CONNECTION_REMOVE, { clientId: conn.clientId }) })
+    incoming.forEach(conn => { this.emit(EVENTS.CONNECTION_REMOVE, { clientId: conn.clientId }) })
   }
   
-  /**
-   * Get a node by clientId
-   * @param {string} clientId - Node clientId
-   * @returns {Node|undefined}
-   */
   getNode(clientId) {
     return this.graph.getNode(clientId)
   }
   
-  /**
-   * Get all nodes
-   * @returns {Node[]}
-   */
   getNodes() {
     return this.graph.getNodes()
   }
   
-  /**
-   * Get nodes by type
-   * @param {string} type - Node type
-   * @returns {Node[]}
-   */
   getNodesByType(type) {
     return this.graph.getNodesByType(type)
   }
-  
   // --- Connection Operations ---
   
-  /**
-   * Add a connection
-   * @param {Connection} connection - Connection instance to add
-   */
   addConnection(connection) {
-    if (!(connection instanceof Connection)) {
-      throw new Error('addConnection requires a Connection instance')
-    }
-    
+    if (!(connection instanceof Connection)) { throw new Error('addConnection requires a Connection instance') }
     this.graph = this.graph.addConnection(connection)
     this.emit(EVENTS.CONNECTION_ADD, { connection, clientId: connection.clientId })
   }
   
-  /**
-   * Update a connection
-   * @param {string} clientId - Connection clientId
-   * @param {Object} updates - Properties to update
-   */
   updateConnection(clientId, updates) {
     const existingConn = this.graph.getConnection(clientId)
     if (!existingConn) {
       console.warn(`Connection ${clientId} not found, cannot update`)
       return
     }
-    
     this.graph = this.graph.updateConnection(clientId, updates)
     const updatedConn = this.graph.getConnection(clientId)
     this.emit(EVENTS.CONNECTION_UPDATE, { connection: updatedConn, clientId, updates })
@@ -230,7 +145,6 @@ class Store {
       console.warn(`Connection ${clientId} not found, cannot remove`)
       return
     }
-    
     this.graph = this.graph.removeConnection(clientId)
     this.emit(EVENTS.CONNECTION_REMOVE, { clientId })
   }
@@ -257,10 +171,6 @@ class Store {
   
 // ===== View State Operations =====
 
-  /**
-   * Set zoom level
-   * @param {number} zoom - Zoom level (1 = 100%)
-   */
   setZoom(zoom) {
     this.viewState.zoom = Math.max(0.1, Math.min(5, zoom))
   }
@@ -273,17 +183,14 @@ class Store {
   setSelectedNodeIds(clientIds) {
     const uniqueIds = [...new Set((clientIds || []).filter(Boolean))]
     this.viewState.selectedNodeIds = uniqueIds
-
     if (uniqueIds.length === 0) {
       this.viewState.primarySelectedNodeId = null
       this.emitSelectionChange()
       return
     }
-
     if (!uniqueIds.includes(this.viewState.primarySelectedNodeId)) {
       this.viewState.primarySelectedNodeId = uniqueIds[0]
     }
-
     this.emitSelectionChange()
   }
 
@@ -430,40 +337,22 @@ class Store {
   }
   
   // ===== Serialization =====
-  
-  /**
-   * Get serializable state (for history snapshots)
-   * @returns {Object} JSON representation
-   */
   getState() {
     return {
       graph: this.graph.toJSON()
-      // Note: viewState is NOT included - it's not undoable
     }
   }
   
-  /**
-   * Restore state (from history)
-   * @param {Object} state - JSON state from getState()
-   */
   restoreState(state) {
     this.graph = Graph.fromJSON(state.graph)
     this.emit(EVENTS.GRAPH_RESTORE, { graph: this.graph })
   }
   
-  // ===== Utility =====
-  
-  /**
-   * Get graph size
-   * @returns {Object} { nodes: number, connections: number }
-   */
+  // ===== Utility ===== 
   getSize() {
     return this.graph.getSize()
   }
   
-  /**
-   * Clear all state
-   */
   clear() {
     this.graph = new Graph()
     this.viewState = {
@@ -482,10 +371,6 @@ class Store {
     this.emit(EVENTS.GRAPH_REPLACE, { graph: this.graph })
   }
   
-  /**
-   * Destroy the store and prevent further updates
-   * Called when editor is torn down
-   */
   destroy() {
     this.destroyed = true
     this.subscribers = []

--- a/app/javascript/editorV2/state/Store.js
+++ b/app/javascript/editorV2/state/Store.js
@@ -164,7 +164,18 @@ class Store {
   getConnectionsFor(clientId) {
     return this.graph.getConnectionsFor(clientId)
   }
-  
+
+  getInternalConnections(clientIds) {
+    const idSet = new Set(clientIds)
+    const internal = []
+    this.graph.getConnections().forEach(conn => {
+      if (idSet.has(conn.sourceId) && idSet.has(conn.targetId)) {
+        internal.push(conn)
+      }
+    })
+    return internal
+  }
+
   getDescendantIds(clientId) {
     return this.graph.getDescendantIds(clientId)
   }

--- a/app/javascript/editorV2/state/Store.js
+++ b/app/javascript/editorV2/state/Store.js
@@ -30,7 +30,7 @@ class Store {
       isMarqueeSelecting: false,
       marqueeStart: null,
       marqueeCurrent: null
-    } 
+    }
     this.subscribers = [] 
     this.isUpdating = false 
     this.destroyed = false
@@ -42,7 +42,7 @@ class Store {
   
   // ===== Subscriber Pattern =====
   subscribe(callback) {
-    this.subscribers.push(callback) 
+    this.subscribers.push(callback)
     // Return unsubscribe function
     return () => {
       const index = this.subscribers.indexOf(callback)

--- a/app/javascript/editorV2/state/Store.js
+++ b/app/javascript/editorV2/state/Store.js
@@ -276,12 +276,15 @@ class Store {
 
     if (uniqueIds.length === 0) {
       this.viewState.primarySelectedNodeId = null
+      this.emitSelectionChange()
       return
     }
 
     if (!uniqueIds.includes(this.viewState.primarySelectedNodeId)) {
       this.viewState.primarySelectedNodeId = uniqueIds[0]
     }
+
+    this.emitSelectionChange()
   }
 
   selectOnlyNode(clientId) {
@@ -292,6 +295,7 @@ class Store {
 
     this.viewState.selectedNodeIds = [clientId]
     this.viewState.primarySelectedNodeId = clientId
+    this.emitSelectionChange()
   }
 
   addNodeToSelection(clientId) {
@@ -301,6 +305,7 @@ class Store {
     if (!this.viewState.primarySelectedNodeId) {
       this.viewState.primarySelectedNodeId = clientId
     }
+    this.emitSelectionChange()
   }
 
   removeNodeFromSelection(clientId) {
@@ -311,6 +316,7 @@ class Store {
     if (this.viewState.primarySelectedNodeId === clientId) {
       this.viewState.primarySelectedNodeId = this.viewState.selectedNodeIds[0] || null
     }
+    this.emitSelectionChange()
   }
 
   toggleNodeSelection(clientId) {
@@ -327,6 +333,14 @@ class Store {
   clearSelection() {
     this.viewState.selectedNodeIds = []
     this.viewState.primarySelectedNodeId = null
+    this.emitSelectionChange()
+  }
+
+  emitSelectionChange() {
+    this.emit(EVENTS.SELECTION_CHANGE, {
+      selectedNodeIds: this.getSelectedNodeIds(),
+      primarySelectedNodeId: this.getPrimarySelectedNode()
+    })
   }
 
   isNodeSelected(clientId) {

--- a/app/javascript/editorV2/state/Store.js
+++ b/app/javascript/editorV2/state/Store.js
@@ -29,6 +29,7 @@ class Store {
       selectedNodeIds: [],
       primarySelectedNodeId: null,
       editingNodeId: null,
+      recentPlacementAnchor: null,
       isMarqueeSelecting: false,
       marqueeStart: null,
       marqueeCurrent: null
@@ -357,6 +358,23 @@ class Store {
     return this.viewState.editingNodeId
   }
 
+  setRecentPlacementAnchor(point) {
+    if (!point || typeof point.x !== 'number' || typeof point.y !== 'number') {
+      this.viewState.recentPlacementAnchor = null
+      return
+    }
+    this.viewState.recentPlacementAnchor = { x: point.x, y: point.y }
+  }
+
+  getRecentPlacementAnchor() {
+    const anchor = this.viewState.recentPlacementAnchor
+    return anchor ? { x: anchor.x, y: anchor.y } : null
+  }
+
+  clearRecentPlacementAnchor() {
+    this.viewState.recentPlacementAnchor = null
+  }
+
   startMarquee(point) {
     this.viewState.isMarqueeSelecting = true
     this.viewState.marqueeStart = point
@@ -441,6 +459,7 @@ class Store {
       selectedNodeIds: [],
       primarySelectedNodeId: null,
       editingNodeId: null,
+      recentPlacementAnchor: null,
       isMarqueeSelecting: false,
       marqueeStart: null,
       marqueeCurrent: null
@@ -458,6 +477,7 @@ class Store {
     this.subscribers = []
     this.graph = new Graph()
     this.clickSuppressedUntil = 0
+    this.viewState.recentPlacementAnchor = null
   }
 }
 

--- a/app/javascript/editorV2/sync/SyncManager.js
+++ b/app/javascript/editorV2/sync/SyncManager.js
@@ -58,6 +58,61 @@ class SyncManager {
   setRecentPlacementAnchorForClientId(clientId) {
     this.setRecentPlacementAnchorFromNode(this.store.getNode(clientId))
   }
+
+  getDeletedNodeBackups(clientIds) {
+    const uniqueClientIds = [...new Set((clientIds || []).filter(Boolean))]
+    return uniqueClientIds
+      .map(clientId => this.store.getNode(clientId))
+      .filter(node => node && node.type !== 'root')
+      .map(node => ({
+        clientId: node.clientId,
+        serverId: node.serverId,
+        type: node.type,
+        position: { ...node.position },
+        data: { ...node.data }
+      }))
+  }
+
+  getDeletedConnectionBackups(clientIds) {
+    const backups = new Map()
+
+    clientIds.forEach(clientId => {
+      const { outgoing, incoming } = this.store.getConnectionsFor(clientId)
+
+      const touchedConnections = [...outgoing, ...incoming]
+
+      touchedConnections.forEach(connection => {
+        if (!backups.has(connection.clientId)) {
+          backups.set(connection.clientId, {
+            clientId: connection.clientId,
+            serverId: connection.serverId,
+            sourceId: connection.sourceId,
+            targetId: connection.targetId
+          })
+        }
+      })
+    })
+
+    return [...backups.values()]
+  }
+
+  restoreDeletedNodes(nodeBackups) {
+    nodeBackups.forEach(nodeData => {
+      this.store.addNode(new Node({
+        clientId: nodeData.clientId,
+        serverId: nodeData.serverId,
+        type: nodeData.type,
+        position: nodeData.position,
+        data: nodeData.data
+      }))
+    })
+  }
+
+  restoreDeletedConnections(connectionBackups) {
+    connectionBackups.forEach(connectionData => {
+      this.store.addConnection(new Connection(connectionData))
+    })
+  }
   
   /**
    * Set loading state for undo/redo
@@ -244,6 +299,24 @@ class SyncManager {
         )
         break
 
+      case 'deleteNodes':
+        for (const node of operation.nodes) {
+          await this.api.createNode({
+            type: node.type,
+            position: node.position,
+            data: node.data
+          }, node.clientId)
+        }
+
+        for (const connection of operation.connections) {
+          await this.api.createConnection(
+            connection.sourceId,
+            connection.targetId,
+            connection.clientId
+          )
+        }
+        break
+
       case 'insertTemplate':
         for (const connection of [...operation.connections].reverse()) {
           await this.api.deleteConnection(connection.clientId, connection.sourceId)
@@ -316,6 +389,10 @@ class SyncManager {
       case 'deleteConnection':
         // Redo: delete the connection again
         await this.api.deleteConnection(operation.clientId, operation.sourceId)
+        break
+
+      case 'deleteNodes':
+        await this.api.deleteNodes(operation.nodes.map(node => node.clientId))
         break
 
       case 'insertTemplate':
@@ -558,13 +635,7 @@ class SyncManager {
     const deletedServerId = existingNode.serverId
     
     // Get connections that will be deleted
-    const { outgoing, incoming } = this.store.getConnectionsFor(clientId)
-    const deletedConnections = [...outgoing, ...incoming].map(conn => ({
-      clientId: conn.clientId,
-      serverId: conn.serverId,
-      sourceId: conn.sourceId,
-      targetId: conn.targetId
-    }))
+    const deletedConnections = this.getDeletedConnectionBackups([clientId])
     
     // Store for rollback
     const nodeBackup = existingNode
@@ -600,6 +671,60 @@ class SyncManager {
       showError(`Failed to delete node: ${error.message}`)
       console.error('Failed to delete node:', error)
       
+      throw error
+    }
+  }
+
+  /**
+   * Delete multiple nodes selected as a set
+   * @param {string[]} clientIds - Node client IDs
+   * @returns {Promise<void>}
+   */
+  async deleteNodes(clientIds) {
+    const deletedNodes = this.getDeletedNodeBackups(clientIds)
+    if (deletedNodes.length === 0) {
+      return
+    }
+
+    const deletedConnections = this.getDeletedConnectionBackups(deletedNodes.map(node => node.clientId))
+
+    deletedNodes.forEach(node => {
+      this.store.removeNode(node.clientId)
+    })
+
+    try {
+      await this.api.deleteNodes(deletedNodes.map(node => node.clientId))
+
+      if (deletedNodes.length === 1) {
+        const deletedNode = deletedNodes[0]
+        this.history.push(`Delete ${deletedNode.type} node`, {
+          type: 'deleteNode',
+          clientId: deletedNode.clientId,
+          serverId: deletedNode.serverId,
+          entity: {
+            type: deletedNode.type,
+            position: deletedNode.position,
+            data: deletedNode.data
+          },
+          connections: deletedConnections
+        })
+      } else {
+        this.history.push(`Delete ${deletedNodes.length} selected nodes`, {
+          type: 'deleteNodes',
+          nodes: deletedNodes,
+          connections: deletedConnections
+        })
+      }
+
+      this.setRecentPlacementAnchorFromNode(deletedNodes[0])
+      this.notifyPersistedMutation()
+    } catch (error) {
+      this.restoreDeletedNodes(deletedNodes)
+      this.restoreDeletedConnections(deletedConnections)
+
+      showError(`Failed to delete nodes: ${error.message}`)
+      console.error('Failed to delete nodes:', error)
+
       throw error
     }
   }

--- a/app/javascript/editorV2/sync/SyncManager.js
+++ b/app/javascript/editorV2/sync/SyncManager.js
@@ -244,19 +244,22 @@ class SyncManager {
         break
         
       case 'deleteNode':
-        // Undo: recreate the node
+        // Undo: recreate the node first (connections reference it)
         await this.api.createNode({
           type: operation.entity.type,
           position: operation.entity.position,
           data: operation.entity.data
         }, operation.clientId)
         
-        // Undo: recreate cascade-deleted connections
-        // NOTE: If node recreation succeeds but some connections fail,
-        // the server state will be partially inconsistent. User can retry
-        // or refresh the page to see actual server state.
-        for (const conn of operation.connections) {
-          await this.api.createConnection(conn.sourceId, conn.targetId, conn.clientId)
+        if (operation.connections.length > 0) {
+          await this.requireAllSettled(
+            Promise.allSettled(
+              operation.connections.map(conn =>
+                this.api.createConnection(conn.sourceId, conn.targetId, conn.clientId)
+              )
+            ),
+            'recreate connections'
+          )
         }
         break
         
@@ -300,30 +303,54 @@ class SyncManager {
         break
 
       case 'deleteNodes':
-        for (const node of operation.nodes) {
-          await this.api.createNode({
-            type: node.type,
-            position: node.position,
-            data: node.data
-          }, node.clientId)
+        if (operation.nodes.length > 0) {
+          await this.requireAllSettled(
+            Promise.allSettled(
+              operation.nodes.map(node =>
+                this.api.createNode({
+                  type: node.type,
+                  position: node.position,
+                  data: node.data
+                }, node.clientId)
+              )
+            ),
+            'recreate nodes'
+          )
         }
 
-        for (const connection of operation.connections) {
-          await this.api.createConnection(
-            connection.sourceId,
-            connection.targetId,
-            connection.clientId
+        if (operation.connections.length > 0) {
+          await this.requireAllSettled(
+            Promise.allSettled(
+              operation.connections.map(connection =>
+                this.api.createConnection(connection.sourceId, connection.targetId, connection.clientId)
+              )
+            ),
+            'recreate connections'
           )
         }
         break
 
       case 'insertTemplate':
-        for (const connection of [...operation.connections].reverse()) {
-          await this.api.deleteConnection(connection.clientId, connection.sourceId)
+        if (operation.connections.length > 0) {
+          await this.requireAllSettled(
+            Promise.allSettled(
+              operation.connections.map(conn =>
+                this.api.deleteConnection(conn.clientId, conn.sourceId)
+              )
+            ),
+            'delete connections'
+          )
         }
 
-        for (const node of [...operation.nodes].reverse()) {
-          await this.api.deleteNode(node.clientId)
+        if (operation.nodes.length > 0) {
+          await this.requireAllSettled(
+            Promise.allSettled(
+              operation.nodes.map(node =>
+                this.api.deleteNode(node.clientId)
+              )
+            ),
+            'delete nodes'
+          )
         }
         break
         
@@ -396,12 +423,26 @@ class SyncManager {
         break
 
       case 'insertTemplate':
-        for (const node of operation.nodes) {
-          await this.api.createNode(node.entity, node.clientId)
+        if (operation.nodes.length > 0) {
+          await this.requireAllSettled(
+            Promise.allSettled(
+              operation.nodes.map(node =>
+                this.api.createNode(node.entity, node.clientId)
+              )
+            ),
+            'create nodes'
+          )
         }
 
-        for (const connection of operation.connections) {
-          await this.api.createConnection(connection.sourceId, connection.targetId, connection.clientId)
+        if (operation.connections.length > 0) {
+          await this.requireAllSettled(
+            Promise.allSettled(
+              operation.connections.map(connection =>
+                this.api.createConnection(connection.sourceId, connection.targetId, connection.clientId)
+              )
+            ),
+            'create connections'
+          )
         }
         break
         
@@ -410,6 +451,19 @@ class SyncManager {
     }
   }
   
+  // ===== Batch Helper =====
+
+  async requireAllSettled(settledPromise, context) {
+    const results = await settledPromise
+    const failures = results.filter(r => r.status === 'rejected')
+    if (failures.length > 0) {
+      const message = `${failures.length} of ${results.length} ${context} failed`
+      const error = failures.length === 1 ? failures[0].reason : new Error(message)
+      throw error
+    }
+    return results.map(r => r.value)
+  }
+
   // ===== Node Operations =====
   
   /**

--- a/app/javascript/editorV2/sync/SyncManager.js
+++ b/app/javascript/editorV2/sync/SyncManager.js
@@ -510,6 +510,98 @@ class SyncManager {
     }
   }
 
+  async insertNodeSet(nodeModels, connectionModels, description) {
+    nodeModels.forEach(node => this.store.addNode(node))
+    connectionModels.forEach(connection => this.store.addConnection(connection))
+
+    const persistedNodes = []
+    const persistedConnections = []
+
+    try {
+      if (nodeModels.length > 0) {
+        await this.requireAllSettled(
+          Promise.allSettled(
+            nodeModels.map(nodeData =>
+              this.api.createNode(
+                { type: nodeData.type, position: nodeData.position, data: nodeData.data },
+                nodeData.clientId
+              ).then(response => {
+                persistedNodes.push(nodeData)
+                this.store.updateNode(nodeData.clientId, { serverId: response.id })
+              })
+            )
+          ),
+          'create nodes'
+        )
+      }
+
+      if (connectionModels.length > 0) {
+        await this.requireAllSettled(
+          Promise.allSettled(
+            connectionModels.map(connectionData =>
+              this.api.createConnection(
+                connectionData.sourceId,
+                connectionData.targetId,
+                connectionData.clientId
+              ).then(response => {
+                persistedConnections.push(connectionData)
+                this.store.updateConnection(connectionData.clientId, { serverId: response.id })
+              })
+            )
+          ),
+          'create connections'
+        )
+      }
+
+      this.history.push(description, {
+        type: 'insertTemplate',
+        nodes: nodeModels.map(node => ({
+          clientId: node.clientId,
+          serverId: node.serverId,
+          entity: { type: node.type, position: { ...node.position }, data: { ...node.data } }
+        })),
+        connections: connectionModels.map(conn => ({
+          clientId: conn.clientId,
+          serverId: conn.serverId,
+          sourceId: conn.sourceId,
+          targetId: conn.targetId
+        }))
+      })
+
+      const anchorNode = nodeModels[0]
+      if (anchorNode?.position) {
+        this.store.setRecentPlacementAnchor(anchorNode.position)
+      }
+      this.notifyPersistedMutation()
+
+      return { clientIds: nodeModels.map(n => n.clientId) }
+    } catch (error) {
+      [...connectionModels].reverse().forEach(conn => this.store.removeConnection(conn.clientId))
+      ;[...nodeModels].reverse().forEach(node => this.store.removeNode(node.clientId))
+
+      for (const connection of [...persistedConnections].reverse()) {
+        try {
+          await this.api.deleteConnection(connection.clientId, connection.sourceId)
+        } catch (rollbackError) {
+          console.error('Failed to roll back connection:', rollbackError)
+        }
+      }
+
+      if (persistedNodes.length > 0) {
+        try {
+          await this.api.deleteNodes(persistedNodes.map(node => node.clientId))
+        } catch (rollbackError) {
+          console.error('Failed to roll back nodes:', rollbackError)
+        }
+      }
+
+      showError(`Failed to ${description.toLowerCase()}: ${error.message}`)
+      console.error(`Failed to ${description.toLowerCase()}:`, error)
+
+      throw error
+    }
+  }
+
   async insertTemplate(template, organizerAnchor) {
     const operation = buildTemplateInsertOperation(template, organizerAnchor)
     const nodeModels = operation.nodes.map(nodeData => new Node({
@@ -519,44 +611,9 @@ class SyncManager {
       data: nodeData.entity.data
     }))
     const connectionModels = operation.connections.map(connectionData => new Connection(connectionData))
-    const persistedNodes = []
-    const persistedConnections = []
 
-    nodeModels.forEach(node => this.store.addNode(node))
-    connectionModels.forEach(connection => this.store.addConnection(connection))
-
-    try {
-      for (const nodeData of operation.nodes) {
-        const response = await this.api.createNode(nodeData.entity, nodeData.clientId)
-        persistedNodes.push(nodeData)
-        this.store.updateNode(nodeData.clientId, { serverId: response.id })
-      }
-
-      for (const connectionData of operation.connections) {
-        const response = await this.api.createConnection(connectionData.sourceId, connectionData.targetId, connectionData.clientId)
-        persistedConnections.push(connectionData)
-        this.store.updateConnection(connectionData.clientId, { serverId: response.id })
-      }
-
-      this.history.push(`Insert template: ${template.name}`, operation)
-      const anchorNode = operation.nodes.find(nodeData => nodeData.clientId === operation.organizerClientId) || operation.nodes[0]
-      if (anchorNode?.entity?.position) {
-        this.store.setRecentPlacementAnchor(anchorNode.entity.position)
-      }
-      this.notifyPersistedMutation()
-
-      return {
-        organizerClientId: operation.organizerClientId
-      }
-    } catch (error) {
-      this.rollbackInsertedTemplateLocally(operation)
-      await this.rollbackInsertedTemplateRemotely(persistedConnections, persistedNodes)
-
-      showError(`Failed to insert template: ${error.message}`)
-      console.error('Failed to insert template:', error)
-
-      throw error
-    }
+    const result = await this.insertNodeSet(nodeModels, connectionModels, `Insert template: ${template.name}`)
+    return { organizerClientId: operation.organizerClientId, ...result }
   }
   
   /**
@@ -886,34 +943,6 @@ class SyncManager {
     }
   }
 
-  rollbackInsertedTemplateLocally(operation) {
-    [...operation.connections].reverse().forEach(connection => {
-      this.store.removeConnection(connection.clientId)
-    });
-
-    [...operation.nodes].reverse().forEach(node => {
-      this.store.removeNode(node.clientId)
-    });
-  }
-
-  async rollbackInsertedTemplateRemotely(persistedConnections, persistedNodes) {
-    for (const connection of [...persistedConnections].reverse()) {
-      try {
-        await this.api.deleteConnection(connection.clientId, connection.sourceId)
-      } catch (rollbackError) {
-        console.error('Failed to roll back template connection:', rollbackError)
-      }
-    }
-
-    if (persistedNodes.length > 0) {
-      try {
-        await this.api.deleteNodes(persistedNodes.map(node => node.clientId))
-      } catch (rollbackError) {
-        console.error('Failed to roll back template nodes:', rollbackError)
-      }
-    }
-  }
-  
   // ===== Initialization =====
   
   /**

--- a/app/javascript/editorV2/sync/SyncManager.js
+++ b/app/javascript/editorV2/sync/SyncManager.js
@@ -239,8 +239,7 @@ class SyncManager {
   async executeInverseOperation(operation) {
     switch (operation.type) {
       case 'createNode':
-        // Undo: delete the created node
-        await this.api.deleteNode(operation.clientId)
+        await this.api.deleteNodes([operation.clientId])
         break
         
       case 'deleteNode':
@@ -343,14 +342,7 @@ class SyncManager {
         }
 
         if (operation.nodes.length > 0) {
-          await this.requireAllSettled(
-            Promise.allSettled(
-              operation.nodes.map(node =>
-                this.api.deleteNode(node.clientId)
-              )
-            ),
-            'delete nodes'
-          )
+          await this.api.deleteNodes(operation.nodes.map(node => node.clientId))
         }
         break
         
@@ -375,8 +367,7 @@ class SyncManager {
         break
         
       case 'deleteNode':
-        // Redo: delete the node again (connections already cascade-deleted)
-        await this.api.deleteNode(operation.clientId)
+        await this.api.deleteNodes([operation.clientId])
         break
         
       case 'updateNodePosition':
@@ -461,7 +452,6 @@ class SyncManager {
       const error = failures.length === 1 ? failures[0].reason : new Error(message)
       throw error
     }
-    return results.map(r => r.value)
   }
 
   // ===== Node Operations =====
@@ -668,67 +658,6 @@ class SyncManager {
     }
   }
   
-  /**
-   * Delete a node
-   * @param {string} clientId - Node client ID
-   * @returns {Promise<void>}
-   */
-  async deleteNode(clientId) {
-    const existingNode = this.store.getNode(clientId)
-    if (!existingNode) {
-      console.warn(`Node ${clientId} not found, cannot delete`)
-      return
-    }
-    
-    // Store node data for rollback and history
-    const deletedEntity = {
-      type: existingNode.type,
-      position: { ...existingNode.position },
-      data: { ...existingNode.data }
-    }
-    const deletedServerId = existingNode.serverId
-    
-    // Get connections that will be deleted
-    const deletedConnections = this.getDeletedConnectionBackups([clientId])
-    
-    // Store for rollback
-    const nodeBackup = existingNode
-    
-    // 1. Optimistic update: Remove from store
-    this.store.removeNode(clientId)
-    
-    try {
-      // 2. Sync with server
-      await this.api.deleteNode(clientId)
-      
-      // 3. Push to history after success
-      this.history.push(`Delete ${nodeBackup.type} node`, {
-        type: 'deleteNode',
-        clientId,
-        serverId: deletedServerId,
-        entity: deletedEntity,
-        connections: deletedConnections
-      })
-
-      this.store.setRecentPlacementAnchor(deletedEntity.position)
-
-      this.notifyPersistedMutation()
-      
-    } catch (error) {
-      // 4. Rollback: Re-add the node AND connections
-      this.store.addNode(nodeBackup)
-      deletedConnections.forEach(connData => {
-        const conn = new Connection(connData)
-        this.store.addConnection(conn)
-      })
-      
-      showError(`Failed to delete node: ${error.message}`)
-      console.error('Failed to delete node:', error)
-      
-      throw error
-    }
-  }
-
   /**
    * Delete multiple nodes selected as a set
    * @param {string[]} clientIds - Node client IDs
@@ -976,11 +905,11 @@ class SyncManager {
       }
     }
 
-    for (const node of [...persistedNodes].reverse()) {
+    if (persistedNodes.length > 0) {
       try {
-        await this.api.deleteNode(node.clientId)
+        await this.api.deleteNodes(persistedNodes.map(node => node.clientId))
       } catch (rollbackError) {
-        console.error('Failed to roll back template node:', rollbackError)
+        console.error('Failed to roll back template nodes:', rollbackError)
       }
     }
   }

--- a/app/javascript/editorV2/sync/SyncManager.js
+++ b/app/javascript/editorV2/sync/SyncManager.js
@@ -48,6 +48,16 @@ class SyncManager {
   notifyPersistedMutation() {
     this.onPersistedMutation?.()
   }
+
+  setRecentPlacementAnchorFromNode(node) {
+    if (node?.position) {
+      this.store.setRecentPlacementAnchor(node.position)
+    }
+  }
+
+  setRecentPlacementAnchorForClientId(clientId) {
+    this.setRecentPlacementAnchorFromNode(this.store.getNode(clientId))
+  }
   
   /**
    * Set loading state for undo/redo
@@ -362,6 +372,8 @@ class SyncManager {
         }
       })
 
+      this.store.setRecentPlacementAnchor(position)
+
       this.notifyPersistedMutation()
       
       return clientId
@@ -406,6 +418,10 @@ class SyncManager {
       }
 
       this.history.push(`Insert template: ${template.name}`, operation)
+      const anchorNode = operation.nodes.find(nodeData => nodeData.clientId === operation.organizerClientId) || operation.nodes[0]
+      if (anchorNode?.entity?.position) {
+        this.store.setRecentPlacementAnchor(anchorNode.entity.position)
+      }
       this.notifyPersistedMutation()
 
       return {
@@ -455,6 +471,8 @@ class SyncManager {
         newValue: newPosition
       })
 
+      this.store.setRecentPlacementAnchor(newPosition)
+
       this.notifyPersistedMutation()
       
     } catch (error) {
@@ -503,6 +521,8 @@ class SyncManager {
         previousValue: previousData,
         newValue: data
       })
+
+      this.store.setRecentPlacementAnchor(existingNode.position)
 
       this.notifyPersistedMutation()
       
@@ -564,6 +584,8 @@ class SyncManager {
         entity: deletedEntity,
         connections: deletedConnections
       })
+
+      this.store.setRecentPlacementAnchor(deletedEntity.position)
 
       this.notifyPersistedMutation()
       
@@ -637,6 +659,8 @@ class SyncManager {
         targetId: targetClientId
       })
 
+      this.setRecentPlacementAnchorFromNode(targetNode)
+
       this.notifyPersistedMutation()
       
       return clientId
@@ -683,6 +707,8 @@ class SyncManager {
         sourceId,
         targetId
       })
+
+      this.setRecentPlacementAnchorForClientId(targetId)
 
       this.notifyPersistedMutation()
       

--- a/app/javascript/editorV2/templates/TemplatePlacement.js
+++ b/app/javascript/editorV2/templates/TemplatePlacement.js
@@ -65,7 +65,7 @@ function isPositionClear(position, store) {
   })
 }
 
-export function findTemplateAnchor(template, viewport, store) {
+export function findTemplateAnchor(template, viewport, store, recentAnchor = null) {
   const organizer = organizerNodeFor(template)
   if (!organizer) {
     throw new Error(`Template "${template.id}" is missing its organizer node`)
@@ -74,9 +74,10 @@ export function findTemplateAnchor(template, viewport, store) {
   const center = viewport?.getVisibleCanvasCenter() || { x: 200, y: 200 }
   const organizerDims = NODE_DIMENSIONS.organizer || NODE_DIMENSIONS.default
   const visibleBounds = viewport ? getVisibleBounds(viewport) : null
+  const origin = recentAnchor || center
   const centeredAnchor = {
-    x: Math.max(0, Math.round(center.x - (organizerDims.width / 2))),
-    y: Math.max(0, Math.round(center.y - (organizerDims.height / 2)))
+    x: Math.max(0, Math.round(origin.x - (organizerDims.width / 2))),
+    y: Math.max(0, Math.round(origin.y - (organizerDims.height / 2)))
   }
 
   if (!viewport) {

--- a/app/javascript/editorV2/utils/nodePlacement.js
+++ b/app/javascript/editorV2/utils/nodePlacement.js
@@ -1,0 +1,56 @@
+import { NODE_DIMENSIONS } from '../constants.js'
+
+const NODE_PLACEMENT_PADDING = 40
+const NODE_PLACEMENT_STEP = 36
+const NODE_PLACEMENT_RING_STEPS = 10
+const NODE_PLACEMENT_MAX_RINGS = 12
+
+function getNodeDimensions(type) {
+  return NODE_DIMENSIONS[type] || NODE_DIMENSIONS.default
+}
+
+function isPositionClear(store, candidate, candidateDims) {
+  const candidateBounds = {
+    left: candidate.x,
+    right: candidate.x + candidateDims.width,
+    top: candidate.y,
+    bottom: candidate.y + candidateDims.height
+  }
+  return store.getNodes().every(node => {
+    const dims = getNodeDimensions(node.type)
+    const nodeBounds = {
+      left: node.position.x - NODE_PLACEMENT_PADDING,
+      right: node.position.x + dims.width + NODE_PLACEMENT_PADDING,
+      top: node.position.y - NODE_PLACEMENT_PADDING,
+      bottom: node.position.y + dims.height + NODE_PLACEMENT_PADDING
+    }
+    return (
+      candidateBounds.right <= nodeBounds.left ||
+      candidateBounds.left >= nodeBounds.right ||
+      candidateBounds.bottom <= nodeBounds.top ||
+      candidateBounds.top >= nodeBounds.bottom
+    )
+  })
+}
+
+export function findAnchoredNodePlacement(store, type, origin) {
+  const dims = getNodeDimensions(type)
+  const resolvedOrigin = origin || { x: 200, y: 200 }
+  const anchor = {
+    x: Math.max(0, Math.round(resolvedOrigin.x - (dims.width / 2))),
+    y: Math.max(0, Math.round(resolvedOrigin.y - (dims.height / 2)))
+  }
+  if (isPositionClear(store, anchor, dims)) { return anchor }
+  for (let ring = 1; ring <= NODE_PLACEMENT_MAX_RINGS; ring += 1) {
+    const radius = ring * NODE_PLACEMENT_STEP
+    for (let step = 0; step < NODE_PLACEMENT_RING_STEPS; step += 1) {
+      const angle = (Math.PI * 2 * step) / NODE_PLACEMENT_RING_STEPS
+      const candidate = {
+        x: Math.max(0, Math.round(anchor.x + (Math.cos(angle) * radius))),
+        y: Math.max(0, Math.round(anchor.y + (Math.sin(angle) * radius)))
+      }
+      if (isPositionClear(store, candidate, dims)) { return candidate }
+    }
+  }
+  return anchor
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
     member do
       post :compile
     end
-    resources :nodes, controller: 'bot_nodes', except: [:index, :new] do
+    resources :nodes, controller: 'bot_nodes', except: [:index, :new, :destroy] do
       member do
         post :connect
         post :update_position

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
         post :update_position
       end
       collection do
+        delete :batch_destroy
         post :batch_update_positions
       end
     end

--- a/spec/requests/bot_nodes_controller_spec.rb
+++ b/spec/requests/bot_nodes_controller_spec.rb
@@ -176,7 +176,7 @@ RSpec.describe BotNodesController, type: :request do
     before { sign_in user }
 
     it 'destroys deletable nodes in one transaction and ignores root nodes' do
-      root = create(:node, :root, bot: bot)
+      root = bot.root_node
       node1 = create(:node, bot: bot)
       node2 = create(:node, bot: bot)
       connection_1 = connect_nodes(root, node1)
@@ -203,7 +203,7 @@ RSpec.describe BotNodesController, type: :request do
     end
 
     it 'returns success when only root nodes are requested' do
-      root = create(:node, :root, bot: bot)
+      root = bot.root_node
 
       expect {
         delete batch_destroy_bot_nodes_path(bot), params: { node_ids: [root.id] }

--- a/spec/requests/bot_nodes_controller_spec.rb
+++ b/spec/requests/bot_nodes_controller_spec.rb
@@ -150,30 +150,32 @@ RSpec.describe BotNodesController, type: :request do
     end
   end
 
-  describe 'DELETE #destroy' do
-    before { sign_in user }
-
-    it 'destroys the node' do
-      node_to_delete = create(:node, bot: bot)
-      expect {
-        delete bot_node_path(bot, node_to_delete)
-      }.to change(Node, :count).by(-1)
-      expect(response).to have_http_status(:no_content)
-    end
-
-    it 'destroys associated connections' do
-      node1 = create(:node, bot: bot)
-      node2 = create(:node, bot: bot)
-      connect_nodes(node1, node2)
-      
-      expect {
-        delete bot_node_path(bot, node1)
-      }.to change(Connection, :count).by(-1)
-    end
-  end
-
   describe 'DELETE #batch_destroy' do
     before { sign_in user }
+
+    it 'destroys a single non-root node' do
+      node_to_delete = create(:node, bot: bot)
+      expect {
+        delete batch_destroy_bot_nodes_path(bot), params: { node_ids: [node_to_delete.id] }
+      }.to change(Node, :count).by(-1)
+      expect(response).to have_http_status(:success)
+      json = JSON.parse(response.body)
+      expect(json['deleted_node_ids']).to match_array([node_to_delete.id])
+    end
+
+    it 'destroys associated connections for a single node' do
+      root = bot.root_node
+      node1 = create(:node, bot: bot)
+      node2 = create(:node, bot: bot)
+      connection = connect_nodes(node1, node2)
+
+      expect {
+        delete batch_destroy_bot_nodes_path(bot), params: { node_ids: [node1.id] }
+      }.to change(Connection, :count).by(-1)
+
+      json = JSON.parse(response.body)
+      expect(json['deleted_connection_ids']).to match_array([connection.id])
+    end
 
     it 'destroys deletable nodes in one transaction and ignores root nodes' do
       root = bot.root_node

--- a/spec/requests/bot_nodes_controller_spec.rb
+++ b/spec/requests/bot_nodes_controller_spec.rb
@@ -172,6 +172,49 @@ RSpec.describe BotNodesController, type: :request do
     end
   end
 
+  describe 'DELETE #batch_destroy' do
+    before { sign_in user }
+
+    it 'destroys deletable nodes in one transaction and ignores root nodes' do
+      root = create(:node, :root, bot: bot)
+      node1 = create(:node, bot: bot)
+      node2 = create(:node, bot: bot)
+      connection_1 = connect_nodes(root, node1)
+      connection_2 = connect_nodes(node1, node2)
+      other_bot = create(:bot)
+      other_node = create(:node, bot: other_bot)
+
+      expect {
+        delete batch_destroy_bot_nodes_path(bot), params: {
+          node_ids: [root.id, node1.id, node2.id, other_node.id]
+        }
+      }.to change(Node, :count).by(-2).and change(Connection, :count).by(-2)
+
+      expect(response).to have_http_status(:success)
+
+      json = JSON.parse(response.body)
+      expect(json['deleted_node_ids']).to match_array([node1.id, node2.id])
+      expect(json['deleted_connection_ids']).to match_array([connection_1.id, connection_2.id])
+
+      expect(root.reload).to be_present
+      expect(other_node.reload).to be_present
+      expect { node1.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      expect { node2.reload }.to raise_error(ActiveRecord::RecordNotFound)
+    end
+
+    it 'returns success when only root nodes are requested' do
+      root = create(:node, :root, bot: bot)
+
+      expect {
+        delete batch_destroy_bot_nodes_path(bot), params: { node_ids: [root.id] }
+      }.not_to change(Node, :count)
+
+      expect(response).to have_http_status(:success)
+      expect(JSON.parse(response.body)).to eq('deleted_node_ids' => [], 'deleted_connection_ids' => [])
+      expect(root.reload).to be_present
+    end
+  end
+
   describe 'POST #update_position' do
     before { sign_in user }
 


### PR DESCRIPTION
adds editor polish features and refactors shared infrastructure across the delete, copy/paste, and undo/redo paths.

Features:
- Single-click opens the node editor panel; node placement anchor tracks the most recent edit for smarter paste positioning
- Multi-node copy/paste: select multiple non-root nodes, copy their internal connections, paste as a set with preserved relative positions via SyncManager.insertNodeSet
- Batch node deletion: replaces the singular DELETE endpoint and client method with a batch_destroy endpoint that handles single and multi-node deletion in one transaction, filtering out root nodes

Performance:
- Diff-based undo/redo rendering: NodeRenderer and ConnectionRenderer reconcile against lightweight snapshots on GRAPH_RESTORE instead of tearing down and rebuilding the full DOM, making position-only undos near-instant
- Parallelized batch API calls in SyncManager undo/redo and template insertion via requireAllSettled

Infrastructure:
- SyncManager.insertNodeSet() extracts the shared optimistic-add/server-sync/rollback pattern from insertTemplate; both template insertion and paste delegate to it
- SyncManager.deleteNodes() replaces deleteNode(); singular route and controller action removed
- api.js cleaned up: dead ByClientId mapping methods removed, ByServerId methods prefixed with underscore
- Brighter selected-node highlighting across all four node types with wider glow spread

Cleanup:
- Removed hello_controller (dead scaffold), History duplicate methods, Store.getSelectedNode and cancelMarquee (dead code), verbose ConnectionRenderer debug logging
- Whitespace and JSDoc cleanup across editorV2 models, state, and handlers