### PR TITLE
Worktree is satisfiable

### DIFF
--- a/app/javascript/bot_execution/condition_evaluator_v2.js
+++ b/app/javascript/bot_execution/condition_evaluator_v2.js
@@ -62,7 +62,10 @@ class ConditionEvaluatorV2 {
       return profileCollector.measure('condition.v2.relational', () => {
         const operator = conditionNode.operator
         if (operator === "same_piece") { return analysis.samePiece({ subject: conditionNode.subject, target: conditionNode.target }) }
-        if (!this.relationalSingularActorsCanEvaluate(conditionNode, analysis)) { return false }
+        if (!this.relationalSingularActorsCanEvaluate(conditionNode, analysis)) {
+          profileCollector.increment('condition.v2.relational.failed.singular_actors')
+          return false
+        }
         const result = analysis.relationalResult({
           subject: conditionNode.subject, subjectFilter: conditionNode.subjectFilter || "any",
           subjectFilterMode: conditionNode.subjectFilterMode || null, operator,
@@ -72,7 +75,9 @@ class ConditionEvaluatorV2 {
         const subjectComparisonPresent = this.relationalComparisonPresent(conditionNode, "subject")
         const targetComparisonPresent = this.relationalComparisonPresent(conditionNode, "target")
         if (!subjectComparisonPresent && !targetComparisonPresent) {
-          return result.pairs.length > 0
+          const passed = result.pairs.length > 0
+          if (!passed) { profileCollector.increment('condition.v2.relational.failed.no_pairs_no_comparison') }
+          return passed
         }
         const subjectMetric = conditionNode.subjectComparisonMetric
         const targetMetric = conditionNode.targetComparisonMetric
@@ -86,7 +91,7 @@ class ConditionEvaluatorV2 {
           const targetReference = targetComparisonPresent
             ? targetCoerce(this.relationalComparisonReferenceTotal({ side: "target", conditionNode, analysis }))
             : null
-          return analysis.evaluateRelationalValueMetrics({
+          const passed = analysis.evaluateRelationalValueMetrics({
             pairs: result.pairs,
             subjectMetric: subjectComparisonPresent ? subjectMetric : null,
             subjectComparator: conditionNode.subjectComparator,
@@ -97,10 +102,30 @@ class ConditionEvaluatorV2 {
             targetReference,
             targetCoerce
           })
+          if (!passed) {
+            const subCause = result.pairs.length === 0 ? 'no_pairs' : 'comparison'
+            profileCollector.increment(`condition.v2.relational.failed.value_metrics.${subCause}`)
+            if (subCause === 'comparison') {
+              const priorPairs = analysis.relationalResult({
+                subject: conditionNode.subject, subjectFilter: conditionNode.subjectFilter || "any",
+                subjectFilterMode: conditionNode.subjectFilterMode || null, operator,
+                target: conditionNode.target, targetFilter: conditionNode.targetFilter || "any",
+                targetFilterMode: conditionNode.targetFilterMode || null,
+                boardScope: 'prior'
+              }).pairs
+              profileCollector.increment(`condition.v2.relational.failed.value_metrics.comparison.prior_pairs_${priorPairs.length === 0 ? 'zero' : 'nonzero'}`)
+            }
+          }
+          return passed
         }
         const subjectPasses = subjectComparisonPresent ? this.evaluateRelationalSubjectComparison(conditionNode, analysis, result) : true
         const targetPasses = targetComparisonPresent ? this.evaluateRelationalTargetComparison(conditionNode, analysis, result) : true
-        return subjectPasses && targetPasses
+        const passed = subjectPasses && targetPasses
+        if (!passed) {
+          const subCause = result.pairs.length === 0 ? 'no_pairs' : 'comparison'
+          profileCollector.increment(`condition.v2.relational.failed.non_value_metrics.${subCause}`)
+        }
+        return passed
       })
     }
 

--- a/app/javascript/editorV2/panels/condition_preview/RULES.md
+++ b/app/javascript/editorV2/panels/condition_preview/RULES.md
@@ -81,3 +81,15 @@ listed — changing those is a behavior change, not a tuning operation.
   representative PBS payload; baselines commented inline in
   `forward_proposition_benchmark.js`. Run before/after changes to
   mechanisms or phase ordering.
+
+  To extend the bench with a new diagnostic: call
+  `profileCollector.increment('forward_proposition.<area>.<event>')` at
+  the site you care about. Any counter whose label starts with a
+  `PROFILE_LABEL_PREFIXES` entry in `forward_proposition_benchmark.js`
+  is picked up by `relevantCounters` and printed per payload. Use
+  `profileCollector.measure(label, fn)` for timing instead. Both are
+  no-ops unless `MATCH_PROFILE=1` (set automatically by the bench).
+
+  Run with `npm run bench:forward-proposition -- 1000` (trailing arg
+  is attempts per payload). The output JSON groups timings and counters
+  under each payload.

--- a/app/javascript/editorV2/panels/condition_preview/forward_pattern/move_patterns.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_pattern/move_patterns.js
@@ -2,7 +2,7 @@ import Board from 'gameplay/board'
 import Rules from 'gameplay/rules'
 import { nextPositionOnRay, controlledSquares } from 'gameplay/board_query_utils'
 import {
-  RAY_STEPS, shieldAttackerSpeciesForStep, originCandidatesForSpecies,
+  RAY_STEPS, raySliderSpeciesForStep, originCandidatesForSpecies,
   adjacentNeighborPositions
 } from 'editorV2/panels/condition_preview/shared/geometry_utils'
 import { candidateSpecies, legalPriorTurnState } from 'editorV2/panels/condition_preview/shared/example_utils'
@@ -110,7 +110,7 @@ function generateShieldDecreaseCapture({ driver, combinedPlan, random }) {
     step = pickRandom(stepsForSpecies, random)
   } else {
     step = pickRandom([...RAY_STEPS], random)
-    attackerSpecies = pickRandom(shieldAttackerSpeciesForStep(step), random)
+    attackerSpecies = pickRandom(raySliderSpeciesForStep(step), random)
     if (!attackerSpecies) { return null }
   }
 

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/cross_frame/moved_piece_obstructs_in_attack_or_defend.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/cross_frame/moved_piece_obstructs_in_attack_or_defend.test.js
@@ -226,6 +226,25 @@ describe('movedPieceObstructsInAttackOrDefend — narrows subject species per ra
       expect(isOrthogonalTo(pos, D4)).toBe(true)
     }
   })
+
+  it('direction "+": with bishop-only subject, placed attacker is on a diagonal from placed target', () => {
+    const ctx = defaultTestCtx({
+      singulars: { moved_piece: movedPieceSingular(Board.QUEEN, new Set([D4])) }
+    })
+    const pieces = new Map([[D4, pieceCode(Board.WHITE, Board.QUEEN)]])
+
+    const result = movedPieceObstructsInAttackOrDefend.apply(
+      entry({ direction: '+', subjectSpecies: new Set([Board.BISHOP]) }),
+      ctx, pieces, () => 0.5
+    )
+
+    expect(result).not.toBeNull()
+    const bishopPositions = positionsOfPiece(result, Board.BLACK, Board.BISHOP)
+    expect(bishopPositions.length).toBe(1)
+    const newPositions = [...result.keys()].filter(p => p !== D4 && p !== bishopPositions[0])
+    expect(newPositions.length).toBe(1)
+    expect(isDiagonalTo(bishopPositions[0], newPositions[0])).toBe(true)
+  })
 })
 
 function positionsOfPiece(pieces, team, species) {

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/cross_frame/moved_piece_obstructs_in_attack_or_defend.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/cross_frame/moved_piece_obstructs_in_attack_or_defend.test.js
@@ -163,3 +163,85 @@ describe('movedPieceObstructsInAttackOrDefend — apply returns null when priorR
     expect(result).toBeNull()
   })
 })
+
+describe('movedPieceObstructsInAttackOrDefend — appliesTo gates on slider subject species', () => {
+  it('returns false when subject species is knight only', () => {
+    const ctx = defaultTestCtx({ singulars: { moved_piece: movedPieceSingular() } })
+    expect(movedPieceObstructsInAttackOrDefend.appliesTo(
+      entry({ subjectSpecies: new Set([Board.NIGHT]) }),
+      ctx, new Map()
+    )).toBe(false)
+  })
+
+  it('returns false for pawn-only and king-only subjects', () => {
+    const ctx = defaultTestCtx({ singulars: { moved_piece: movedPieceSingular() } })
+    expect(movedPieceObstructsInAttackOrDefend.appliesTo(
+      entry({ subjectSpecies: new Set([Board.PAWN]) }), ctx, new Map()
+    )).toBe(false)
+    expect(movedPieceObstructsInAttackOrDefend.appliesTo(
+      entry({ subjectSpecies: new Set([Board.KING]) }), ctx, new Map()
+    )).toBe(false)
+  })
+
+  it('returns true when subject mixes a non-slider with a slider', () => {
+    const ctx = defaultTestCtx({ singulars: { moved_piece: movedPieceSingular() } })
+    expect(movedPieceObstructsInAttackOrDefend.appliesTo(
+      entry({ subjectSpecies: new Set([Board.NIGHT, Board.QUEEN]) }),
+      ctx, new Map()
+    )).toBe(true)
+  })
+})
+
+describe('movedPieceObstructsInAttackOrDefend — narrows subject species per ray step', () => {
+  it('with bishop-only subject, the placed attacker is diagonally aligned with destination', () => {
+    const ctx = defaultTestCtx({ singulars: { moved_piece: movedPieceSingular() } })
+    const pieces = new Map([[D4, pieceCode(Board.WHITE, Board.NIGHT)]])
+
+    const result = movedPieceObstructsInAttackOrDefend.apply(
+      entry({ direction: '-', subjectSpecies: new Set([Board.BISHOP]) }),
+      ctx, pieces, () => 0.5
+    )
+
+    expect(result).not.toBeNull()
+    const bishopPositions = positionsOfPiece(result, Board.BLACK, Board.BISHOP)
+    expect(bishopPositions.length).toBeGreaterThan(0)
+    for (const pos of bishopPositions) {
+      expect(isDiagonalTo(pos, D4)).toBe(true)
+    }
+  })
+
+  it('with rook-only subject, the placed attacker is orthogonally aligned with destination', () => {
+    const ctx = defaultTestCtx({ singulars: { moved_piece: movedPieceSingular() } })
+    const pieces = new Map([[D4, pieceCode(Board.WHITE, Board.NIGHT)]])
+
+    const result = movedPieceObstructsInAttackOrDefend.apply(
+      entry({ direction: '-', subjectSpecies: new Set([Board.ROOK]) }),
+      ctx, pieces, () => 0.5
+    )
+
+    expect(result).not.toBeNull()
+    const rookPositions = positionsOfPiece(result, Board.BLACK, Board.ROOK)
+    expect(rookPositions.length).toBeGreaterThan(0)
+    for (const pos of rookPositions) {
+      expect(isOrthogonalTo(pos, D4)).toBe(true)
+    }
+  })
+})
+
+function positionsOfPiece(pieces, team, species) {
+  const code = pieceCode(team, species)
+  return [...pieces.entries()].filter(([_, c]) => c === code).map(([pos]) => pos)
+}
+
+function isDiagonalTo(a, b) {
+  const fileDiff = Math.abs((a % 8) - (b % 8))
+  const rankDiff = Math.abs(Math.floor(a / 8) - Math.floor(b / 8))
+  return fileDiff === rankDiff && fileDiff > 0
+}
+
+function isOrthogonalTo(a, b) {
+  if (a === b) { return false }
+  const sameFile = (a % 8) === (b % 8)
+  const sameRank = Math.floor(a / 8) === Math.floor(b / 8)
+  return sameFile || sameRank
+}

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/collect.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/collect.js
@@ -1,3 +1,4 @@
+import profileCollector from 'gameplay/profile_collector'
 import { Candidate } from '../shared/candidate'
 import { CandidateVerifier } from '../shared/candidate_verifier'
 import { ExampleFactory } from '../shared/example_factory'
@@ -26,9 +27,16 @@ export function collectForwardPropositionExamples({
       if (standardExamples.length >= maxStandardSize) { return }
       if (Date.now() > deadline) { return }
       const result = buildAttempt(combinedPlan, random, scenario)
-      if (!result) { continue }
+      if (!result) {
+        profileCollector.increment('forward_proposition.attempt.build_failed')
+        continue
+      }
       const candidate = new Candidate({ priorBoard: result.priorBoard, moveObject: result.moveObject })
-      if (!verifier.isVerified(candidate)) { continue }
+      if (!verifier.isVerified(candidate)) {
+        profileCollector.increment('forward_proposition.attempt.verifier_rejected')
+        continue
+      }
+      profileCollector.increment('forward_proposition.attempt.verifier_passed')
       const example = factory.build(candidate, { generationPath: 'forward-proposition', geometryKey: 'forward' })
       if (!example) { continue }
       produced['forward-proposition'] += 1

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/collect.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/collect.js
@@ -32,8 +32,10 @@ export function collectForwardPropositionExamples({
         continue
       }
       const candidate = new Candidate({ priorBoard: result.priorBoard, moveObject: result.moveObject })
-      if (!verifier.isVerified(candidate)) {
+      const cause = verifier.rejectionCause(candidate)
+      if (cause !== null) {
         profileCollector.increment('forward_proposition.attempt.verifier_rejected')
+        profileCollector.increment(`forward_proposition.attempt.verifier_rejected.${cause}`)
         continue
       }
       profileCollector.increment('forward_proposition.attempt.verifier_passed')

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/cross_frame/mechanisms/moved_piece_obstructs_in_attack_or_defend.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/cross_frame/mechanisms/moved_piece_obstructs_in_attack_or_defend.js
@@ -1,6 +1,8 @@
 import { QUEEN_RAY_STEPS, nextPositionOnRay } from 'gameplay/board_query_utils'
 import { shuffled } from 'editorV2/panels/condition_preview/shared/board_utils'
-import { originCandidatesForSpecies, walkRay } from 'editorV2/panels/condition_preview/shared/geometry_utils'
+import {
+  originCandidatesForSpecies, walkRay, raySliderSpeciesForStep, SLIDER_SPECIES
+} from 'editorV2/panels/condition_preview/shared/geometry_utils'
 import {
   movedPieceRoleIn, singularSquare, ensureRolePieceAt, commitPriorRegion
 } from './participates_helpers'
@@ -15,7 +17,16 @@ export const movedPieceObstructsInAttackOrDefend = {
     if (!RELEVANT_OPERATORS.has(entry.operator)) { return false }
     // Obstructs only fires when moved_piece isn't a relation participant —
     // participates owns the bound-singular case.
-    return movedPieceRoleIn(entry) === null
+    if (movedPieceRoleIn(entry) !== null) { return false }
+    // The mechanism's premise is "A attacks T along a queen-ray, blocked by
+    // moved_piece's position." That premise only holds when A is a ray-
+    // compatible slider. Skip when subject species can't slide at all.
+    const subjectSpecies = entry.subjectProposition?.species_set
+    if (!subjectSpecies) { return false }
+    for (const sp of subjectSpecies) {
+      if (SLIDER_SPECIES.has(sp)) { return true }
+    }
+    return false
   },
 
   apply(entry, ctx, pieces, random) {
@@ -40,16 +51,18 @@ function applyMinus(entry, ctx, pieces, random) {
   if (subjectSide == null || targetSide == null) { return null }
 
   for (const step of shuffled([...QUEEN_RAY_STEPS], random)) {
+    const narrowedSubject = narrowSubjectForStep(subjectSide, step)
+    if (narrowedSubject === null) { continue }
     const positiveRay = walkRay(destination, step)
     const negativeRay = walkRay(destination, -step)
     const result = tryFlankingPlacement({
       attackerRay: positiveRay, targetRay: negativeRay,
-      subjectSide, targetSide, ctx, pieces, random, destination
+      subjectSide: narrowedSubject, targetSide, ctx, pieces, random, destination
     })
     if (result !== null) { return result }
     const swapped = tryFlankingPlacement({
       attackerRay: negativeRay, targetRay: positiveRay,
-      subjectSide, targetSide, ctx, pieces, random, destination
+      subjectSide: narrowedSubject, targetSide, ctx, pieces, random, destination
     })
     if (swapped !== null) { return swapped }
   }
@@ -74,22 +87,34 @@ function applyPlus(entry, ctx, pieces, random) {
 
   for (const origin of shuffled(possibleOrigins, random)) {
     for (const step of shuffled([...QUEEN_RAY_STEPS], random)) {
+      const narrowedSubject = narrowSubjectForStep(subjectSide, step)
+      if (narrowedSubject === null) { continue }
       const positiveRay = walkRayFromOriginAvoidingDestination(origin, step, destination)
       const negativeRay = walkRayFromOriginAvoidingDestination(origin, -step, destination)
       if (positiveRay === null || negativeRay === null) { continue }
       const result = tryFlankingPlacementAroundOrigin({
         origin, attackerRay: positiveRay, targetRay: negativeRay,
-        subjectSide, targetSide, ctx, pieces, random
+        subjectSide: narrowedSubject, targetSide, ctx, pieces, random
       })
       if (result !== null) { return result }
       const swapped = tryFlankingPlacementAroundOrigin({
         origin, attackerRay: negativeRay, targetRay: positiveRay,
-        subjectSide, targetSide, ctx, pieces, random
+        subjectSide: narrowedSubject, targetSide, ctx, pieces, random
       })
       if (swapped !== null) { return swapped }
     }
   }
   return null
+}
+
+function narrowSubjectForStep(subjectSide, step) {
+  const compatible = raySliderSpeciesForStep(step)
+  const narrowed = new Set()
+  for (const sp of compatible) {
+    if (subjectSide.species_set.has(sp)) { narrowed.add(sp) }
+  }
+  if (narrowed.size === 0) { return null }
+  return { ...subjectSide, species_set: narrowed }
 }
 
 // Walk a ray from `origin` in direction `step`, returning null if the ray

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/cross_frame/mechanisms/moved_piece_obstructs_shield.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/cross_frame/mechanisms/moved_piece_obstructs_shield.js
@@ -2,7 +2,7 @@ import Board from 'gameplay/board'
 import { QUEEN_RAY_STEPS } from 'gameplay/board_query_utils'
 import { shuffled } from 'editorV2/panels/condition_preview/shared/board_utils'
 import {
-  originCandidatesForSpecies, shieldAttackerSpeciesForStep, walkRay
+  originCandidatesForSpecies, raySliderSpeciesForStep, walkRay
 } from 'editorV2/panels/condition_preview/shared/geometry_utils'
 import {
   movedPieceRoleIn, singularSquare, ensureRolePieceAt, commitPriorRegion
@@ -41,7 +41,7 @@ function applyMinus(entry, ctx, pieces, random) {
   const attackerTeam = Board.opposingTeam(alliedTeam)
 
   for (const step of shuffled([...QUEEN_RAY_STEPS], random)) {
-    const sliders = shieldAttackerSpeciesForStep(step)
+    const sliders = raySliderSpeciesForStep(step)
     if (sliders.length === 0) { continue }
     const aSeg = tryInterceptOnASegment({
       destination, step, attackerTeam, sliders, subjectSide, targetSide, ctx, pieces, random
@@ -164,7 +164,7 @@ function applyPlus(entry, ctx, pieces, random) {
 
   for (const origin of shuffled(origins, random)) {
     for (const step of shuffled([...QUEEN_RAY_STEPS], random)) {
-      const sliders = shieldAttackerSpeciesForStep(step)
+      const sliders = raySliderSpeciesForStep(step)
       if (sliders.length === 0) { continue }
       const result = tryShieldThroughOrigin({
         origin, step, destination, attackerTeam, sliders,

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/cross_frame/mechanisms/moved_piece_participates_shield.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/cross_frame/mechanisms/moved_piece_participates_shield.js
@@ -4,13 +4,11 @@ import {
 } from 'gameplay/board_query_utils'
 import { shuffled } from 'editorV2/panels/condition_preview/shared/board_utils'
 import {
-  originCandidatesForSpecies, shieldAttackerSpeciesForStep, walkRay
+  originCandidatesForSpecies, raySliderSpeciesForStep, walkRay, SLIDER_SPECIES
 } from 'editorV2/panels/condition_preview/shared/geometry_utils'
 import {
   singularSquare, ensureRolePieceAt, commitPriorRegion, movedPieceRoleIn
 } from './participates_helpers'
-
-const SLIDER_SPECIES = new Set([Board.ROOK, Board.BISHOP, Board.QUEEN])
 
 export const movedPieceParticipatesShield = {
   name: 'moved-piece-participates-shield',
@@ -80,7 +78,7 @@ function applyShielder(entry, ctx, pieces, random) {
   const targetSpeciesSet = entry.targetProposition?.species_set ?? entry.currentProposition.species_set
 
   for (const step of shuffled([...QUEEN_RAY_STEPS], random)) {
-    const compatibleSliders = shieldAttackerSpeciesForStep(step)
+    const compatibleSliders = raySliderSpeciesForStep(step)
     if (compatibleSliders.length === 0) { continue }
     const result = placeTargetAndAttackerAroundShielder({
       destination, step, alliedTeam, attackerTeam,
@@ -109,7 +107,7 @@ function applyShielderMinus(entry, ctx, pieces, random) {
 
   for (const origin of shuffled(origins, random)) {
     for (const step of shuffled([...QUEEN_RAY_STEPS], random)) {
-      const compatibleSliders = shieldAttackerSpeciesForStep(step)
+      const compatibleSliders = raySliderSpeciesForStep(step)
       if (compatibleSliders.length === 0) { continue }
       const towardTarget = rayPositionsAvoiding(origin, -step, destination)
       const towardAttacker = rayPositionsAvoiding(origin, step, destination)
@@ -205,7 +203,7 @@ function applyShielded(entry, ctx, pieces, random) {
   const shielderSpeciesSet = entry.subjectProposition?.species_set ?? entry.currentProposition.species_set
 
   for (const step of shuffled([...QUEEN_RAY_STEPS], random)) {
-    const compatibleSliders = shieldAttackerSpeciesForStep(step)
+    const compatibleSliders = raySliderSpeciesForStep(step)
     if (compatibleSliders.length === 0) { continue }
     const result = placeShielderAndAttackerThroughTarget({
       destination, step, alliedTeam, attackerTeam,
@@ -234,7 +232,7 @@ function applyShieldedMinus(entry, ctx, pieces, random) {
 
   for (const origin of shuffled(origins, random)) {
     for (const step of shuffled([...QUEEN_RAY_STEPS], random)) {
-      const compatibleSliders = shieldAttackerSpeciesForStep(step)
+      const compatibleSliders = raySliderSpeciesForStep(step)
       if (compatibleSliders.length === 0) { continue }
       const lineSquares = rayPositionsAvoiding(origin, step, destination)
       if (lineSquares === null) { continue }

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/cross_frame/satisfy_cross_frame.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/cross_frame/satisfy_cross_frame.js
@@ -1,3 +1,4 @@
+import profileCollector from 'gameplay/profile_collector'
 import {
   buildBoardFromLayout, buildLayoutFromPieces, shuffled
 } from 'editorV2/panels/condition_preview/shared/board_utils'
@@ -32,12 +33,20 @@ export function satisfyCrossFrame(ctx, pieces, random) {
   if (entries.length === 0) { return pieces }
 
   for (const entry of shuffled(entries, random)) {
+    profileCollector.increment(`forward_proposition.cross_frame.entry_seen.${entry.metric}.${entry.operator}`)
     const applicable = MECHANISMS.filter(m => m.appliesTo(entry, ctx, pieces))
     for (const mechanism of shuffled(applicable, random)) {
+      profileCollector.increment(`forward_proposition.cross_frame.mech_applies.${mechanism.name}.${entry.metric}.${entry.operator}`)
       const next = mechanism.apply(entry, ctx, pieces, random)
       if (next === null) { continue }
+      profileCollector.increment(`forward_proposition.cross_frame.mech_applied.${mechanism.name}.${entry.metric}.${entry.operator}`)
       pieces = next
-      if (entrySatisfied(entry, ctx, pieces)) { break }
+      const satisfied = entrySatisfied(entry, ctx, pieces)
+      profileCollector.increment(`forward_proposition.cross_frame.entry_satisfied.${satisfied ? 'true' : 'false'}.${entry.metric}.${entry.operator}`)
+      if (satisfied) {
+        profileCollector.increment(`forward_proposition.cross_frame.mech_won.${mechanism.name}.${entry.metric}.${entry.operator}`)
+        break
+      }
     }
   }
   return pieces

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/cross_frame/satisfy_cross_frame.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/cross_frame/satisfy_cross_frame.js
@@ -35,6 +35,10 @@ export function satisfyCrossFrame(ctx, pieces, random) {
   for (const entry of shuffled(entries, random)) {
     profileCollector.increment(`forward_proposition.cross_frame.entry_seen.${entry.metric}.${entry.operator}`)
     const applicable = MECHANISMS.filter(m => m.appliesTo(entry, ctx, pieces))
+    // Mechanisms chain via `pieces`: a non-null return is kept and the next
+    // mechanism builds on it. entrySatisfied gates the chain — false keeps
+    // iterating, true breaks. Count attack/defend uses chaining (each call
+    // adds one attacker); other operators are one-shot (unconditional true).
     for (const mechanism of shuffled(applicable, random)) {
       profileCollector.increment(`forward_proposition.cross_frame.mech_applies.${mechanism.name}.${entry.metric}.${entry.operator}`)
       const next = mechanism.apply(entry, ctx, pieces, random)
@@ -52,10 +56,11 @@ export function satisfyCrossFrame(ctx, pieces, random) {
   return pieces
 }
 
-// Direct metric check on (afterPieces, priorPieces). Currently supports
-// count metric on attack/defend relations — the metrics produced by our
-// only mechanism today. Other metrics are treated as "assume satisfied"
-// until a mechanism that needs them lands.
+// Chain-control gate (see satisfyCrossFrame). True breaks the mechanism
+// loop, false keeps it chaining. Only count attack/defend uses a real
+// after-vs-prior count check; one-shot operators (adjacent, shield,
+// aggregate_*) return true unconditionally so the first non-null mechanism
+// wins.
 function entrySatisfied(entry, ctx, afterPieces) {
   if (entry.metric !== 'count') { return true }
   if (entry.operator !== 'attack' && entry.operator !== 'defend') { return true }

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/pin_geometry.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/pin_geometry.js
@@ -3,7 +3,7 @@ import { nextPositionOnRay } from 'gameplay/board_query_utils'
 import {
   shuffled, pieceCode, legalPlacementForSpecies
 } from 'editorV2/panels/condition_preview/shared/board_utils'
-import { shieldAttackerSpeciesForStep } from 'editorV2/panels/condition_preview/shared/geometry_utils'
+import { raySliderSpeciesForStep } from 'editorV2/panels/condition_preview/shared/geometry_utils'
 import { placePiece } from 'editorV2/panels/condition_preview/shared/piece_placement'
 import { respectsAllCaps } from './respect_caps'
 
@@ -14,7 +14,7 @@ import { respectsAllCaps } from './respect_caps'
 // Otherwise places a new slider on an empty square in the ray (legal +
 // cap-respecting).
 export function placeSliderBeyondTarget({ pieces, attackerTeam, targetPos, step, ctx, random }) {
-  const compatibleSliders = shieldAttackerSpeciesForStep(step)
+  const compatibleSliders = raySliderSpeciesForStep(step)
 
   const candidates = []
   let current = nextPositionOnRay(targetPos, step)

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/relations/satisfy_relations.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/relations/satisfy_relations.js
@@ -1,3 +1,4 @@
+import profileCollector from 'gameplay/profile_collector'
 import { satisfyAttackOrDefend } from './attack_or_defend'
 import { satisfyAdjacent } from './adjacent'
 import { satisfyShield } from './shield'
@@ -14,8 +15,10 @@ export function satisfyRelations(ctx, pieces, random) {
     if (relation.operator === 'same_piece') { continue }
     const satisfier = SATISFIERS[relation.operator]
     if (!satisfier) { return null }
+    const sizeBefore = pieces.size
     const next = satisfier(relation, pieces, ctx, random)
     if (next === null) { return null }
+    profileCollector.increment(`forward_proposition.satisfy_relations.size_delta.${relation.operator}.${next.size - sizeBefore}`)
     pieces = next
   }
   return pieces

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/relations/shield.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/relations/shield.js
@@ -4,7 +4,7 @@ import {
   shuffled, pieceCode, legalPlacementForSpecies, pickWeightedSpecies
 } from 'editorV2/panels/condition_preview/shared/board_utils'
 import { placePiece } from 'editorV2/panels/condition_preview/shared/piece_placement'
-import { shieldAttackerSpeciesForStep, walkRay } from 'editorV2/panels/condition_preview/shared/geometry_utils'
+import { raySliderSpeciesForStep, walkRay } from 'editorV2/panels/condition_preview/shared/geometry_utils'
 import {
   ROOK_RAY_STEPS, BISHOP_RAY_STEPS, QUEEN_RAY_STEPS,
   shieldingPositions, nextPositionOnRay
@@ -119,7 +119,7 @@ function tryAsBystander(relation, pieces, ctx, random) {
     if (piecesWithTarget === null) { continue }
 
     for (const step of shuffled(QUEEN_RAY_STEPS, random)) {
-      const compatibleSliders = shieldAttackerSpeciesForStep(step)
+      const compatibleSliders = raySliderSpeciesForStep(step)
       const lineSquares = walkRay(target.position, step)
       const placed = tryPlaceShielderAndAttackerFromTarget({
         relation, attackerTeam, compatibleSliders,
@@ -150,7 +150,7 @@ function tryAsTarget(relation, pieces, ctx, random, actorKey) {
   const attackerTeam = Board.opposingTeam(relation.targetSide.team)
 
   for (const step of shuffled(QUEEN_RAY_STEPS, random)) {
-    const compatibleSliders = shieldAttackerSpeciesForStep(step)
+    const compatibleSliders = raySliderSpeciesForStep(step)
     const lineSquares = walkRay(targetPos, step)
     const placed = tryPlaceShielderAndAttackerFromTarget({
       relation, attackerTeam, compatibleSliders,
@@ -167,7 +167,7 @@ function tryAsShielder(relation, pieces, ctx, random, actorKey) {
   const attackerTeam = Board.opposingTeam(relation.targetSide.team)
 
   for (const step of shuffled(QUEEN_RAY_STEPS, random)) {
-    const compatibleSliders = shieldAttackerSpeciesForStep(step)
+    const compatibleSliders = raySliderSpeciesForStep(step)
     const towardTarget = walkRay(shielderPos, -step)
     const towardAttacker = walkRay(shielderPos, step)
     const placed = tryPlaceTargetAndAttackerFromShielder({

--- a/app/javascript/editorV2/panels/condition_preview/seeds/relation_geometry.js
+++ b/app/javascript/editorV2/panels/condition_preview/seeds/relation_geometry.js
@@ -5,7 +5,7 @@ import {
   buildBoardFromLayout, buildLayoutFromPieces
 } from 'editorV2/panels/condition_preview/shared/board_utils'
 import {
-  RAY_STEPS, adjacentNeighborPositions, shieldAttackerSpeciesForStep
+  RAY_STEPS, adjacentNeighborPositions, raySliderSpeciesForStep
 } from 'editorV2/panels/condition_preview/shared/geometry_utils'
 import { buildCandidateSkeletons } from 'editorV2/panels/condition_preview/seeds/skeleton_builders'
 import { shuffled, ALL_POSITIONS } from '../shared/board_utils'
@@ -81,7 +81,7 @@ function placeAdjacentExtras({ plan, side, extraSpecies, anchorPosition, current
 }
 
 function findShieldAttackerOnRay({ originPosition, step, occupied, random }) {
-  const speciesOptions = shuffled(shieldAttackerSpeciesForStep(step), random)
+  const speciesOptions = shuffled(raySliderSpeciesForStep(step), random)
   for (let distance = 1; distance <= 3; distance += 1) {
     let position = originPosition
     let valid = true

--- a/app/javascript/editorV2/panels/condition_preview/seeds/skeleton_builders.js
+++ b/app/javascript/editorV2/panels/condition_preview/seeds/skeleton_builders.js
@@ -1,7 +1,7 @@
 import Board from 'gameplay/board'
 import { controlledSquares, shieldedPositions, nextPositionOnRay } from 'gameplay/board_query_utils'
 import { pieceCode, clonePiecesMap, buildLayoutFromPieces, buildBoardFromLayout, legalPlacementForSpecies, ALL_POSITIONS } from 'editorV2/panels/condition_preview/shared/board_utils'
-import { RAY_STEPS, adjacentNeighborPositions, shieldAttackerSpeciesForStep } from 'editorV2/panels/condition_preview/shared/geometry_utils'
+import { RAY_STEPS, adjacentNeighborPositions, raySliderSpeciesForStep } from 'editorV2/panels/condition_preview/shared/geometry_utils'
 
 
 function legalSubjectPlacements(subjectSpecies) {
@@ -137,7 +137,7 @@ export function buildShieldSkeletons({ plan, subjectSpecies, targetSpecies, fixe
           }
           if (attackerPosition === null) { continue }
 
-          shieldAttackerSpeciesForStep(step).forEach(attackerSpecies => {
+          raySliderSpeciesForStep(step).forEach(attackerSpecies => {
             const relationPieces = mergeRelationPieces({
               basePieces: fixedPieces,
               relationPieces: new Map([

--- a/app/javascript/editorV2/panels/condition_preview/shared/candidate_verifier.js
+++ b/app/javascript/editorV2/panels/condition_preview/shared/candidate_verifier.js
@@ -29,4 +29,16 @@ export class CandidateVerifier {
   isVerified(candidate) {
     return this.isLegal(candidate) && this.passesEvaluation(candidate)
   }
+
+  rejectionCause(candidate) {
+    if (candidate.moveObject.illegal) { return 'illegal_move' }
+    if (!legalPriorTurnState(candidate.priorBoard, candidate.moveObject)) { return 'illegal_prior_turn' }
+    const input = { board: candidate.priorBoard, moveObject: candidate.moveObject }
+    for (const payload of this.combinedPlan.evaluationPayloads) {
+      if (!this.evaluator.evaluate(payload, input)) {
+        return `evaluation_${payload.kind}`
+      }
+    }
+    return null
+  }
 }

--- a/app/javascript/editorV2/panels/condition_preview/shared/geometry_utils.js
+++ b/app/javascript/editorV2/panels/condition_preview/shared/geometry_utils.js
@@ -145,7 +145,9 @@ export function attackerCandidatesFor(targetPosition, species, team, board) {
   }
 }
 
-export function shieldAttackerSpeciesForStep(step) {
+export const SLIDER_SPECIES = Object.freeze(new Set([Board.ROOK, Board.BISHOP, Board.QUEEN]))
+
+export function raySliderSpeciesForStep(step) {
   return ROOK_RAY_STEPS.includes(step) ? [Board.ROOK, Board.QUEEN] : [Board.BISHOP, Board.QUEEN]
 }
 

--- a/app/javascript/gameplay/benchmarks/forward_proposition_benchmark.js
+++ b/app/javascript/gameplay/benchmarks/forward_proposition_benchmark.js
@@ -139,14 +139,15 @@ function benchmarkPayload({ name, payload }, attempts) {
     attempts
   })
   const totalMs = performance.now() - started
+  const snapshot = profileCollector.snapshot()
   return {
     name,
     attempts,
     verified: produced["forward-proposition"],
     total_ms: Number(totalMs.toFixed(2)),
     avg_ms_per_attempt: Number((totalMs / attempts).toFixed(4)),
-    timings: relevantTimings(profileCollector.snapshot()),
-    counters: relevantCounters(profileCollector.snapshot())
+    timings: relevantTimings(snapshot),
+    counters: relevantCounters(snapshot)
   }
 }
 

--- a/app/javascript/gameplay/benchmarks/forward_proposition_benchmark.js
+++ b/app/javascript/gameplay/benchmarks/forward_proposition_benchmark.js
@@ -145,7 +145,8 @@ function benchmarkPayload({ name, payload }, attempts) {
     verified: produced["forward-proposition"],
     total_ms: Number(totalMs.toFixed(2)),
     avg_ms_per_attempt: Number((totalMs / attempts).toFixed(4)),
-    timings: relevantTimings(profileCollector.snapshot())
+    timings: relevantTimings(profileCollector.snapshot()),
+    counters: relevantCounters(profileCollector.snapshot())
   }
 }
 
@@ -159,6 +160,16 @@ function relevantTimings(snapshot) {
       total_ms: Number(data.total_ms.toFixed(2)),
       avg_ms: Number((data.total_ms / data.count).toFixed(4))
     }
+  }
+  return result
+}
+
+function relevantCounters(snapshot) {
+  const result = {}
+  if (!snapshot) { return result }
+  for (const [label, value] of Object.entries(snapshot.counters ?? {})) {
+    if (!PROFILE_LABEL_PREFIXES.some(p => label.startsWith(p))) { continue }
+    result[label] = value
   }
   return result
 }


### PR DESCRIPTION
Fixes a geometry bug in `moved_piece_obstructs_in_attack_or_defend.js` that caused the cross-frame mechanism to place non-slider species (knight, pawn, king) on queen-rays as "attackers" — placements with no real chess-attack semantics that the verifier silently rejected downstream. The mechanism now requires the subject to contain at least one slider, and narrows species per chosen ray step before placement