### PR TITLE
isSatisfiable detects pairwise count contradictions across propositions

### DIFF
--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/is_satisfiable.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/is_satisfiable.test.js
@@ -190,5 +190,15 @@ describe('isSatisfiable', () => {
       })
       expect(isSatisfiable(ctx)).toBe(true)
     })
+
+    it('throws a helpful error when an unsupported region kind reaches the contradiction check', () => {
+      const ctx = defaultCtx({
+        propositions: [
+          prop({ species: [Board.QUEEN], region: { kind: 'mystery' }, countMin: 1 }),
+          prop({ species: ALL_SPECIES, region: { kind: 'set', squares: new Set([H1]) }, countMax: 0 })
+        ]
+      })
+      expect(() => isSatisfiable(ctx)).toThrow(/unsupported region kind 'mystery'/)
+    })
   })
 })

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/is_satisfiable.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/is_satisfiable.test.js
@@ -67,4 +67,128 @@ describe('isSatisfiable', () => {
     })
     expect(isSatisfiable(ctx)).toBe(false)
   })
+
+  describe('pairwise count contradictions', () => {
+    const ALL_SPECIES = [Board.PAWN, Board.NIGHT, Board.BISHOP, Board.ROOK, Board.QUEEN, Board.KING]
+    const H1 = 7
+    const A1 = 0
+
+    function prop({
+      team = Board.WHITE,
+      frame = 'current',
+      species,
+      region,
+      countMin = 0,
+      countMax = Infinity
+    }) {
+      return {
+        team, frame,
+        species_set: new Set(species),
+        region,
+        count_range: { min: countMin, max: countMax },
+        aggregate_value_range: { ...PERMISSIVE },
+        aggregate_mobility_range: { ...PERMISSIVE }
+      }
+    }
+
+    it('returns false when a min>0 species-specific demand subsets an emptiness prop on the same square', () => {
+      const ctx = defaultCtx({
+        propositions: [
+          prop({ species: [Board.QUEEN], region: { kind: 'set', squares: new Set([H1]) }, countMin: 1 }),
+          prop({ species: ALL_SPECIES, region: { kind: 'set', squares: new Set([H1]) }, countMax: 0 })
+        ]
+      })
+      expect(isSatisfiable(ctx)).toBe(false)
+    })
+
+    it('returns false when demand exceeds free squares (region partially overlaps emptiness)', () => {
+      const ctx = defaultCtx({
+        propositions: [
+          prop({ species: [Board.QUEEN], region: { kind: 'set', squares: new Set([H1, A1]) }, countMin: 2 }),
+          prop({ species: ALL_SPECIES, region: { kind: 'set', squares: new Set([H1]) }, countMax: 0 })
+        ]
+      })
+      expect(isSatisfiable(ctx)).toBe(false)
+    })
+
+    it('returns true when demand fits in non-overlapping free squares', () => {
+      const ctx = defaultCtx({
+        propositions: [
+          prop({ species: [Board.QUEEN], region: { kind: 'set', squares: new Set([H1, A1]) }, countMin: 1 }),
+          prop({ species: ALL_SPECIES, region: { kind: 'set', squares: new Set([H1]) }, countMax: 0 })
+        ]
+      })
+      expect(isSatisfiable(ctx)).toBe(true)
+    })
+
+    it('returns true when regions are disjoint', () => {
+      const ctx = defaultCtx({
+        propositions: [
+          prop({ species: [Board.QUEEN], region: { kind: 'set', squares: new Set([H1]) }, countMin: 1 }),
+          prop({ species: ALL_SPECIES, region: { kind: 'set', squares: new Set([A1]) }, countMax: 0 })
+        ]
+      })
+      expect(isSatisfiable(ctx)).toBe(true)
+    })
+
+    it('returns true when teams differ', () => {
+      const ctx = defaultCtx({
+        propositions: [
+          prop({ team: Board.WHITE, species: [Board.QUEEN], region: { kind: 'set', squares: new Set([H1]) }, countMin: 1 }),
+          prop({ team: Board.BLACK, species: ALL_SPECIES, region: { kind: 'set', squares: new Set([H1]) }, countMax: 0 })
+        ]
+      })
+      expect(isSatisfiable(ctx)).toBe(true)
+    })
+
+    it('returns true when frames differ', () => {
+      const ctx = defaultCtx({
+        propositions: [
+          prop({ frame: 'current', species: [Board.QUEEN], region: { kind: 'set', squares: new Set([H1]) }, countMin: 1 }),
+          prop({ frame: 'prior', species: ALL_SPECIES, region: { kind: 'set', squares: new Set([H1]) }, countMax: 0 })
+        ]
+      })
+      expect(isSatisfiable(ctx)).toBe(true)
+    })
+
+    it('returns true when neither species_set is a subset of the other (under-detect)', () => {
+      const ctx = defaultCtx({
+        propositions: [
+          prop({ species: [Board.QUEEN, Board.ROOK], region: { kind: 'set', squares: new Set([H1]) }, countMin: 1 }),
+          prop({ species: [Board.ROOK, Board.KING], region: { kind: 'set', squares: new Set([H1]) }, countMax: 0 })
+        ]
+      })
+      expect(isSatisfiable(ctx)).toBe(true)
+    })
+
+    it('returns true when either region is related-to (skipped in v1)', () => {
+      const ctx = defaultCtx({
+        propositions: [
+          prop({ species: [Board.QUEEN], region: { kind: 'set', squares: new Set([H1]) }, countMin: 1 }),
+          prop({ species: ALL_SPECIES, region: { kind: 'related-to', actor: 'moved_piece', operator: 'adjacent' }, countMax: 0 })
+        ]
+      })
+      expect(isSatisfiable(ctx)).toBe(true)
+    })
+
+    it('returns false for non-emptiness cap: demand >= 3 in subset region vs cap of 1 in superset', () => {
+      const ctx = defaultCtx({
+        propositions: [
+          prop({ species: [Board.QUEEN], region: { kind: 'set', squares: new Set([H1]) }, countMin: 3 }),
+          prop({ species: ALL_SPECIES, region: { kind: 'all' }, countMax: 1 })
+        ]
+      })
+      expect(isSatisfiable(ctx)).toBe(false)
+    })
+
+    it('returns true when capper.region is `all` but demand fits within cap', () => {
+      const ctx = defaultCtx({
+        propositions: [
+          prop({ species: [Board.QUEEN], region: { kind: 'set', squares: new Set([H1]) }, countMin: 1 }),
+          prop({ species: ALL_SPECIES, region: { kind: 'all' }, countMax: 5 })
+        ]
+      })
+      expect(isSatisfiable(ctx)).toBe(true)
+    })
+  })
 })

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/is_satisfiable.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/is_satisfiable.test.js
@@ -54,6 +54,20 @@ describe('isSatisfiable', () => {
     expect(isSatisfiable(ctx)).toBe(false)
   })
 
+  it('returns false when a proposition has an empty species_set', () => {
+    const ctx = defaultCtx({
+      propositions: [{
+        team: Board.WHITE, frame: 'current',
+        species_set: new Set(),
+        region: { kind: 'all' },
+        count_range: { ...PERMISSIVE },
+        aggregate_value_range: { ...PERMISSIVE },
+        aggregate_mobility_range: { ...PERMISSIVE }
+      }]
+    })
+    expect(isSatisfiable(ctx)).toBe(false)
+  })
+
   it('returns false when a proposition has aggregate_value_range with min > max', () => {
     const ctx = defaultCtx({
       propositions: [{

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/scenarios/eligibility.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/scenarios/eligibility.test.js
@@ -30,4 +30,16 @@ describe('eligibleScenariosFor', () => {
     const eligible = eligibleScenariosFor(plan, [kingsideCastleScenario, queensideCastleScenario])
     expect(eligible).toEqual([])
   })
+
+  it('filters out a castle scenario when chain demands enough queens on the home rank to force overlap with the castle emptiness', () => {
+    const plan = buildCombinedPlan([{
+      version: 2, kind: 'position',
+      subject: 'allied', subjectFilter: 'queen',
+      positionAxis: 'rank', positionComparator: 'equal_to', positionTarget: 1,
+      operator: 'count', comparator: 'greater_than_or_equal_to',
+      target: 'exact_number', targetTotal: 8
+    }])
+    const eligible = eligibleScenariosFor(plan, [kingsideCastleScenario, queensideCastleScenario])
+    expect(eligible).toEqual([])
+  })
 })

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/is_satisfiable.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/is_satisfiable.js
@@ -1,5 +1,7 @@
 import { ALL_POSITIONS } from 'editorV2/panels/condition_preview/shared/board_utils'
 
+const ALL_POSITIONS_SET = new Set(ALL_POSITIONS)
+
 export function isSatisfiable(ctx) {
   for (const key of Object.keys(ctx.singulars ?? {})) {
     const singular = ctx.singulars[key]
@@ -8,6 +10,7 @@ export function isSatisfiable(ctx) {
     if (regionIsEmpty(singular.priorRegion)) { return false }
   }
   for (const proposition of ctx.propositions ?? []) {
+    if (proposition.species_set.size === 0) { return false }
     if (proposition.count_range.min > proposition.count_range.max) { return false }
     if (proposition.aggregate_value_range.min > proposition.aggregate_value_range.max) { return false }
     if (proposition.aggregate_mobility_range.min > proposition.aggregate_mobility_range.max) { return false }
@@ -50,7 +53,7 @@ function countContradicts(demander, capper, demanderSquares, capperSquares) {
 }
 
 function squaresOf(region) {
-  if (region.kind === 'all') { return new Set(ALL_POSITIONS) }
+  if (region.kind === 'all') { return ALL_POSITIONS_SET }
   if (region.kind === 'set') { return region.squares }
   throw new Error(`isSatisfiable.squaresOf: unsupported region kind '${region.kind}' (expected 'all' or 'set'; 'related-to' should be filtered upstream)`)
 }

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/is_satisfiable.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/is_satisfiable.js
@@ -1,3 +1,5 @@
+import { ALL_POSITIONS } from 'editorV2/panels/condition_preview/shared/board_utils'
+
 export function isSatisfiable(ctx) {
   for (const key of Object.keys(ctx.singulars ?? {})) {
     const singular = ctx.singulars[key]
@@ -9,6 +11,61 @@ export function isSatisfiable(ctx) {
     if (proposition.count_range.min > proposition.count_range.max) { return false }
     if (proposition.aggregate_value_range.min > proposition.aggregate_value_range.max) { return false }
     if (proposition.aggregate_mobility_range.min > proposition.aggregate_mobility_range.max) { return false }
+  }
+  if (hasPairwiseCountContradiction(ctx.propositions ?? [])) { return false }
+  return true
+}
+
+function hasPairwiseCountContradiction(propositions) {
+  for (let i = 0; i < propositions.length; i += 1) {
+    for (let j = i + 1; j < propositions.length; j += 1) {
+      if (pairContradictsOnCount(propositions[i], propositions[j])) { return true }
+    }
+  }
+  return false
+}
+
+function pairContradictsOnCount(a, b) {
+  if (a.team !== b.team) { return false }
+  if (a.frame !== b.frame) { return false }
+  if (a.region.kind === 'related-to' || b.region.kind === 'related-to') { return false }
+
+  const aSubsetB = isSubset(a.species_set, b.species_set)
+  const bSubsetA = isSubset(b.species_set, a.species_set)
+  if (!aSubsetB && !bSubsetA) { return false }
+
+  const aSquares = squaresOf(a.region)
+  const bSquares = squaresOf(b.region)
+
+  if (aSubsetB && countContradicts(a, b, aSquares, bSquares)) { return true }
+  if (bSubsetA && countContradicts(b, a, bSquares, aSquares)) { return true }
+  return false
+}
+
+function countContradicts(demander, capper, demanderSquares, capperSquares) {
+  if (demander.count_range.min === 0) { return false }
+  const free = setDifferenceSize(demanderSquares, capperSquares)
+  const forced = Math.max(0, demander.count_range.min - free)
+  return forced > capper.count_range.max
+}
+
+function squaresOf(region) {
+  if (region.kind === 'all') { return new Set(ALL_POSITIONS) }
+  return region.squares
+}
+
+function setDifferenceSize(a, b) {
+  let n = 0
+  for (const x of a) {
+    if (!b.has(x)) { n += 1 }
+  }
+  return n
+}
+
+function isSubset(small, large) {
+  if (small.size > large.size) { return false }
+  for (const x of small) {
+    if (!large.has(x)) { return false }
   }
   return true
 }

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/is_satisfiable.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/is_satisfiable.js
@@ -51,7 +51,8 @@ function countContradicts(demander, capper, demanderSquares, capperSquares) {
 
 function squaresOf(region) {
   if (region.kind === 'all') { return new Set(ALL_POSITIONS) }
-  return region.squares
+  if (region.kind === 'set') { return region.squares }
+  throw new Error(`isSatisfiable.squaresOf: unsupported region kind '${region.kind}' (expected 'all' or 'set'; 'related-to' should be filtered upstream)`)
 }
 
 function setDifferenceSize(a, b) {


### PR DESCRIPTION
Catches the chain-demand vs scenario-emptiness case (e.g. chain requires white queen at H1, kingside_castle requires H1 empty) at eligibility filter time instead of burning the per-scenario attempt budget.

Predicate: forced_overlap = max(0, demander.count_min - |demanderSquares \ capperSquares|); contradicts if forced_overlap > capper.count_max. Skips related-to regions, non-subset species_set pairs, and cross-team or cross-frame pairs.