### PR TITLE
Main  value types  2.1

### DIFF
--- a/DEAD_CODE_INVENTORY.md
+++ b/DEAD_CODE_INVENTORY.md
@@ -1,0 +1,40 @@
+# Dead-code inventory — value redesign (aggregate_value gated off)
+
+Code left **dormant and intact** by the value redesign so old behavior can be
+restored quickly if UX testing demands it. If we stay on this path, this is the
+list to delete. Identifiers are authoritative; line numbers are approximate.
+
+## Newly dormant (introduced by this work — safe to delete to finalize)
+
+| Identifier | File | ~Line | Notes |
+|---|---|---|---|
+| `NON_KING_VALUE_SPECIES` (const) | `app/javascript/editorV2/panels/condition_preview/plans/plan.js` | 20 | Replaced by `plans/value_source_options.js`. Now unreferenced. |
+| `valueSourceOptions` (fn) | `app/javascript/editorV2/panels/condition_preview/plans/plan.js` | 28 | Old non-king copy. Live path uses `kingInclusiveValueSourceOptions` (import line 14). Unreferenced. |
+| `detectSingularActorWithAggregateValue` (fn) | `app/javascript/editorV2/panels/condition_preview/plans/plan.js` | 264 | Unregistered from `CONTRADICTION_DETECTORS`; body retained, unreachable. |
+| both-sides-aggregate validation block | `app/models/nodes/data_validator.rb` | 125–127 | Can't fire (line ~230 rejects aggregate metric first). Kept per "don't delete dead code"; restore value if aggregate_value is re-enabled. |
+
+## Intentionally preserved dormant (handoff §3E/§9 — recoverable capability)
+
+| Identifier | File | ~Line |
+|---|---|---|
+| `aggregate_value` dispatch branches | `app/javascript/bot_execution/candidate_move_analysis_v2.js` | 276–321 |
+| `relationalAggregateValueFromPairs` (fn) | `app/javascript/bot_execution/candidate_move_analysis_v2.js` | ~337 |
+| `metricForPositions` `case 'aggregate_value'` + `valueOfPositions` | `app/javascript/bot_execution/relational_analysis.js` | 167, 175 |
+| `actor_aggregate_value.js` | `app/javascript/editorV2/panels/condition_preview/forward_resolver/strategies/` | — |
+| `relation_aggregate_value.js` | `app/javascript/editorV2/panels/condition_preview/forward_resolver/strategies/` | — |
+| `relation_pbs_aggregate_value.js` | `app/javascript/editorV2/panels/condition_preview/forward_resolver/strategies/` | — |
+| ConditionForm.js aggregate UI logic: `leftUsesAggregateValue`/`rightUsesAggregateValue`, aggregate note toggles, mutual-exclusion, `disableOptions(['aggregate_value'])`, `metric === 'aggregate_value'` arm | `app/javascript/editorV2/panels/ConditionForm.js` | ~216, 479, 796, 824–831, 1022, 1045 |
+
+## Pre-existing dead (NOT introduced by this work)
+
+| Identifier | File | ~Line | Notes |
+|---|---|---|---|
+| `NON_KING_VALUE_SPECIES`, `valueSourceOptions`, `expandDescriptorVariants`, `expandRelationalPlanSources` | `app/javascript/editorV2/panels/condition_preview/plans/generation_plan.js` | 63, 155, 218, 251 | Dead before this work: nothing imports its `expandRelationalPlanSources`; `buildPlan` never reaches them. Untouched. |
+
+## Skipped tests (dormant, preserved — re-enable with the aggregate engine)
+
+- `app/javascript/editorV2/__tests__/ConditionExampleGenerator.test.js` — "flags contradiction when a singular actor uses aggregate_value" (`it.skip`)
+- `app/javascript/bot_execution/__tests__/condition_evaluator_v2.test.js` — 8-test aggregate cluster (sum/dedup/count+aggregate combinatorial) + 3 relational-aggregate PBS tests (`it.skip`)
+- `app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/pbs_relation_diversity.test.js` — 5 aggregate_value `it.skip` (count test left live)
+- `app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/subject_side_aggregate_value_diversity.test.js` — whole describe (`describe.skip`)
+- `app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/narrow_for_crossframe.test.js` — "handles aggregate_value metric the same as count" (`it.skip`)

--- a/app/forms/node_form.rb
+++ b/app/forms/node_form.rb
@@ -34,9 +34,8 @@ class NodeForm
   }.freeze
 
   COMPARISON_METRIC_LABELS = {
-    'count' => 'Count',
-    'individual_value' => 'Individual Value',
-    'aggregate_value' => 'Aggregate Value'
+    'count' => 'count',
+    'individual_value' => 'value'
   }.freeze
 
   COMPARATOR_SYMBOLS = {

--- a/app/javascript/bot_execution/__tests__/candidate_move_analysis_v2.test.js
+++ b/app/javascript/bot_execution/__tests__/candidate_move_analysis_v2.test.js
@@ -136,7 +136,7 @@ describe('CandidateMoveAnalysisV2', () => {
       ).toBe(4)
     })
 
-    it('keeps king value as zero in aggregate value totals', () => {
+    it('returns Infinity for a king-containing aggregate value total', () => {
       const board = buildBoard({
         pieces: {
           e1: 'wK',
@@ -155,7 +155,7 @@ describe('CandidateMoveAnalysisV2', () => {
           filter: 'any',
           operator: 'value'
         })
-      ).toBe(6)
+      ).toBe(Infinity)
     })
   })
 
@@ -1219,6 +1219,26 @@ describe('CandidateMoveAnalysisV2', () => {
 
       it('returns 0 for count when the moved piece does not match the filter', () => {
         expect(analysis.unaryTotal({ actor: 'moved_piece', filter: 'queen', operator: 'count' })).toBe(0)
+      })
+    })
+
+    describe('individualComparableValue', () => {
+      let analysis
+
+      beforeEach(() => {
+        const board = buildBoard({ pieces: { e1: 'wK', e8: 'bK', h2: 'wP' } })
+        const moveObject = getMove('h2', 'h3', board)
+        analysis = new CandidateMoveAnalysisV2({ board, moveObject })
+      })
+
+      it('returns canonical material value for non-king species', () => {
+        expect(analysis.individualComparableValue(Board.PAWN)).toBe(1)
+        expect(analysis.individualComparableValue(Board.ROOK)).toBe(5)
+        expect(analysis.individualComparableValue(Board.QUEEN)).toBe(9)
+      })
+
+      it('returns Infinity for the king', () => {
+        expect(analysis.individualComparableValue(Board.KING)).toBe(Infinity)
       })
     })
 

--- a/app/javascript/bot_execution/__tests__/condition_evaluator_v2.test.js
+++ b/app/javascript/bot_execution/__tests__/condition_evaluator_v2.test.js
@@ -1057,6 +1057,76 @@ describe('ConditionEvaluatorV2', () => {
       ).toBe(true)
     })
 
+    // wK e4 attacks bN e5. King value (Infinity) > 9 qualifies the king→knight pair.
+    it('includes a king participant at Infinity in the individual_value pair filter', () => {
+      const board = buildBoard({
+        pieces: {
+          e4: 'wK',
+          h8: 'bK',
+          d4: 'wP',
+          h2: 'wP',
+          e5: 'bN'
+        }
+      })
+
+      const moveObject = getMove('h2', 'h3', board)
+
+      expect(
+        evaluate(
+          {
+            version: 2,
+            kind: 'relational',
+            subject: 'allied',
+            subjectFilter: 'king',
+            subjectComparisonMetric: 'individual_value',
+            subjectComparator: 'greater_than',
+            subjectComparisonSource: 'exact_number',
+            subjectComparisonSourceTotal: 9,
+            operator: 'attack',
+            target: 'enemy',
+            targetFilter: 'knight'
+          },
+          board,
+          moveObject
+        )
+      ).toBe(true)
+    })
+
+    // King reads as Infinity, never a finite total: king == 9 must be false.
+    it('does not let a king participant satisfy a finite individual_value equality', () => {
+      const board = buildBoard({
+        pieces: {
+          e4: 'wK',
+          h8: 'bK',
+          d4: 'wP',
+          h2: 'wP',
+          e5: 'bN'
+        }
+      })
+
+      const moveObject = getMove('h2', 'h3', board)
+
+      expect(
+        evaluate(
+          {
+            version: 2,
+            kind: 'relational',
+            subject: 'allied',
+            subjectFilter: 'king',
+            subjectComparisonMetric: 'individual_value',
+            subjectComparator: 'equal_to',
+            subjectComparisonSource: 'exact_number',
+            subjectComparisonSourceTotal: 9,
+            operator: 'attack',
+            target: 'enemy',
+            targetFilter: 'knight'
+          },
+          board,
+          moveObject
+        )
+      ).toBe(false)
+    })
+
     it('uses a subject-only comparison block as the full truth condition when it fails', () => {
       const board = buildBoard({
         pieces: {
@@ -1373,7 +1443,9 @@ describe('ConditionEvaluatorV2', () => {
       ).toBe(false)
     })
 
-    it('returns true for aggregate_value when sum of attacked pieces exceeds threshold', () => {
+    // Dormant: relational aggregate_value is grammar-gated. The evaluation
+    // engine is retained; re-enable these together with the metric.
+    it.skip('returns true for aggregate_value when sum of attacked pieces exceeds threshold', () => {
       // wR on d4 attacks bQ on d7 (9) and bN on g4 (3). Sum = 12 > 8.
       const board = buildBoard({
         pieces: {
@@ -1409,7 +1481,7 @@ describe('ConditionEvaluatorV2', () => {
       ).toBe(true)
     })
 
-    it('returns false for aggregate_value when sum of attacked pieces does not exceed threshold', () => {
+    it.skip('returns false for aggregate_value when sum of attacked pieces does not exceed threshold', () => {
       const board = buildBoard({
         pieces: {
           e1: 'wK',
@@ -1444,7 +1516,7 @@ describe('ConditionEvaluatorV2', () => {
       ).toBe(false)
     })
 
-    it('does not double-count a single subject that participates in multiple pairs when computing subject aggregate_value', () => {
+    it.skip('does not double-count a single subject that participates in multiple pairs when computing subject aggregate_value', () => {
       // wP e4 attacks bN d5 and bB f5 — one pawn, two enemies. Pairs: (e4,d5), (e4,f5).
       // Aggregate over unique subject positions = value(wP) = 1, not 1+1=2.
       const board = buildBoard({
@@ -1481,7 +1553,7 @@ describe('ConditionEvaluatorV2', () => {
       ).toBe(false)
     })
 
-    it('counts each unique subject once when multiple pairs share subjects with multiple targets', () => {
+    it.skip('counts each unique subject once when multiple pairs share subjects with multiple targets', () => {
       // wP a4 attacks bR b5; wP e4 attacks bN d5 and bB f5.
       // Pairs: (a4,b5), (e4,d5), (e4,f5). Unique subjects: {a4, e4}. Aggregate = 1+1 = 2.
       const board = buildBoard({
@@ -1520,7 +1592,7 @@ describe('ConditionEvaluatorV2', () => {
       ).toBe(true)
     })
 
-    it('does not double-count a single target that is attacked by multiple subjects when computing target aggregate_value', () => {
+    it.skip('does not double-count a single target that is attacked by multiple subjects when computing target aggregate_value', () => {
       // wP c4 and wP e4 both attack bN d5. Pairs: (c4,d5), (e4,d5).
       // Aggregate over unique target positions = value(bN) = 3, not 3+3=6.
       const board = buildBoard({
@@ -1557,7 +1629,7 @@ describe('ConditionEvaluatorV2', () => {
       ).toBe(true)
     })
 
-    it('returns true for count+aggregate_value combinatorial when two pawns combined attacked value exceeds threshold', () => {
+    it.skip('returns true for count+aggregate_value combinatorial when two pawns combined attacked value exceeds threshold', () => {
       // wP c5 attacks bR d6 (5), wP f5 attacks bR e6 (5). Both groups sum 5.
       // Find 2 groups with combined sum > 8: 5+5=10 > 8 → true.
       const board = buildBoard({
@@ -1599,7 +1671,7 @@ describe('ConditionEvaluatorV2', () => {
       ).toBe(true)
     })
 
-    it('returns false for count+aggregate_value combinatorial when no two groups combined exceed threshold', () => {
+    it.skip('returns false for count+aggregate_value combinatorial when no two groups combined exceed threshold', () => {
       // wP c5 attacks bN d6 (3), wP f5 attacks bN e6 (3). Best 2: 3+3=6, not > 8.
       const board = buildBoard({
         pieces: {
@@ -1640,7 +1712,7 @@ describe('ConditionEvaluatorV2', () => {
       ).toBe(false)
     })
 
-    it('returns true for count+aggregate_value when a valid 2-group subset exists even if full set does not', () => {
+    it.skip('returns true for count+aggregate_value when a valid 2-group subset exists even if full set does not', () => {
       // wP b5→bN c6(3), wP e5→bR d6(5), wP g5→bR h6(5).
       // b5+e5=8 (not >8), b5+g5=8 (not >8), e5+g5=10 >8 → true.
       const board = buildBoard({
@@ -3199,7 +3271,7 @@ describe('ConditionEvaluatorV2', () => {
   })
 
   describe('PBS empty-side coercion', () => {
-    it('unary aggregate_value PBS verifies when after has pieces and prior is empty (promotion)', () => {
+    it('unary value PBS verifies when after has pieces and prior is empty (promotion)', () => {
       const board = buildBoard({ pieces: { e1: 'wK', e8: 'bK', g7: 'wP' } })
       const moveObject = getMove('g7', 'g8', board, Board.QUEEN)
       expect(evaluate({
@@ -3210,7 +3282,7 @@ describe('ConditionEvaluatorV2', () => {
       }, board, moveObject)).toBe(true)
     })
 
-    it('unary aggregate_value PBS verifies when after is empty and prior has pieces (capture)', () => {
+    it('unary value PBS verifies when after is empty and prior has pieces (capture)', () => {
       const board = buildBoard({ pieces: { e1: 'wK', e8: 'bK', e4: 'wP', d5: 'bN' } })
       const moveObject = getMove('e4', 'd5', board)
       expect(evaluate({
@@ -3221,7 +3293,7 @@ describe('ConditionEvaluatorV2', () => {
       }, board, moveObject)).toBe(true)
     })
 
-    it('unary aggregate_value PBS equal_to verifies when both frames are empty', () => {
+    it('unary value PBS equal_to verifies when both frames are empty', () => {
       const board = buildBoard({ pieces: { e1: 'wK', e8: 'bK', e2: 'wP' } })
       const moveObject = getMove('e2', 'e3', board)
       expect(evaluate({
@@ -3232,7 +3304,8 @@ describe('ConditionEvaluatorV2', () => {
       }, board, moveObject)).toBe(true)
     })
 
-    it('relational aggregate_value PBS verifies when after has pairs and prior is empty', () => {
+    // Dormant: relational aggregate_value is grammar-gated. Engine retained.
+    it.skip('relational aggregate_value PBS verifies when after has pairs and prior is empty', () => {
       const board = buildBoard({ pieces: { e1: 'wK', e8: 'bK', a1: 'wN', d4: 'bQ' } })
       const moveObject = getMove('a1', 'c2', board)
       expect(evaluate({
@@ -3245,7 +3318,7 @@ describe('ConditionEvaluatorV2', () => {
       }, board, moveObject)).toBe(true)
     })
 
-    it('relational aggregate_value PBS equal_to verifies when both frames have empty pairs', () => {
+    it.skip('relational aggregate_value PBS equal_to verifies when both frames have empty pairs', () => {
       const board = buildBoard({ pieces: { e1: 'wK', e8: 'bK' } })
       const moveObject = getMove('e1', 'e2', board)
       expect(evaluate({
@@ -3258,7 +3331,7 @@ describe('ConditionEvaluatorV2', () => {
       }, board, moveObject)).toBe(true)
     })
 
-    it('combinatorial PBS (count + aggregate_value) verifies when target prior is empty', () => {
+    it.skip('combinatorial PBS (count + aggregate_value) verifies when target prior is empty', () => {
       const board = buildBoard({ pieces: { e1: 'wK', e8: 'bK', a1: 'wN', d4: 'bQ' } })
       const moveObject = getMove('a1', 'c2', board)
       expect(evaluate({

--- a/app/javascript/bot_execution/__tests__/utils.test.js
+++ b/app/javascript/bot_execution/__tests__/utils.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { compareTotals } from 'bot_execution/utils'
+import { compareTotals, compareValues } from 'bot_execution/utils'
 
 describe('compareTotals', () => {
   it('compares numeric totals via the named comparator', () => {
@@ -21,5 +21,38 @@ describe('compareTotals', () => {
 
   it('throws on unknown comparator', () => {
     expect(() => compareTotals('not_a_comparator', 1, 1)).toThrow(/Unknown comparator/)
+  })
+
+  it('handles Infinity operands without producing NaN or null', () => {
+    expect(compareTotals('greater_than', Infinity, 9)).toBe(true)
+    expect(compareTotals('equal_to', Infinity, Infinity)).toBe(true)
+    expect(compareTotals('less_than', 9, Infinity)).toBe(true)
+    expect(compareTotals('greater_than', 9, Infinity)).toBe(false)
+    expect(compareTotals('less_than', Infinity, Infinity)).toBe(false)
+    expect(compareTotals('greater_than_or_equal_to', Infinity, Infinity)).toBe(true)
+  })
+
+  it('still returns false when an operand is null even if the other is Infinity', () => {
+    expect(compareTotals('equal_to', null, Infinity)).toBe(false)
+    expect(compareTotals('greater_than', Infinity, null)).toBe(false)
+  })
+})
+
+describe('compareValues', () => {
+  it('compares finite values via the named comparator', () => {
+    expect(compareValues(3, 'equal_to', 3)).toBe(true)
+    expect(compareValues(4, 'greater_than', 3)).toBe(true)
+    expect(compareValues(3, 'less_than', 4)).toBe(true)
+  })
+
+  it('handles Infinity (king value) without NaN', () => {
+    expect(compareValues(Infinity, 'greater_than', 9)).toBe(true)
+    expect(compareValues(Infinity, 'equal_to', Infinity)).toBe(true)
+    expect(compareValues(9, 'less_than', Infinity)).toBe(true)
+    expect(compareValues(Infinity, 'less_than', Infinity)).toBe(false)
+  })
+
+  it('throws on unknown comparator', () => {
+    expect(() => compareValues(1, 'not_a_comparator', 1)).toThrow(/Unknown comparator/)
   })
 })

--- a/app/javascript/bot_execution/candidate_move_analysis_v2.js
+++ b/app/javascript/bot_execution/candidate_move_analysis_v2.js
@@ -106,7 +106,6 @@ class CandidateMoveAnalysisV2 {
   }
 
   individualComparableValue(species) {
-    if (species === Board.KING) { return null }
     return materialValue(species)
   }
 

--- a/app/javascript/editorV2/__tests__/ConditionExampleGenerator.test.js
+++ b/app/javascript/editorV2/__tests__/ConditionExampleGenerator.test.js
@@ -474,7 +474,10 @@ describe('ConditionExampleGenerator', () => {
     expect(preview.reason).toMatch(/singular actor/i)
   })
 
-  it('flags contradiction when a singular actor uses aggregate_value', () => {
+  // Dormant: detectSingularActorWithAggregateValue is unregistered from
+  // CONTRADICTION_DETECTORS while aggregate_value is grammar-gated. Re-enable
+  // the detector and this test together.
+  it.skip('flags contradiction when a singular actor uses aggregate_value', () => {
     const payload = {
       version: 2, kind: 'relational',
       subject: 'moved_piece', subjectFilter: 'any', operator: 'attack',
@@ -1942,8 +1945,9 @@ describe('ConditionExampleGenerator', () => {
   })
 
   it('flags contradiction when singular actor species conflicts with inventory cap (patch 2b)', () => {
-    // moved_piece value > 5 narrows moved_piece species_set to {queen} via
-    // plan-builder. allied/queen count = 0 narrows inventory.movingTeam.current.queen
+    // moved_piece value == 9 narrows moved_piece species_set to {queen} via
+    // plan-builder (king is Infinity, not 9, so it cannot escape the cap).
+    // allied/queen count = 0 narrows inventory.movingTeam.current.queen
     // count_range to [0, 0]. Singular-actor contribution then raises that
     // count_range.min to 1 (moved_piece is a queen, on the board). Range becomes
     // [1, 0] → unsat.
@@ -1951,8 +1955,8 @@ describe('ConditionExampleGenerator', () => {
       {
         version: 2, kind: 'unary',
         subject: 'moved_piece', subjectFilter: 'any',
-        operator: 'value', comparator: 'greater_than',
-        target: 'exact_number', targetTotal: 5
+        operator: 'value', comparator: 'equal_to',
+        target: 'exact_number', targetTotal: 9
       },
       {
         version: 2, kind: 'unary',

--- a/app/javascript/editorV2/__tests__/conditionPreviewFormatter.test.js
+++ b/app/javascript/editorV2/__tests__/conditionPreviewFormatter.test.js
@@ -42,6 +42,24 @@ describe('conditionPreviewFormatter', () => {
       ).toBe('Allied pawn/s (count > 2) : attack : Enemy bishop/s (value < Prior Board State)')
     })
 
+    it('labels the individual_value relational metric as "value"', () => {
+      expect(
+        formatConditionPreview({
+          version: 2,
+          kind: 'relational',
+          subject: 'allied',
+          subjectFilter: 'pawn',
+          subjectComparisonMetric: 'individual_value',
+          subjectComparator: 'greater_than',
+          subjectComparisonSource: 'exact_number',
+          subjectComparisonSourceTotal: 3,
+          operator: 'attack',
+          target: 'enemy',
+          targetFilter: 'bishop'
+        }).text
+      ).toBe('Allied pawn/s (value > 3) : attack : Enemy bishop/s')
+    })
+
     it('formats unary previews in a three-block layout', () => {
       expect(
         formatConditionPreview({
@@ -68,7 +86,7 @@ describe('conditionPreviewFormatter', () => {
           target: 'enemy',
           targetFilter: 'rook'
         }).text
-      ).toBe('Allies any : aggregate value : > Enemy rook/s')
+      ).toBe('Allies any : value : > Enemy rook/s')
     })
 
     it('formats same_piece with the explicit operator phrase', () => {

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/narrow_for_crossframe.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/narrow_for_crossframe.test.js
@@ -43,7 +43,8 @@ describe('narrowForCrossFrame — narrows captured_piece for unary enemy count/v
     expect(ctx.singulars.captured_piece.species_set).toEqual(new Set([Board.QUEEN]))
   })
 
-  it('handles aggregate_value metric the same as count', () => {
+  // Dormant: relational aggregate_value is grammar-gated. Engine retained.
+  it.skip('handles aggregate_value metric the same as count', () => {
     const ctx = defaultTestCtx({
       singulars: { captured_piece: capturedPieceSingular() },
       crossFrame: [{

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/pbs_relation_diversity.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/pbs_relation_diversity.test.js
@@ -86,7 +86,8 @@ const ATTEMPTS_PER_SEED = 200
 const MIN_EMPTY_PRIOR_DELTAS = 5
 
 describe('PBS relation diversity', () => {
-  it('shield aggregate_value > PBS produces 0→N deltas', () => {
+  // Dormant: relational aggregate_value is grammar-gated. Engine retained.
+  it.skip('shield aggregate_value > PBS produces 0→N deltas', () => {
     const payload = {
       version: 2, kind: 'relational',
       subject: 'enemy', subjectFilter: 'pawn', subjectFilterMode: 'exclude',
@@ -101,7 +102,7 @@ describe('PBS relation diversity', () => {
     expect(countEmptyPriorDeltas(histogram)).toBeGreaterThanOrEqual(MIN_EMPTY_PRIOR_DELTAS)
   })
 
-  it('attack aggregate_value > PBS produces 0→N deltas', () => {
+  it.skip('attack aggregate_value > PBS produces 0→N deltas', () => {
     const payload = {
       version: 2, kind: 'relational',
       subject: 'allied', subjectFilter: 'knight',
@@ -116,7 +117,7 @@ describe('PBS relation diversity', () => {
     expect(countEmptyPriorDeltas(histogram)).toBeGreaterThanOrEqual(MIN_EMPTY_PRIOR_DELTAS)
   })
 
-  it('defend aggregate_value > PBS produces 0→N deltas', () => {
+  it.skip('defend aggregate_value > PBS produces 0→N deltas', () => {
     const payload = {
       version: 2, kind: 'relational',
       subject: 'allied', subjectFilter: 'knight',
@@ -131,7 +132,7 @@ describe('PBS relation diversity', () => {
     expect(countEmptyPriorDeltas(histogram)).toBeGreaterThanOrEqual(MIN_EMPTY_PRIOR_DELTAS)
   })
 
-  it('adjacent aggregate_value > PBS produces 0→N deltas', () => {
+  it.skip('adjacent aggregate_value > PBS produces 0→N deltas', () => {
     const payload = {
       version: 2, kind: 'relational',
       subject: 'allied', subjectFilter: 'knight',
@@ -166,7 +167,7 @@ describe('PBS relation diversity', () => {
     expect(nToZero).toBeGreaterThanOrEqual(MIN_EMPTY_PRIOR_DELTAS)
   })
 
-  it('shield aggregate_value = PBS produces 0=0 examples', () => {
+  it.skip('shield aggregate_value = PBS produces 0=0 examples', () => {
     const payload = {
       version: 2, kind: 'relational',
       subject: 'enemy', subjectFilter: 'pawn', subjectFilterMode: 'exclude',

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/propositions.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/propositions.test.js
@@ -325,7 +325,7 @@ describe('emitConstraintsFromPlan — individual_value descriptor narrowing', ()
     const { propositions } = emitConstraintsFromPlan(plan)
     const [p] = propositions
 
-    expect(p.species_set).toEqual(new Set([Board.QUEEN]))
+    expect(p.species_set).toEqual(new Set([Board.QUEEN, Board.KING]))
   })
 
   it('narrows relation.subjectSide.species_set on a two-group plan when subject side has individual_value descriptor', () => {
@@ -344,7 +344,7 @@ describe('emitConstraintsFromPlan — individual_value descriptor narrowing', ()
     const { relations } = emitConstraintsFromPlan(plan)
     const [r] = relations
 
-    expect(r.subjectSide.species_set).toEqual(new Set([Board.QUEEN]))
+    expect(r.subjectSide.species_set).toEqual(new Set([Board.QUEEN, Board.KING]))
   })
 })
 

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/singulars.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/singulars.test.js
@@ -147,7 +147,7 @@ describe('buildSingulars — unary value narrowing on singular subject', () => {
     }])
     const singulars = buildSingulars(combinedPlan)
 
-    expect(singulars.moved_piece.species_set).toEqual(new Set([Board.QUEEN]))
+    expect(singulars.moved_piece.species_set).toEqual(new Set([Board.QUEEN, Board.KING]))
   })
 
   it('narrows species_set to species whose materialValue satisfies value = target (exact match)', () => {
@@ -232,8 +232,38 @@ describe('buildSingulars — relational singular value comparison', () => {
     const singulars = buildSingulars(combinedPlan)
 
     expect(singulars.moved_piece.species_set.has(Board.PAWN)).toBe(false)
-    expect(singulars.moved_piece.species_set.has(Board.KING)).toBe(false)
+    expect(singulars.moved_piece.species_set.has(Board.KING)).toBe(true)
     expect(singulars.moved_piece.species_set.has(Board.NIGHT)).toBe(true)
+    expect(singulars.moved_piece.species_set.has(Board.QUEEN)).toBe(true)
+  })
+
+  it('excludes the king from moved_piece when its value must be less than a capturable piece', () => {
+    const combinedPlan = buildCombinedPlan([{
+      version: 2, kind: 'relational',
+      subject: 'moved_piece', subjectFilter: 'any',
+      operator: 'attack',
+      target: 'enemy', targetFilter: 'any',
+      subjectComparator: 'less_than',
+      subjectComparisonMetric: 'individual_value',
+      subjectComparisonSource: 'captured_piece'
+    }])
+    const singulars = buildSingulars(combinedPlan)
+
+    expect(singulars.moved_piece.species_set.has(Board.KING)).toBe(false)
+  })
+
+  it('keeps the queen in moved_piece when value < enemy_moved_piece, since enemy_moved_piece can be a king', () => {
+    const combinedPlan = buildCombinedPlan([{
+      version: 2, kind: 'relational',
+      subject: 'moved_piece', subjectFilter: 'any',
+      operator: 'attack',
+      target: 'enemy', targetFilter: 'any',
+      subjectComparator: 'less_than',
+      subjectComparisonMetric: 'individual_value',
+      subjectComparisonSource: 'enemy_moved_piece'
+    }])
+    const singulars = buildSingulars(combinedPlan)
+
     expect(singulars.moved_piece.species_set.has(Board.QUEEN)).toBe(true)
   })
 })

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/subject_side_aggregate_value_diversity.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/subject_side_aggregate_value_diversity.test.js
@@ -59,7 +59,8 @@ function collect(seed) {
   return standardExamples
 }
 
-describe('enemy aggregate_value < 3 attack moved_piece diversity', () => {
+// Dormant: relational aggregate_value is grammar-gated. Engine retained.
+describe.skip('enemy aggregate_value < 3 attack moved_piece diversity', () => {
   // Seed-brittle: if random-consumption order shifts upstream, seed 7777's output changes and this may fail despite the feature working. Start any failure investigation by checking whether the planning path is firing at all.
   it('produces at least one example with two pawn attackers', () => {
     const examples = collect(7777)

--- a/app/javascript/editorV2/panels/condition_preview/plans/__tests__/generation_plan.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/plans/__tests__/generation_plan.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import Board from 'gameplay/board'
 import { buildPlan } from 'editorV2/panels/condition_preview/plans/generation_plan'
+import { expandRelationalPlanSources } from 'editorV2/panels/condition_preview/plans/plan'
 
 describe('buildPlan team assignment for captured-type actors', () => {
   const teams = { movingTeam: Board.WHITE, enemyTeam: Board.BLACK }
@@ -59,5 +60,30 @@ describe('buildPlan team assignment for captured-type actors', () => {
     )
     expect(plan.status).toBe('supported')
     expect(plan.targetTeam).toBe(Board.WHITE)
+  })
+})
+
+describe('expandRelationalPlanSources — king as a value source', () => {
+  const teams = { movingTeam: Board.WHITE, enemyTeam: Board.BLACK }
+
+  it('includes the king (value Infinity) among moved_piece value-source variants', () => {
+    const plan = buildPlan(
+      {
+        version: 2, kind: 'relational',
+        subject: 'allied', subjectFilter: 'any',
+        operator: 'attack',
+        target: 'enemy', targetFilter: 'any',
+        subjectComparisonMetric: 'individual_value',
+        subjectComparator: 'greater_than',
+        subjectComparisonSource: 'moved_piece'
+      },
+      teams
+    )
+    expect(plan.status).toBe('supported')
+
+    const variants = expandRelationalPlanSources(plan)
+    const pools = variants.map(v => v.sourceConstraints?.movedPieceSpeciesPool || [])
+
+    expect(pools.some(pool => pool.includes(Board.KING))).toBe(true)
   })
 })

--- a/app/javascript/editorV2/panels/condition_preview/plans/plan.js
+++ b/app/javascript/editorV2/panels/condition_preview/plans/plan.js
@@ -11,6 +11,7 @@ import {
   comparisonRequirementsFromDescriptors,
   valueComparisonAllowsEmpty
 } from 'editorV2/panels/condition_preview/plans/comparison_requirements'
+import { valueSourceOptions as kingInclusiveValueSourceOptions } from 'editorV2/panels/condition_preview/plans/value_source_options'
 
 const ALL_MOVE_KINDS = Object.freeze([MOVE_KIND_STANDARD, MOVE_KIND_CASTLE, MOVE_KIND_PROMOTION, MOVE_KIND_EN_PASSANT])
 
@@ -73,7 +74,7 @@ function mergeConstraints(base, extra) {
 function expandDescriptorVariants(descriptors) {
   return descriptors.reduce((variants, descriptor) => {
     const options = isValueMetric(descriptor.metric)
-      ? valueSourceOptions(descriptor)
+      ? kingInclusiveValueSourceOptions(descriptor)
       : [{ resolvedTotal: descriptor.total, constraints: {} }]
 
     const nextVariants = []
@@ -320,7 +321,6 @@ const CONTRADICTION_DETECTORS = [
   detectSingularActorWithImpossibleCount,
   detectSingularActorWithImpossibleUnaryCount,
   detectMovedPieceWithCountZero,
-  detectSingularActorWithAggregateValue,
   detectFilterMatchesNoSpecies
 ]
 

--- a/app/javascript/editorV2/panels/condition_preview/plans/value_source_options.js
+++ b/app/javascript/editorV2/panels/condition_preview/plans/value_source_options.js
@@ -1,0 +1,41 @@
+import Board from 'gameplay/board'
+import { materialValue } from 'gameplay/board_query_utils'
+import { EXACT_NUMBER_COMPARISON_SOURCE } from 'editorV2/panels/condition_preview/plans/comparison_requirements'
+
+// Shared value-source enumeration. value -> [species] is derived from
+// materialValue, so the king (Infinity) participates like any other piece
+// rather than being excluded by a hardcoded non-king table.
+const VALUE_SPECIES = Object.freeze([
+  Board.PAWN, Board.NIGHT, Board.BISHOP, Board.ROOK, Board.QUEEN, Board.KING
+])
+
+const VALUE_TO_SPECIES = (() => {
+  const map = new Map()
+  for (const species of VALUE_SPECIES) {
+    const value = materialValue(species)
+    if (!map.has(value)) { map.set(value, []) }
+    map.get(value).push(species)
+  }
+  return map
+})()
+
+const SOURCE_CONSTRAINT_KEY = Object.freeze({
+  moved_piece: 'movedPieceSpeciesPool',
+  captured_piece: 'capturedPieceSpeciesPool',
+  enemy_moved_piece: 'enemyMovedPieceSpeciesPool',
+  enemy_captured_piece: 'enemyCapturedPieceSpeciesPool'
+})
+
+export function valueSourceOptions(descriptor) {
+  if (descriptor.source === EXACT_NUMBER_COMPARISON_SOURCE) {
+    return [{ resolvedTotal: Number(descriptor.total || 0), constraints: {} }]
+  }
+  const constraintKey = SOURCE_CONSTRAINT_KEY[descriptor.source]
+  if (!constraintKey) { return [] }
+  return Array.from(VALUE_TO_SPECIES.entries())
+    .filter(([value]) => value > 0)
+    .map(([value, speciesPool]) => ({
+      resolvedTotal: value,
+      constraints: { [constraintKey]: speciesPool }
+    }))
+}

--- a/app/javascript/editorV2/panels/condition_preview/plans/value_source_options.js
+++ b/app/javascript/editorV2/panels/condition_preview/plans/value_source_options.js
@@ -16,6 +16,7 @@ const VALUE_TO_SPECIES = (() => {
     if (!map.has(value)) { map.set(value, []) }
     map.get(value).push(species)
   }
+  for (const pool of map.values()) { Object.freeze(pool) }
   return map
 })()
 

--- a/app/javascript/editorV2/utils/conditionPreviewFormatter.js
+++ b/app/javascript/editorV2/utils/conditionPreviewFormatter.js
@@ -85,7 +85,7 @@ function operatorLabel(operator) {
     case 'mobility':
       return 'mobility'
     case 'value':
-      return 'aggregate value'
+      return 'value'
     default:
       return operator
   }
@@ -102,9 +102,7 @@ function metricLabel(metric) {
     case 'value':
       return 'value'
     case 'individual_value':
-      return 'individual value'
-    case 'aggregate_value':
-      return 'aggregate value'
+      return 'value'
     default:
       return metric
   }

--- a/app/javascript/gameplay/__tests__/board_query_utils.test.js
+++ b/app/javascript/gameplay/__tests__/board_query_utils.test.js
@@ -4,6 +4,7 @@ import Board from 'gameplay/board'
 import {
   controlledSquares,
   controllingPositions,
+  materialValue,
   pawnAttackPositions,
   pieceControlsSquare,
   squareClassification
@@ -12,6 +13,20 @@ import {
 import { buildBoard, position, square } from 'gameplay/__tests__/helpers'
 
 describe('board_query_utils', () => {
+  describe('materialValue', () => {
+    it('returns canonical material values for non-king species', () => {
+      expect(materialValue(Board.PAWN)).toBe(1)
+      expect(materialValue(Board.NIGHT)).toBe(3)
+      expect(materialValue(Board.BISHOP)).toBe(3)
+      expect(materialValue(Board.ROOK)).toBe(5)
+      expect(materialValue(Board.QUEEN)).toBe(9)
+    })
+
+    it('returns Infinity for the king', () => {
+      expect(materialValue(Board.KING)).toBe(Infinity)
+    })
+  })
+
   describe('squareClassification', () => {
     it('classifies empty, teammate, and opponent squares relative to the moving team', () => {
       const board = buildBoard({

--- a/app/javascript/gameplay/board_query_utils.js
+++ b/app/javascript/gameplay/board_query_utils.js
@@ -299,7 +299,7 @@ function pieceValue(species) {
         case Board.QUEEN:
         return 9
         case Board.KING:
-        return 0
+        return Infinity
         default:
         return 0
     }

--- a/app/models/node_grammar_rules.rb
+++ b/app/models/node_grammar_rules.rb
@@ -54,8 +54,7 @@ class NodeGrammarRules
 
   COMPARISON_SOURCES_BY_METRIC = {
     'count' => %w[exact_number prior_board_state],
-    'individual_value' => NodeGrammarV2::COMPARISON_SOURCES,
-    'aggregate_value' => NodeGrammarV2::COMPARISON_SOURCES
+    'individual_value' => NodeGrammarV2::COMPARISON_SOURCES
   }.freeze
 
   class << self

--- a/app/models/node_grammar_v2.rb
+++ b/app/models/node_grammar_v2.rb
@@ -27,7 +27,7 @@
     POSITION_AXES = %w[rank file square].freeze
     POSITION_MOBILITY_SUBJECTS = %w[allied enemy moved_piece enemy_moved_piece].freeze
 
-    COMPARISON_METRICS = %w[count individual_value aggregate_value].freeze
+    COMPARISON_METRICS = %w[count individual_value].freeze
     COMPARATORS = %w[equal_to greater_than less_than greater_than_or_equal_to less_than_or_equal_to].freeze
     EXACT_COMPARISON_SOURCE = 'exact_number'
     PRIOR_BOARD_COMPARISON_SOURCE = 'prior_board_state'

--- a/db/migrate/20260515120000_rename_relational_aggregate_value_to_individual_value.rb
+++ b/db/migrate/20260515120000_rename_relational_aggregate_value_to_individual_value.rb
@@ -1,0 +1,21 @@
+class RenameRelationalAggregateValueToIndividualValue < ActiveRecord::Migration[7.1]
+  def up
+    execute <<-SQL
+      UPDATE nodes
+      SET data = jsonb_set(data::jsonb, '{subjectComparisonMetric}', '"individual_value"')::json
+      WHERE data->>'subjectComparisonMetric' = 'aggregate_value'
+        AND data->>'kind' = 'relational';
+
+      UPDATE nodes
+      SET data = jsonb_set(data::jsonb, '{targetComparisonMetric}', '"individual_value"')::json
+      WHERE data->>'targetComparisonMetric' = 'aggregate_value'
+        AND data->>'kind' = 'relational';
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration,
+          'aggregate_value -> individual_value is lossy (individual != aggregate). ' \
+          'Restore from the pre-migration DB snapshot / branch state instead.'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_05_02_120000) do
+ActiveRecord::Schema[7.1].define(version: 2026_05_15_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/spec/migrations/rename_relational_aggregate_value_to_individual_value_spec.rb
+++ b/spec/migrations/rename_relational_aggregate_value_to_individual_value_spec.rb
@@ -1,0 +1,103 @@
+require 'rails_helper'
+
+# §4 migration. Canonical target the §3 implementation must create:
+#   db/migrate/20260515120000_rename_relational_aggregate_value_to_individual_value.rb
+#   class RenameRelationalAggregateValueToIndividualValue
+# Guarded so the absent migration fails these examples individually
+# (NEW-TDD-RED) rather than aborting the whole suite at load.
+begin
+  require Rails.root.join(
+    'db', 'migrate', '20260515120000_rename_relational_aggregate_value_to_individual_value'
+  )
+rescue LoadError
+  nil
+end
+
+RSpec.describe 'RenameRelationalAggregateValueToIndividualValue (§4 migration)', type: :model do
+  let(:migration) { RenameRelationalAggregateValueToIndividualValue.new }
+
+  # Persist a legacy pre-§3B row, bypassing the (post-§3B) validation that
+  # would reject aggregate_value.
+  def legacy_node(data)
+    node = create(:node, :condition)
+    node.update_column(:data, data)
+    node
+  end
+
+  it 'rewrites a relational subject aggregate_value to individual_value' do
+    node = legacy_node(
+      'version' => 2, 'kind' => 'relational',
+      'subject' => 'allied', 'subjectFilter' => 'any',
+      'operator' => 'attack', 'target' => 'enemy', 'targetFilter' => 'any',
+      'subjectComparisonMetric' => 'aggregate_value',
+      'subjectComparator' => 'greater_than',
+      'subjectComparisonSource' => 'exact_number',
+      'subjectComparisonSourceTotal' => 0
+    )
+
+    migration.up
+
+    expect(node.reload.data['subjectComparisonMetric']).to eq('individual_value')
+  end
+
+  it 'rewrites a relational target aggregate_value to individual_value' do
+    node = legacy_node(
+      'version' => 2, 'kind' => 'relational',
+      'subject' => 'allied', 'subjectFilter' => 'any',
+      'operator' => 'attack', 'target' => 'enemy', 'targetFilter' => 'any',
+      'targetComparisonMetric' => 'aggregate_value',
+      'targetComparator' => 'greater_than',
+      'targetComparisonSource' => 'exact_number',
+      'targetComparisonSourceTotal' => 0
+    )
+
+    migration.up
+
+    expect(node.reload.data['targetComparisonMetric']).to eq('individual_value')
+  end
+
+  it 'leaves relational count and individual_value nodes untouched' do
+    count_node = legacy_node(
+      'version' => 2, 'kind' => 'relational',
+      'subject' => 'allied', 'subjectFilter' => 'any',
+      'operator' => 'attack', 'target' => 'enemy', 'targetFilter' => 'any',
+      'subjectComparisonMetric' => 'count',
+      'subjectComparator' => 'greater_than',
+      'subjectComparisonSource' => 'exact_number',
+      'subjectComparisonSourceTotal' => 0
+    )
+    individual_node = legacy_node(
+      'version' => 2, 'kind' => 'relational',
+      'subject' => 'allied', 'subjectFilter' => 'any',
+      'operator' => 'attack', 'target' => 'enemy', 'targetFilter' => 'any',
+      'subjectComparisonMetric' => 'individual_value',
+      'subjectComparator' => 'greater_than',
+      'subjectComparisonSource' => 'exact_number',
+      'subjectComparisonSourceTotal' => 0
+    )
+
+    migration.up
+
+    expect(count_node.reload.data['subjectComparisonMetric']).to eq('count')
+    expect(individual_node.reload.data['subjectComparisonMetric']).to eq('individual_value')
+  end
+
+  it 'is idempotent on re-run' do
+    node = legacy_node(
+      'version' => 2, 'kind' => 'relational',
+      'subject' => 'allied', 'subjectFilter' => 'any',
+      'operator' => 'attack', 'target' => 'enemy', 'targetFilter' => 'any',
+      'subjectComparisonMetric' => 'aggregate_value',
+      'subjectComparator' => 'greater_than',
+      'subjectComparisonSource' => 'exact_number',
+      'subjectComparisonSourceTotal' => 0
+    )
+
+    migration.up
+    first = node.reload.data
+    migration.up
+
+    expect(node.reload.data).to eq(first)
+    expect(node.reload.data['subjectComparisonMetric']).to eq('individual_value')
+  end
+end

--- a/spec/models/node_form_spec.rb
+++ b/spec/models/node_form_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe NodeForm, type: :model do
+  describe '.comparison_metric_options' do
+    it 'offers count and value (individual_value) but never aggregate_value' do
+      options = described_class.comparison_metric_options
+
+      expect(options).to include(['count', 'count'])
+      expect(options).to include(['value', 'individual_value'])
+      expect(options.map(&:last)).not_to include('aggregate_value')
+    end
+  end
+end

--- a/spec/models/node_grammar_rules_spec.rb
+++ b/spec/models/node_grammar_rules_spec.rb
@@ -56,6 +56,11 @@ RSpec.describe NodeGrammarRules, type: :model do
       expect(described_class.valid_comparison_source_for_metric?(metric: 'value', source: 'moved_piece')).to be(true)
       expect(described_class.valid_comparison_source_for_metric?(metric: 'value', source: 'captured_piece')).to be(true)
     end
+
+    it 'allows distinct piece sources for individual_value but not for aggregate_value' do
+      expect(described_class.valid_comparison_source_for_metric?(metric: 'individual_value', source: 'moved_piece')).to be(true)
+      expect(described_class.valid_comparison_source_for_metric?(metric: 'aggregate_value', source: 'moved_piece')).to be(false)
+    end
   end
 
   describe '.valid_unary_target_for_operator?' do
@@ -73,6 +78,14 @@ RSpec.describe NodeGrammarRules, type: :model do
     it 'rejects captured-piece actor targets for mobility' do
       expect(described_class.valid_unary_target_for_operator?(target: 'captured_piece', operator: 'mobility')).to be(false)
       expect(described_class.valid_unary_target_for_operator?(target: 'enemy_captured_piece', operator: 'mobility')).to be(false)
+    end
+  end
+
+  describe 'NodeGrammarV2.valid_comparison_metric?' do
+    it 'accepts count and individual_value but not aggregate_value' do
+      expect(NodeGrammarV2.valid_comparison_metric?('count')).to be(true)
+      expect(NodeGrammarV2.valid_comparison_metric?('individual_value')).to be(true)
+      expect(NodeGrammarV2.valid_comparison_metric?('aggregate_value')).to be(false)
     end
   end
 end

--- a/spec/models/node_spec.rb
+++ b/spec/models/node_spec.rb
@@ -223,6 +223,62 @@ RSpec.describe Node, type: :model do
         expect(node).not_to be_valid
         expect(node.errors[:data]).to include('cannot use subject-side comparison when targetComparisonSource is prior_board_state')
       end
+
+      it 'accepts a relational individual_value comparison metric' do
+        node = build(:node, :condition, data: {
+          version: 2,
+          kind: 'relational',
+          subject: 'allied',
+          subjectFilter: 'any',
+          subjectComparisonMetric: 'individual_value',
+          subjectComparator: 'greater_than',
+          subjectComparisonSource: 'exact_number',
+          subjectComparisonSourceTotal: 0,
+          operator: 'attack',
+          target: 'enemy',
+          targetFilter: 'any'
+        })
+
+        expect(node).to be_valid
+      end
+
+      it 'rejects aggregate_value as a subject relational comparison metric' do
+        node = build(:node, :condition, data: {
+          version: 2,
+          kind: 'relational',
+          subject: 'allied',
+          subjectFilter: 'any',
+          subjectComparisonMetric: 'aggregate_value',
+          subjectComparator: 'greater_than',
+          subjectComparisonSource: 'exact_number',
+          subjectComparisonSourceTotal: 0,
+          operator: 'attack',
+          target: 'enemy',
+          targetFilter: 'any'
+        })
+
+        expect(node).not_to be_valid
+        expect(node.errors[:data]).to include('has invalid subjectComparisonMetric')
+      end
+
+      it 'rejects aggregate_value as a target relational comparison metric' do
+        node = build(:node, :condition, data: {
+          version: 2,
+          kind: 'relational',
+          subject: 'allied',
+          subjectFilter: 'any',
+          operator: 'attack',
+          target: 'enemy',
+          targetFilter: 'any',
+          targetComparisonMetric: 'aggregate_value',
+          targetComparator: 'greater_than',
+          targetComparisonSource: 'exact_number',
+          targetComparisonSourceTotal: 0
+        })
+
+        expect(node).not_to be_valid
+        expect(node.errors[:data]).to include('has invalid targetComparisonMetric')
+      end
     end
 
     it 'is valid with prototype action data' do


### PR DESCRIPTION
Value redesign: king = Infinity; relational aggregate_value retired

  Why: one global value notion. King must never read cheaper than a pawn, and a king in a material sum fails loudly (Infinity), not silently (0). Aggregate relational value is re-expressible via count — gated off
  and migrated away, engine kept dormant for fast re-enable.

  What:
  - pieceValue/materialValue/individualComparableValue(KING) → Infinity (was 0/null).
  - Relational metrics now count | individual_value; validation rejects relational aggregate_value (both sides). UI shows "value"; editor labels lowercased.
  - Migration 20260515120000: persisted relational aggregate_value → individual_value (subject+target), idempotent; down raises IrreversibleMigration.
  - New shared value_source_options.js (king-inclusive, frozen pools). Old NON_KING_VALUE_SPECIES, the singular+aggregate detector, aggregate engine/strategies, and aggregate tests left dormant, not deleted — see
  DEAD_CODE_INVENTORY.md.

  Testing: TDD-first; full JS green (19 intentional skips); migration idempotency + grammar rejection covered.

  Merge gates:
  1. Confirm the migration won't rewrite template Node rows (handoff excluded templates).
  2. The king-actor grammar change (gating which singulars can be king) must ship with/before this, or value_source_options emits unsatisfiable captured-piece=king variants.

  CI note: 5 pre-existing Ruby baseline failures (node_grammar_rules_spec.rb:55, bots_controller:177, tournaments_controller:28/49, bot_eligibility_checker:359) predate this PR — not regressions