### PR TITLE
Main  value types  census

### DIFF
--- a/app/assets/stylesheets/node_editor.css
+++ b/app/assets/stylesheets/node_editor.css
@@ -1208,7 +1208,7 @@
 
 .node-form-panel.condition-form-panel,
 .node-form-panel.node-form-panel--condition {
-  width: min(46rem, calc(100vw - 0.5rem));
+  width: min(49rem, calc(100vw - 0.5rem));
   max-height: calc(100vh - 28px);
   overflow: hidden;
   display: flex;
@@ -1222,7 +1222,7 @@
 
 .condition-form-layout {
   display: grid;
-  grid-template-columns: 1fr 7.5rem 1fr;
+  grid-template-columns: 1fr 10.5rem 1fr;
   gap: 14px;
   align-items: start;
   justify-content: center;
@@ -1253,7 +1253,7 @@
 .condition-form-operator {
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-start;
   gap: 10px;
   align-self: stretch;
   padding: 16px 14px 15px;
@@ -1347,6 +1347,114 @@
   gap: 8px;
 }
 
+.condition-form-radio-row,
+.condition-form-scope-toggle,
+.condition-form-radio-list,
+.condition-form-comparator-toggle {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 0;
+  border: 1px solid #1a1815;
+  border-radius: 6px;
+  overflow: hidden;
+  background: #2d2a25;
+}
+
+.condition-form-radio-row .condition-form-checkbox,
+.condition-form-scope-toggle .condition-form-checkbox,
+.condition-form-radio-list .condition-form-checkbox,
+.condition-form-comparator-toggle .condition-form-checkbox {
+  display: flex;
+  padding: 0;
+  margin: 0;
+  gap: 0;
+  line-height: 1;
+}
+
+.condition-form-radio-row input[type="radio"],
+.condition-form-scope-toggle input[type="radio"],
+.condition-form-radio-list input[type="radio"],
+.condition-form-comparator-toggle input[type="radio"] {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.condition-form-radio-row span,
+.condition-form-scope-toggle span,
+.condition-form-radio-list span,
+.condition-form-comparator-toggle span {
+  flex: 1;
+  display: block;
+  text-align: center;
+  min-width: 1.7rem;
+  padding: 5px 7px;
+  font-size: 12px;
+  color: #D1D5DB;
+  border-top: 1px solid #1a1815;
+  cursor: pointer;
+}
+
+.condition-form-radio-row label:first-child span,
+.condition-form-scope-toggle label:first-child span,
+.condition-form-radio-list label:first-child span,
+.condition-form-comparator-toggle label:first-child span {
+  border-top: none;
+}
+
+.condition-form-radio-row input[type="radio"]:not(:checked) + span:hover,
+.condition-form-scope-toggle input[type="radio"]:not(:checked) + span:hover,
+.condition-form-radio-list input[type="radio"]:not(:checked) + span:hover,
+.condition-form-comparator-toggle input[type="radio"]:not(:checked) + span:hover {
+  background: #3a352f;
+}
+
+.condition-form-radio-row input[type="radio"]:checked + span,
+.condition-form-scope-toggle input[type="radio"]:checked + span,
+.condition-form-radio-list input[type="radio"]:checked + span,
+.condition-form-comparator-toggle input[type="radio"]:checked + span {
+  background: #A855F7;
+  color: #1a1815;
+  font-weight: 700;
+}
+
+.condition-form-comparator-toggle--locked {
+  pointer-events: none;
+}
+
+.condition-form-comparator-toggle--locked label:not(:first-child) {
+  display: none;
+}
+
+.condition-form-scope-toggle span {
+  padding-top: 8px;
+  padding-bottom: 8px;
+}
+
+#cond-census-region-target .condition-form-field {
+  display: flex;
+  justify-content: center;
+}
+
+.condition-form-square-inputs {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.condition-form-radio-list--disabled,
+.condition-form-radio-row--disabled {
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+.condition-form-positions-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
 .condition-form-inline-triple {
   grid-template-columns: 6.5rem 4rem minmax(0, 1fr);
 }
@@ -1361,7 +1469,7 @@
 .condition-form-comparison-grid--relational select {
   flex: 0 0 auto;
   width: auto;
-  padding: 3px 4px;
+  padding: 6px 4px;
   padding-right: 18px;
   font-size: 11px;
   background: #2d2a25;
@@ -1380,23 +1488,28 @@
   gap: 4px;
   flex: 1 1 auto;
   min-width: 0;
-  max-width: 10rem;
+  max-width: 14rem;
 }
 
 .condition-form-comparison-grid--relational .condition-form-comparison-source-stack select {
-  width: 100%;
+  width: 7rem;
+  min-width: 0;
+  align-self: flex-start;
+  padding-top: 6px;
+  padding-bottom: 6px;
 }
 
 .condition-form-comparison-grid--relational .condition-form-comparison-source-stack input[type="number"] {
-  width: 2.5rem;
-  padding: 3px 4px;
+  width: 3.75rem;
+  padding: 5px 6px;
   background: #2d2a25;
   border: 1px solid #1a1815;
   border-radius: 6px;
   color: #E5E5E5;
-  font-size: 11px;
+  font-size: 12px;
   text-align: center;
   box-sizing: border-box;
+  align-self: flex-start;
 }
 
 .condition-form-comparison-grid--unary {
@@ -1474,6 +1587,49 @@
   padding-top: 10px;
   border-top: 1px solid #3d3a35;
 }
+
+#cond-census-comparison {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid #3d3a35;
+}
+
+#cond-census-comparison .condition-form-comparison__body {
+  padding-top: 0;
+  border-top: none;
+}
+
+#cond-census-target-filter-row {
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0;
+  align-items: center;
+}
+
+#cond-census-target-filter-row .condition-form-checkbox {
+  padding-right: 0;
+  align-self: stretch;
+  align-items: center;
+}
+
+#cond-census-target-filter-row .condition-form-checkbox input {
+  margin: 0;
+}
+
+#cond-census-filter-row .condition-form-inline-pair {
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0;
+  align-items: center;
+}
+
+#cond-census-filter-row .condition-form-checkbox {
+  padding-right: 0;
+}
+
+#cond-census-target-filter {
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
 
 .condition-form-result-mode {
   display: inline-flex;
@@ -1555,12 +1711,6 @@
   margin-top: 0;
 }
 
-.condition-form-comparison-grid--position {
-  display: grid;
-  grid-template-columns: 1fr 3rem auto;
-  gap: 6px;
-  align-items: center;
-}
 
 #cond-position-target-total {
   width: 3rem;

--- a/app/forms/node_form.rb
+++ b/app/forms/node_form.rb
@@ -74,16 +74,12 @@ class NodeForm
       NodeGrammarV2::RELATIONAL_OPERATORS.map { |value| [operator_label(value), value] }
     end
 
-    def special_targeted_operator_options
-      NodeGrammarV2::SPECIAL_TARGETED_OPERATORS.map { |value| [operator_label(value), value] }
-    end
-
     def unary_operator_options
       NodeGrammarV2::UNARY_OPERATORS.map { |value| [operator_label(value), value] }
     end
 
     def condition_form_relational_operator_options
-      [['Targets', 'targets'], ['Shield', 'shield'], ['Adjacent', 'adjacent'], ['Same-Piece', 'same_piece']]
+      [['Targets', 'targets'], ['Shield', 'shield'], ['Adjacent', 'adjacent']]
     end
 
     def condition_form_measure_operator_options

--- a/app/forms/node_form.rb
+++ b/app/forms/node_form.rb
@@ -9,7 +9,7 @@ class NodeForm
   }.freeze
 
   FILTER_LABELS = {
-    'any' => 'Any',
+    'any' => 'Any piece',
     'king' => 'King',
     'queen' => 'Queen',
     'rook' => 'Rook',
@@ -30,12 +30,12 @@ class NodeForm
     'same_piece' => 'Same-Piece',
     'count' => 'Count',
     'mobility' => 'Mobility',
-    'value' => 'Aggregate Value'
+    'value' => 'Value'
   }.freeze
 
   COMPARISON_METRIC_LABELS = {
-    'count' => 'count',
-    'individual_value' => 'value'
+    'count' => 'Count',
+    'individual_value' => 'Value'
   }.freeze
 
   COMPARATOR_SYMBOLS = {

--- a/app/javascript/bot_execution/RULES.md
+++ b/app/javascript/bot_execution/RULES.md
@@ -10,6 +10,14 @@
 - `enemyCapturedPiece` is always part of the moving team.
 - Some conditions refer to `prior_board_state` (PBS) in their comparisons. PBS is the board state at the beginning of the moving team's turn. `afterBoard`, the default state conditions query, is the board state after a potential legal move by moving team.
 
-## Discipline
+## Condition evaluation
 
-_Stub. Add bot_execution-specific rules here as they emerge._
+`ConditionEvaluatorV2.evaluate` dispatches `kind ∈ {relational, census,
+identity}`; any other kind throws. `unary`/`position` are retired and never
+reach the evaluator.
+
+- `evaluateCensus`: no spatial keys → delegates to `evaluateUnary` (kept as
+  the whole-board helper). With `positionAxis` it is region-restricted: the
+  **subject** is filtered to the region, but a distinct-actor **target** is
+  read board-wide. `target: 'prior_board_state'` coerces both sides.
+- `evaluateIdentity`: `same_piece` over subject/target only.

--- a/app/javascript/bot_execution/__tests__/condition_evaluator_v2.test.js
+++ b/app/javascript/bot_execution/__tests__/condition_evaluator_v2.test.js
@@ -2259,7 +2259,7 @@ describe('ConditionEvaluatorV2', () => {
     })
   })
 
-  describe('same_piece evaluation', () => {
+  describe('identity evaluation', () => {
     it('returns true when the current move captures the enemy moved piece', () => {
       const board = buildBoard({
         pieces: {
@@ -2281,12 +2281,9 @@ describe('ConditionEvaluatorV2', () => {
         evaluate(
           {
             version: 2,
-            kind: 'relational',
+            kind: 'identity',
             subject: 'enemy_moved_piece',
-            subjectFilter: 'any',
-            operator: 'same_piece',
-            target: 'captured_piece',
-            targetFilter: 'any'
+            target: 'captured_piece'
           },
           board,
           moveObject
@@ -2315,12 +2312,9 @@ describe('ConditionEvaluatorV2', () => {
         evaluate(
           {
             version: 2,
-            kind: 'relational',
+            kind: 'identity',
             subject: 'captured_piece',
-            subjectFilter: 'any',
-            operator: 'same_piece',
-            target: 'enemy_moved_piece',
-            targetFilter: 'any'
+            target: 'enemy_moved_piece'
           },
           board,
           moveObject
@@ -2352,12 +2346,9 @@ describe('ConditionEvaluatorV2', () => {
         evaluate(
           {
             version: 2,
-            kind: 'relational',
+            kind: 'identity',
             subject: 'enemy_moved_piece',
-            subjectFilter: 'any',
-            operator: 'same_piece',
-            target: 'captured_piece',
-            targetFilter: 'any'
+            target: 'captured_piece'
           },
           board,
           moveObject
@@ -2386,12 +2377,9 @@ describe('ConditionEvaluatorV2', () => {
         evaluate(
           {
             version: 2,
-            kind: 'relational',
+            kind: 'identity',
             subject: 'enemy_moved_piece',
-            subjectFilter: 'any',
-            operator: 'same_piece',
-            target: 'captured_piece',
-            targetFilter: 'any'
+            target: 'captured_piece'
           },
           board,
           moveObject
@@ -2421,12 +2409,9 @@ describe('ConditionEvaluatorV2', () => {
         evaluate(
           {
             version: 2,
-            kind: 'relational',
+            kind: 'identity',
             subject: 'enemy_moved_piece',
-            subjectFilter: 'any',
-            operator: 'same_piece',
-            target: 'captured_piece',
-            targetFilter: 'any'
+            target: 'captured_piece'
           },
           board,
           moveObject
@@ -2462,12 +2447,9 @@ describe('ConditionEvaluatorV2', () => {
         evaluate(
           {
             version: 2,
-            kind: 'relational',
+            kind: 'identity',
             subject: 'enemy_moved_piece',
-            subjectFilter: 'any',
-            operator: 'same_piece',
-            target: 'captured_piece',
-            targetFilter: 'any'
+            target: 'captured_piece'
           },
           board,
           moveObject

--- a/app/javascript/bot_execution/__tests__/condition_evaluator_v2.test.js
+++ b/app/javascript/bot_execution/__tests__/condition_evaluator_v2.test.js
@@ -34,7 +34,7 @@ describe('ConditionEvaluatorV2', () => {
       evaluator.evaluate(
         {
           version: 2,
-          kind: 'unary',
+          kind: 'census',
           subject: 'moved_piece',
           subjectFilter: 'any',
           operator: 'value',
@@ -63,7 +63,7 @@ describe('ConditionEvaluatorV2', () => {
       evaluator.evaluate(
         {
           version: 2,
-          kind: 'unary',
+          kind: 'census',
           subject: 'captured_piece',
           subjectFilter: 'any',
           operator: 'value',
@@ -91,7 +91,7 @@ describe('ConditionEvaluatorV2', () => {
       evaluate(
         {
           version: 2,
-          kind: 'unary',
+          kind: 'census',
           subject: 'moved_piece',
           subjectFilter: 'king',
           operator: 'value',
@@ -159,7 +159,7 @@ describe('ConditionEvaluatorV2', () => {
       evaluator.evaluate(
         {
           version: 2,
-          kind: 'unary',
+          kind: 'census',
           subject: 'enemy_moved_piece',
           subjectFilter: 'any',
           operator: 'mobility',
@@ -192,7 +192,7 @@ describe('ConditionEvaluatorV2', () => {
       evaluate(
         {
           version: 2,
-          kind: 'unary',
+          kind: 'census',
           subject: 'enemy_moved_piece',
           subjectFilter: 'pawn',
           operator: 'count',
@@ -209,7 +209,7 @@ describe('ConditionEvaluatorV2', () => {
       evaluate(
         {
           version: 2,
-          kind: 'unary',
+          kind: 'census',
           subject: 'enemy_moved_piece',
           subjectFilter: 'pawn',
           operator: 'count',
@@ -244,7 +244,7 @@ describe('ConditionEvaluatorV2', () => {
       evaluate(
         {
           version: 2,
-          kind: 'unary',
+          kind: 'census',
           subject: 'enemy_moved_piece',
           subjectFilter: 'pawn',
           operator: 'value',
@@ -279,7 +279,7 @@ describe('ConditionEvaluatorV2', () => {
       evaluate(
         {
           version: 2,
-          kind: 'unary',
+          kind: 'census',
           subject: 'enemy_moved_piece',
           subjectFilter: 'pawn',
           operator: 'mobility',
@@ -314,7 +314,7 @@ describe('ConditionEvaluatorV2', () => {
       evaluate(
         {
           version: 2,
-          kind: 'unary',
+          kind: 'census',
           subject: 'enemy_moved_piece',
           subjectFilter: 'knight',
           subjectFilterMode: 'exclude',
@@ -332,7 +332,7 @@ describe('ConditionEvaluatorV2', () => {
       evaluate(
         {
           version: 2,
-          kind: 'unary',
+          kind: 'census',
           subject: 'enemy_moved_piece',
           subjectFilter: 'pawn',
           subjectFilterMode: 'exclude',
@@ -364,7 +364,7 @@ describe('ConditionEvaluatorV2', () => {
       evaluator.evaluate(
         {
           version: 2,
-          kind: 'unary',
+          kind: 'census',
           subject: 'captured_piece',
           subjectFilter: 'pawn',
           subjectFilterMode: 'exclude',
@@ -393,7 +393,7 @@ describe('ConditionEvaluatorV2', () => {
       evaluate(
         {
           version: 2,
-          kind: 'unary',
+          kind: 'census',
           subject: 'moved_piece',
           subjectFilter: 'knight',
           operator: 'count',
@@ -422,7 +422,7 @@ describe('ConditionEvaluatorV2', () => {
       evaluate(
         {
           version: 2,
-          kind: 'unary',
+          kind: 'census',
           subject: 'moved_piece',
           subjectFilter: 'knight',
           operator: 'mobility',
@@ -451,7 +451,7 @@ describe('ConditionEvaluatorV2', () => {
       evaluate(
         {
           version: 2,
-          kind: 'unary',
+          kind: 'census',
           subject: 'moved_piece',
           subjectFilter: 'knight',
           operator: 'value',
@@ -480,7 +480,7 @@ describe('ConditionEvaluatorV2', () => {
       evaluate(
         {
           version: 2,
-          kind: 'unary',
+          kind: 'census',
           subject: 'captured_piece',
           subjectFilter: 'queen',
           operator: 'count',
@@ -509,7 +509,7 @@ describe('ConditionEvaluatorV2', () => {
       evaluate(
         {
           version: 2,
-          kind: 'unary',
+          kind: 'census',
           subject: 'captured_piece',
           subjectFilter: 'any',
           operator: 'value',
@@ -538,7 +538,7 @@ describe('ConditionEvaluatorV2', () => {
       evaluate(
         {
           version: 2,
-          kind: 'unary',
+          kind: 'census',
           subject: 'captured_piece',
           subjectFilter: 'queen',
           operator: 'value',
@@ -568,7 +568,7 @@ describe('ConditionEvaluatorV2', () => {
       evaluate(
         {
           version: 2,
-          kind: 'unary',
+          kind: 'census',
           subject: 'captured_piece',
           subjectFilter: 'queen',
           operator: 'value',
@@ -598,7 +598,7 @@ describe('ConditionEvaluatorV2', () => {
       evaluate(
         {
           version: 2,
-          kind: 'unary',
+          kind: 'census',
           subject: 'captured_piece',
           subjectFilter: 'queen',
           operator: 'value',
@@ -623,7 +623,7 @@ describe('ConditionEvaluatorV2', () => {
       expect(
         evaluate(
           {
-            version: 2, kind: 'unary',
+            version: 2, kind: 'census',
             subject: 'enemy_captured_piece', subjectFilter: 'any',
             operator: 'count', comparator: 'equal_to',
             target: 'exact_number', targetTotal: 0
@@ -644,7 +644,7 @@ describe('ConditionEvaluatorV2', () => {
       expect(
         evaluate(
           {
-            version: 2, kind: 'unary',
+            version: 2, kind: 'census',
             subject: 'enemy_captured_piece', subjectFilter: 'any',
             operator: 'value', comparator: 'equal_to',
             target: 'exact_number', targetTotal: 0
@@ -670,7 +670,7 @@ describe('ConditionEvaluatorV2', () => {
       expect(
         evaluate(
           {
-            version: 2, kind: 'unary',
+            version: 2, kind: 'census',
             subject: 'enemy_captured_piece', subjectFilter: 'queen',
             operator: 'value', comparator: 'equal_to',
             target: 'exact_number', targetTotal: 9
@@ -694,7 +694,7 @@ describe('ConditionEvaluatorV2', () => {
       expect(
         evaluate(
           {
-            version: 2, kind: 'unary',
+            version: 2, kind: 'census',
             subject: 'enemy_captured_piece', subjectFilter: 'queen',
             operator: 'value', comparator: 'equal_to',
             target: 'exact_number', targetTotal: 9
@@ -2493,7 +2493,7 @@ describe('ConditionEvaluatorV2', () => {
         evaluate(
           {
             version: 2,
-            kind: 'position',
+            kind: 'census', target: 'exact_number',
             subject: 'allied',
             subjectFilter: 'any',
             positionAxis: 'rank',
@@ -2525,7 +2525,7 @@ describe('ConditionEvaluatorV2', () => {
         evaluate(
           {
             version: 2,
-            kind: 'position',
+            kind: 'census', target: 'exact_number',
             subject: 'enemy',
             subjectFilter: 'any',
             positionAxis: 'rank',
@@ -2556,7 +2556,7 @@ describe('ConditionEvaluatorV2', () => {
         evaluate(
           {
             version: 2,
-            kind: 'position',
+            kind: 'census', target: 'exact_number',
             subject: 'enemy',
             subjectFilter: 'any',
             positionAxis: 'rank',
@@ -2587,7 +2587,7 @@ describe('ConditionEvaluatorV2', () => {
         evaluate(
           {
             version: 2,
-            kind: 'position',
+            kind: 'census', target: 'exact_number',
             subject: 'enemy',
             subjectFilter: 'any',
             positionAxis: 'square',
@@ -2617,7 +2617,7 @@ describe('ConditionEvaluatorV2', () => {
         evaluate(
           {
             version: 2,
-            kind: 'position',
+            kind: 'census', target: 'exact_number',
             subject: 'moved_piece',
             subjectFilter: 'any',
             positionAxis: 'rank',
@@ -2647,7 +2647,7 @@ describe('ConditionEvaluatorV2', () => {
         evaluate(
           {
             version: 2,
-            kind: 'position',
+            kind: 'census', target: 'exact_number',
             subject: 'moved_piece',
             subjectFilter: 'any',
             positionAxis: 'rank',
@@ -2684,7 +2684,7 @@ describe('ConditionEvaluatorV2', () => {
         evaluate(
           {
             version: 2,
-            kind: 'position',
+            kind: 'census', target: 'exact_number',
             subject: 'enemy_moved_piece',
             subjectFilter: 'any',
             positionAxis: 'rank',
@@ -2716,7 +2716,7 @@ describe('ConditionEvaluatorV2', () => {
         evaluate(
           {
             version: 2,
-            kind: 'position',
+            kind: 'census', target: 'exact_number',
             subject: 'allied',
             subjectFilter: 'pawn',
             positionAxis: 'rank',
@@ -2748,7 +2748,7 @@ describe('ConditionEvaluatorV2', () => {
         evaluate(
           {
             version: 2,
-            kind: 'position',
+            kind: 'census', target: 'exact_number',
             subject: 'allied',
             subjectFilter: 'any',
             positionAxis: 'rank',
@@ -3275,7 +3275,7 @@ describe('ConditionEvaluatorV2', () => {
       const board = buildBoard({ pieces: { e1: 'wK', e8: 'bK', g7: 'wP' } })
       const moveObject = getMove('g7', 'g8', board, Board.QUEEN)
       expect(evaluate({
-        version: 2, kind: 'unary',
+        version: 2, kind: 'census',
         subject: 'allied', subjectFilter: 'queen',
         operator: 'value', comparator: 'greater_than',
         target: 'prior_board_state'
@@ -3286,7 +3286,7 @@ describe('ConditionEvaluatorV2', () => {
       const board = buildBoard({ pieces: { e1: 'wK', e8: 'bK', e4: 'wP', d5: 'bN' } })
       const moveObject = getMove('e4', 'd5', board)
       expect(evaluate({
-        version: 2, kind: 'unary',
+        version: 2, kind: 'census',
         subject: 'enemy', subjectFilter: 'knight',
         operator: 'value', comparator: 'less_than',
         target: 'prior_board_state'
@@ -3297,7 +3297,7 @@ describe('ConditionEvaluatorV2', () => {
       const board = buildBoard({ pieces: { e1: 'wK', e8: 'bK', e2: 'wP' } })
       const moveObject = getMove('e2', 'e3', board)
       expect(evaluate({
-        version: 2, kind: 'unary',
+        version: 2, kind: 'census',
         subject: 'enemy', subjectFilter: 'queen',
         operator: 'value', comparator: 'equal_to',
         target: 'prior_board_state'

--- a/app/javascript/bot_execution/__tests__/condition_evaluator_v2_census.test.js
+++ b/app/javascript/bot_execution/__tests__/condition_evaluator_v2_census.test.js
@@ -1,0 +1,225 @@
+import { describe, expect, it } from 'vitest'
+
+import Board from 'gameplay/board'
+import ConditionEvaluatorV2 from 'bot_execution/condition_evaluator_v2'
+
+import { buildBoard, getMove } from 'gameplay/__tests__/helpers'
+
+// CEv2 census evaluation regression. unary/position are retired, so behavior
+// is pinned directly (no legacy-kind oracle). Representative coverage.
+
+function evaluate(conditionNode, board, moveObject) {
+  return new ConditionEvaluatorV2().evaluate(conditionNode, { board, moveObject })
+}
+
+describe('CEv2 census without spatial keys (board-wide)', () => {
+  it('evaluates a board-wide count census', () => {
+    const board = buildBoard({
+      pieces: { e1: 'wK', e8: 'bK', a2: 'wP', b2: 'wP', c2: 'wP', h7: 'bP' }
+    })
+    const moveObject = getMove('a2', 'a3', board)
+
+    expect(
+      evaluate(
+        {
+          version: 2, kind: 'census', subject: 'allied', subjectFilter: 'pawn',
+          subjectFilterMode: 'include',
+          operator: 'count', comparator: 'greater_than_or_equal_to',
+          target: 'exact_number', targetTotal: 2
+        },
+        board, moveObject
+      )
+    ).toBe(true)
+  })
+
+  it('evaluates a board-wide value census', () => {
+    const board = buildBoard({
+      pieces: { e1: 'wK', e8: 'bK', d1: 'wQ', a1: 'wR', h7: 'bP' }
+    })
+    const moveObject = getMove('a1', 'b1', board)
+
+    expect(
+      evaluate(
+        {
+          version: 2, kind: 'census', subject: 'allied', subjectFilter: 'any',
+          subjectFilterMode: 'include',
+          operator: 'value', comparator: 'greater_than',
+          target: 'exact_number', targetTotal: 10
+        },
+        board, moveObject
+      )
+    ).toBe(true)
+  })
+
+  it('evaluates a board-wide mobility census', () => {
+    const board = buildBoard({
+      pieces: { e1: 'wK', e8: 'bK', d4: 'wQ', h2: 'wP' }
+    })
+    const moveObject = getMove('h2', 'h3', board)
+
+    expect(
+      evaluate(
+        {
+          version: 2, kind: 'census', subject: 'allied', subjectFilter: 'queen',
+          subjectFilterMode: 'include',
+          operator: 'mobility', comparator: 'greater_than',
+          target: 'exact_number', targetTotal: 0
+        },
+        board, moveObject
+      )
+    ).toBe(true)
+  })
+
+  it('evaluates a board-wide census against prior_board_state', () => {
+    const board = buildBoard({ pieces: { e1: 'wK', e8: 'bK', g7: 'wP' } })
+    const moveObject = getMove('g7', 'g8', board, Board.QUEEN)
+
+    expect(
+      evaluate(
+        {
+          version: 2, kind: 'census', subject: 'moved_piece', subjectFilter: 'any',
+          operator: 'value', comparator: 'greater_than', target: 'prior_board_state'
+        },
+        board, moveObject
+      )
+    ).toBe(true)
+  })
+
+  it('evaluates a board-wide census with a distinct-piece actor target', () => {
+    const board = buildBoard({
+      pieces: { e1: 'wK', e8: 'bK', e4: 'wP', d5: 'bN' }
+    })
+    const moveObject = getMove('e4', 'd5', board)
+
+    expect(
+      evaluate(
+        {
+          version: 2, kind: 'census', subject: 'captured_piece', subjectFilter: 'any',
+          operator: 'value', comparator: 'equal_to',
+          target: 'captured_piece', targetFilter: 'any'
+        },
+        board, moveObject
+      )
+    ).toBe(true)
+  })
+})
+
+describe('CEv2 census with spatial keys (region)', () => {
+  it('evaluates a rank-restricted count census', () => {
+    const board = buildBoard({
+      pieces: { e1: 'wK', e8: 'bK', c5: 'bN', c7: 'bP', h2: 'wP' }
+    })
+    const moveObject = getMove('h2', 'h3', board)
+
+    expect(
+      evaluate(
+        {
+          version: 2, kind: 'census', subject: 'enemy', subjectFilter: 'any',
+          positionAxis: 'rank', positionComparator: 'greater_than_or_equal_to', positionTarget: 4,
+          operator: 'count', comparator: 'equal_to', target: 'exact_number', targetTotal: 3
+        },
+        board, moveObject
+      )
+    ).toBe(true)
+  })
+
+  it('evaluates a file-restricted count census', () => {
+    const board = buildBoard({
+      pieces: { e1: 'wK', e8: 'bK', d1: 'wR', d3: 'wQ', a7: 'wP', h7: 'bP' }
+    })
+    const moveObject = getMove('a7', 'a8', board, Board.QUEEN)
+
+    expect(
+      evaluate(
+        {
+          version: 2, kind: 'census', subject: 'allied', subjectFilter: 'major',
+          subjectFilterMode: 'include',
+          positionAxis: 'file', positionComparator: 'equal_to', positionTarget: 4,
+          operator: 'count', comparator: 'equal_to', target: 'exact_number', targetTotal: 2
+        },
+        board, moveObject
+      )
+    ).toBe(true)
+  })
+
+  it('evaluates a single-square value census', () => {
+    const board = buildBoard({
+      pieces: { e1: 'wK', e8: 'bK', d4: 'wR', h2: 'wP' }
+    })
+    const moveObject = getMove('h2', 'h3', board)
+
+    expect(
+      evaluate(
+        {
+          version: 2, kind: 'census', subject: 'allied', subjectFilter: 'any',
+          positionAxis: 'square', positionComparator: 'equal_to', positionTarget: 27, // d4
+          operator: 'value', comparator: 'equal_to', target: 'exact_number', targetTotal: 5
+        },
+        board, moveObject
+      )
+    ).toBe(true)
+  })
+})
+
+describe('CEv2 census region restriction', () => {
+  it('counts only the pieces inside the region, not the whole board', () => {
+    // Three allied majors; only TWO are on rank >= 5 (moving-team perspective).
+    const board = buildBoard({
+      pieces: { e1: 'wK', e8: 'bK', a5: 'wR', b6: 'wQ', a1: 'wR', h7: 'bP' }
+    })
+    const moveObject = getMove('e1', 'd1', board)
+    const region = {
+      version: 2, kind: 'census', subject: 'allied', subjectFilter: 'major',
+      subjectFilterMode: 'include',
+      positionAxis: 'rank', positionComparator: 'greater_than_or_equal_to', positionTarget: 5,
+      operator: 'count', comparator: 'equal_to', target: 'exact_number', targetTotal: 2
+    }
+
+    expect(evaluate(region, board, moveObject)).toBe(true)
+    expect(evaluate({ ...region, targetTotal: 3 }, board, moveObject)).toBe(false)
+  })
+})
+
+describe('CEv2 census against prior_board_state within a region', () => {
+  it('compares the region-restricted metric between the prior and after frames', () => {
+    // Rook moves from off-region (rank 1) onto rank >= 5: region count 1 -> 2.
+    const board = buildBoard({
+      pieces: { e1: 'wK', e8: 'bK', a6: 'wR', a1: 'wR', h7: 'bP' }
+    })
+    const moveObject = getMove('a1', 'a5', board)
+
+    expect(
+      evaluate(
+        {
+          version: 2, kind: 'census', subject: 'allied', subjectFilter: 'major',
+          subjectFilterMode: 'include',
+          positionAxis: 'rank', positionComparator: 'greater_than_or_equal_to', positionTarget: 5,
+          operator: 'count', comparator: 'greater_than', target: 'prior_board_state'
+        },
+        board, moveObject
+      )
+    ).toBe(true)
+  })
+})
+
+describe('CEv2 census with a distinct-piece target within a region', () => {
+  it('region-restricts the subject while leaving the distinct-piece target un-region-filtered', () => {
+    const board = buildBoard({
+      pieces: { e1: 'wK', e8: 'bK', a5: 'wR', b6: 'wR', d4: 'wN', h7: 'bP' }
+    })
+    const moveObject = getMove('d4', 'e6', board)
+
+    expect(
+      evaluate(
+        {
+          version: 2, kind: 'census', subject: 'allied', subjectFilter: 'major',
+          subjectFilterMode: 'include',
+          positionAxis: 'rank', positionComparator: 'greater_than_or_equal_to', positionTarget: 5,
+          operator: 'count', comparator: 'greater_than',
+          target: 'moved_piece', targetFilter: 'any'
+        },
+        board, moveObject
+      )
+    ).toBe(true)
+  })
+})

--- a/app/javascript/bot_execution/__tests__/condition_evaluator_v2_identity.test.js
+++ b/app/javascript/bot_execution/__tests__/condition_evaluator_v2_identity.test.js
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+
+import ConditionEvaluatorV2 from 'bot_execution/condition_evaluator_v2'
+
+import { buildBoard, getMove, playMoveSequence } from 'gameplay/__tests__/helpers'
+
+// NEW-TDD-RED: the identity kind does not exist in CEv2 yet (the kind switch
+// only knows unary | relational | position; anything else throws
+// "Unknown V2 condition kind"). Every `identity` evaluation below is expected
+// to FAIL until the same_piece extraction lands.
+//
+// Each case also evaluates the equivalent same_piece relational on the SAME
+// board/move. Those legacy assertions are regression baselines and must stay
+// GREEN — a failing legacy assertion is UNEXPECTED, not a missing-feature red.
+
+function evaluate(conditionNode, board, moveObject) {
+  return new ConditionEvaluatorV2().evaluate(conditionNode, { board, moveObject })
+}
+
+describe('CEv2 identity ≡ same_piece relational (NEW-TDD-RED)', () => {
+  function forwardScenario() {
+    const board = buildBoard({ pieces: { e1: 'wK', e8: 'bK', e2: 'wP', f7: 'bP' } })
+    playMoveSequence(board, [
+      { from: 'e2', to: 'e4' },
+      { from: 'f7', to: 'f5' }
+    ])
+    return { board, moveObject: getMove('e4', 'f5', board) }
+  }
+
+  it('matches the same_piece relational result when the current move captures the enemy moved piece', () => {
+    const { board, moveObject } = forwardScenario()
+
+    const relationalResult = evaluate(
+      {
+        version: 2, kind: 'relational',
+        subject: 'enemy_moved_piece', subjectFilter: 'any',
+        operator: 'same_piece', target: 'captured_piece', targetFilter: 'any'
+      },
+      board, moveObject
+    )
+    expect(relationalResult).toBe(true)
+
+    expect(
+      evaluate(
+        { version: 2, kind: 'identity', subject: 'enemy_moved_piece', target: 'captured_piece' },
+        board, moveObject
+      )
+    ).toBe(relationalResult)
+  })
+
+  it('matches the same_piece relational result in the reversed subject/target direction', () => {
+    const { board, moveObject } = forwardScenario()
+
+    const relationalResult = evaluate(
+      {
+        version: 2, kind: 'relational',
+        subject: 'captured_piece', subjectFilter: 'any',
+        operator: 'same_piece', target: 'enemy_moved_piece', targetFilter: 'any'
+      },
+      board, moveObject
+    )
+    expect(relationalResult).toBe(true)
+
+    expect(
+      evaluate(
+        { version: 2, kind: 'identity', subject: 'captured_piece', target: 'enemy_moved_piece' },
+        board, moveObject
+      )
+    ).toBe(relationalResult)
+  })
+
+  it('matches the same_piece relational result for an en passant capture of the enemy moved piece', () => {
+    const board = buildBoard({
+      pieces: { e1: 'wK', e8: 'bK', a7: 'bP', e2: 'wP', f7: 'bP' }
+    })
+    playMoveSequence(board, [
+      { from: 'e2', to: 'e4' },
+      { from: 'a7', to: 'a6' },
+      { from: 'e4', to: 'e5' },
+      { from: 'f7', to: 'f5' }
+    ])
+    const moveObject = getMove('e5', 'f6', board)
+
+    const relationalResult = evaluate(
+      {
+        version: 2, kind: 'relational',
+        subject: 'enemy_moved_piece', subjectFilter: 'any',
+        operator: 'same_piece', target: 'captured_piece', targetFilter: 'any'
+      },
+      board, moveObject
+    )
+    expect(relationalResult).toBe(true)
+
+    expect(
+      evaluate(
+        { version: 2, kind: 'identity', subject: 'enemy_moved_piece', target: 'captured_piece' },
+        board, moveObject
+      )
+    ).toBe(relationalResult)
+  })
+})

--- a/app/javascript/bot_execution/__tests__/condition_evaluator_v2_identity.test.js
+++ b/app/javascript/bot_execution/__tests__/condition_evaluator_v2_identity.test.js
@@ -4,20 +4,14 @@ import ConditionEvaluatorV2 from 'bot_execution/condition_evaluator_v2'
 
 import { buildBoard, getMove, playMoveSequence } from 'gameplay/__tests__/helpers'
 
-// NEW-TDD-RED: the identity kind does not exist in CEv2 yet (the kind switch
-// only knows unary | relational | position; anything else throws
-// "Unknown V2 condition kind"). Every `identity` evaluation below is expected
-// to FAIL until the same_piece extraction lands.
-//
-// Each case also evaluates the equivalent same_piece relational on the SAME
-// board/move. Those legacy assertions are regression baselines and must stay
-// GREEN — a failing legacy assertion is UNEXPECTED, not a missing-feature red.
+// identity asserts piece-equivalence across forward, reversed, and en-passant
+// captures.
 
 function evaluate(conditionNode, board, moveObject) {
   return new ConditionEvaluatorV2().evaluate(conditionNode, { board, moveObject })
 }
 
-describe('CEv2 identity ≡ same_piece relational (NEW-TDD-RED)', () => {
+describe('CEv2 identity evaluation', () => {
   function forwardScenario() {
     const board = buildBoard({ pieces: { e1: 'wK', e8: 'bK', e2: 'wP', f7: 'bP' } })
     playMoveSequence(board, [
@@ -27,49 +21,29 @@ describe('CEv2 identity ≡ same_piece relational (NEW-TDD-RED)', () => {
     return { board, moveObject: getMove('e4', 'f5', board) }
   }
 
-  it('matches the same_piece relational result when the current move captures the enemy moved piece', () => {
+  it('is true when the current move captures the enemy moved piece', () => {
     const { board, moveObject } = forwardScenario()
-
-    const relationalResult = evaluate(
-      {
-        version: 2, kind: 'relational',
-        subject: 'enemy_moved_piece', subjectFilter: 'any',
-        operator: 'same_piece', target: 'captured_piece', targetFilter: 'any'
-      },
-      board, moveObject
-    )
-    expect(relationalResult).toBe(true)
 
     expect(
       evaluate(
         { version: 2, kind: 'identity', subject: 'enemy_moved_piece', target: 'captured_piece' },
         board, moveObject
       )
-    ).toBe(relationalResult)
+    ).toBe(true)
   })
 
-  it('matches the same_piece relational result in the reversed subject/target direction', () => {
+  it('is true in the reversed subject/target direction', () => {
     const { board, moveObject } = forwardScenario()
-
-    const relationalResult = evaluate(
-      {
-        version: 2, kind: 'relational',
-        subject: 'captured_piece', subjectFilter: 'any',
-        operator: 'same_piece', target: 'enemy_moved_piece', targetFilter: 'any'
-      },
-      board, moveObject
-    )
-    expect(relationalResult).toBe(true)
 
     expect(
       evaluate(
         { version: 2, kind: 'identity', subject: 'captured_piece', target: 'enemy_moved_piece' },
         board, moveObject
       )
-    ).toBe(relationalResult)
+    ).toBe(true)
   })
 
-  it('matches the same_piece relational result for an en passant capture of the enemy moved piece', () => {
+  it('is true for an en passant capture of the enemy moved piece', () => {
     const board = buildBoard({
       pieces: { e1: 'wK', e8: 'bK', a7: 'bP', e2: 'wP', f7: 'bP' }
     })
@@ -81,21 +55,11 @@ describe('CEv2 identity ≡ same_piece relational (NEW-TDD-RED)', () => {
     ])
     const moveObject = getMove('e5', 'f6', board)
 
-    const relationalResult = evaluate(
-      {
-        version: 2, kind: 'relational',
-        subject: 'enemy_moved_piece', subjectFilter: 'any',
-        operator: 'same_piece', target: 'captured_piece', targetFilter: 'any'
-      },
-      board, moveObject
-    )
-    expect(relationalResult).toBe(true)
-
     expect(
       evaluate(
         { version: 2, kind: 'identity', subject: 'enemy_moved_piece', target: 'captured_piece' },
         board, moveObject
       )
-    ).toBe(relationalResult)
+    ).toBe(true)
   })
 })

--- a/app/javascript/bot_execution/__tests__/position_analysis.test.js
+++ b/app/javascript/bot_execution/__tests__/position_analysis.test.js
@@ -25,7 +25,7 @@ describe('position evaluation for captured-type actors', () => {
       evaluate(
         {
           version: 2,
-          kind: 'position',
+          kind: 'census', target: 'exact_number',
           subject: 'captured_piece',
           subjectFilter: 'any',
           positionAxis: 'rank',
@@ -56,7 +56,7 @@ describe('position evaluation for captured-type actors', () => {
       evaluate(
         {
           version: 2,
-          kind: 'position',
+          kind: 'census', target: 'exact_number',
           subject: 'captured_piece',
           subjectFilter: 'any',
           positionAxis: 'rank',
@@ -100,7 +100,7 @@ describe('position evaluation for captured-type actors', () => {
       evaluate(
         {
           version: 2,
-          kind: 'position',
+          kind: 'census', target: 'exact_number',
           subject: 'enemy_captured_piece',
           subjectFilter: 'any',
           positionAxis: 'rank',
@@ -131,7 +131,7 @@ describe('position evaluation: mobility operator', () => {
     expect(
       evaluate(
         {
-          version: 2, kind: 'position',
+          version: 2, kind: 'census', target: 'exact_number',
           subject: 'allied', subjectFilter: 'any',
           positionAxis: 'rank', positionComparator: 'equal_to', positionTarget: 4,
           operator: 'mobility', comparator: 'greater_than', targetTotal: 0
@@ -150,7 +150,7 @@ describe('position evaluation: mobility operator', () => {
     expect(
       evaluate(
         {
-          version: 2, kind: 'position',
+          version: 2, kind: 'census', target: 'exact_number',
           subject: 'allied', subjectFilter: 'any',
           positionAxis: 'rank', positionComparator: 'equal_to', positionTarget: 4,
           operator: 'mobility', comparator: 'equal_to', targetTotal: 0
@@ -169,7 +169,7 @@ describe('position evaluation: mobility operator', () => {
     expect(
       evaluate(
         {
-          version: 2, kind: 'position',
+          version: 2, kind: 'census', target: 'exact_number',
           subject: 'allied', subjectFilter: 'any',
           positionAxis: 'rank', positionComparator: 'equal_to', positionTarget: 5,
           operator: 'mobility', comparator: 'equal_to', targetTotal: 0
@@ -188,7 +188,7 @@ describe('position evaluation: mobility operator', () => {
     expect(
       evaluate(
         {
-          version: 2, kind: 'position',
+          version: 2, kind: 'census', target: 'exact_number',
           subject: 'enemy', subjectFilter: 'any',
           positionAxis: 'rank', positionComparator: 'equal_to', positionTarget: 4,
           operator: 'mobility', comparator: 'greater_than', targetTotal: 0
@@ -207,7 +207,7 @@ describe('position evaluation: mobility operator', () => {
     expect(
       evaluate(
         {
-          version: 2, kind: 'position',
+          version: 2, kind: 'census', target: 'exact_number',
           subject: 'enemy', subjectFilter: 'any',
           positionAxis: 'rank', positionComparator: 'equal_to', positionTarget: 6,
           operator: 'mobility', comparator: 'equal_to', targetTotal: 0
@@ -228,7 +228,7 @@ describe('position evaluation: mobility operator', () => {
     expect(
       evaluate(
         {
-          version: 2, kind: 'position',
+          version: 2, kind: 'census', target: 'exact_number',
           subject: 'allied', subjectFilter: 'any',
           positionAxis: 'rank', positionComparator: 'equal_to', positionTarget: 5,
           operator: 'mobility', comparator: 'less_than', targetTotal: 100

--- a/app/javascript/bot_execution/__tests__/unary_condition_evaluation.test.js
+++ b/app/javascript/bot_execution/__tests__/unary_condition_evaluation.test.js
@@ -31,7 +31,7 @@ describe('unary condition evaluation — group mobility aggregation', () => {
     expect(
       evaluate(
         {
-          version: 2, kind: 'unary',
+          version: 2, kind: 'census',
           subject: 'allied', subjectFilter: 'bishop',
           operator: 'mobility', comparator: 'equal_to',
           target: 'exact_number', targetTotal: 13
@@ -47,7 +47,7 @@ describe('unary condition evaluation — group mobility aggregation', () => {
     expect(
       evaluate(
         {
-          version: 2, kind: 'unary',
+          version: 2, kind: 'census',
           subject: 'allied', subjectFilter: 'bishop',
           operator: 'mobility', comparator: 'equal_to',
           target: 'exact_number', targetTotal: 7

--- a/app/javascript/bot_execution/condition_evaluator_v2.js
+++ b/app/javascript/bot_execution/condition_evaluator_v2.js
@@ -11,12 +11,12 @@ class ConditionEvaluatorV2 {
     evaluate(conditionNode, analysis) {
       const v2Analysis = this.v2AnalysisFor(analysis)
       switch (conditionNode.kind) {
-        case "unary":
-          return this.evaluateUnary(conditionNode, v2Analysis)
         case "relational":
           return this.evaluateRelational(conditionNode, v2Analysis)
-        case "position":
-          return this.evaluatePosition(conditionNode, v2Analysis)
+        case "census":
+          return this.evaluateCensus(conditionNode, v2Analysis)
+        case "identity":
+          return this.evaluateIdentity(conditionNode, v2Analysis)
         default:
           throw new Error(`Unknown V2 condition kind: ${conditionNode.kind}`)
       }
@@ -237,28 +237,64 @@ class ConditionEvaluatorV2 {
       }
     }
 
-    evaluatePosition(conditionNode, analysis) {
-      return profileCollector.measure('condition.v2.position', () => {
+    evaluateCensus(conditionNode, analysis) {
+      const hasRegion = conditionNode.positionAxis !== undefined && conditionNode.positionAxis !== null
+      if (!hasRegion) {
+        return this.evaluateUnary(conditionNode, analysis)
+      }
+      return profileCollector.measure('condition.v2.census', () => {
         if (conditionNode.subject === "enemy_moved_piece") {
           const resolved = analysis.resolvedEnemyMovedPiece()
           if (!resolved || !resolved.presentOnBoard) { return false }
         }
+        if (!this.unaryTargetCanEvaluate(conditionNode, analysis)) { return false }
 
-        const positions = analysis.positionFilteredPositions({
-          actor: conditionNode.subject,
-          filter: conditionNode.subjectFilter || "any",
-          filterMode: conditionNode.subjectFilterMode || null,
-          positionAxis: conditionNode.positionAxis,
-          positionComparator: conditionNode.positionComparator,
-          positionTarget: conditionNode.positionTarget
+        const operator = conditionNode.operator
+        const leftTotal = analysis.positionMetricTotal({
+          positions: this.censusRegionPositions(conditionNode, analysis),
+          operator
         })
+        const rightTotal = this.censusTargetTotal(conditionNode, analysis)
+        const coerce = coerceFor(conditionNode.target === "prior_board_state")
+        return compareTotals(conditionNode.comparator, coerce(leftTotal), coerce(rightTotal))
+      })
+    }
 
-        const metricTotal = analysis.positionMetricTotal({
-          positions,
-          operator: conditionNode.operator
+    censusRegionPositions(conditionNode, analysis, boardScope = "after") {
+      return analysis.positionFilteredPositions({
+        actor: conditionNode.subject,
+        filter: conditionNode.subjectFilter || "any",
+        filterMode: conditionNode.subjectFilterMode || null,
+        positionAxis: conditionNode.positionAxis,
+        positionComparator: conditionNode.positionComparator,
+        positionTarget: conditionNode.positionTarget,
+        boardScope
+      })
+    }
+
+    censusTargetTotal(conditionNode, analysis) {
+      const operator = conditionNode.operator
+      if (conditionNode.target === "exact_number") { return conditionNode.targetTotal }
+      if (conditionNode.target === "prior_board_state") {
+        return analysis.positionMetricTotal({
+          positions: this.censusRegionPositions(conditionNode, analysis, "prior"),
+          operator,
+          boardScope: "prior"
         })
+      }
+      // Distinct-actor target: read board-wide. The region filters the
+      // subject only; the comparison piece lives elsewhere on the board.
+      return analysis.unaryTotal({
+        actor: conditionNode.target,
+        filter: conditionNode.targetFilter || "any",
+        filterMode: conditionNode.targetFilterMode || null,
+        operator
+      })
+    }
 
-        return compareTotals(conditionNode.comparator, metricTotal, conditionNode.targetTotal)
+    evaluateIdentity(conditionNode, analysis) {
+      return profileCollector.measure('condition.v2.identity', () => {
+        return analysis.samePiece({ subject: conditionNode.subject, target: conditionNode.target })
       })
     }
 

--- a/app/javascript/bot_execution/condition_evaluator_v2.js
+++ b/app/javascript/bot_execution/condition_evaluator_v2.js
@@ -61,7 +61,6 @@ class ConditionEvaluatorV2 {
     evaluateRelational(conditionNode, analysis) {
       return profileCollector.measure('condition.v2.relational', () => {
         const operator = conditionNode.operator
-        if (operator === "same_piece") { return analysis.samePiece({ subject: conditionNode.subject, target: conditionNode.target }) }
         if (!this.relationalSingularActorsCanEvaluate(conditionNode, analysis)) {
           profileCollector.increment('condition.v2.relational.failed.singular_actors')
           return false

--- a/app/javascript/editorV2/RULES.md
+++ b/app/javascript/editorV2/RULES.md
@@ -1,0 +1,23 @@
+# editorV2 rules
+
+## Condition sentence structure — single source of truth
+
+`NodePresenter::SENTENCE_SPEC` (Ruby) is the only definition of which
+chunks a condition kind renders and which payload field feeds each.
+Both render paths interpret it: `NodePresenter` server-side, and
+`conditionPreviewFormatter.js` client-side via the served spec (the
+`shared/_condition_sentence_spec` partial). Do not reintroduce per-kind
+branching in the formatter.
+
+- Adding or changing a chunk role touches a fixed set: `SENTENCE_SPEC`
+  and `ROLE_KEYS` (NodePresenter), `formatConditionPreviewChunk` and
+  `parseChunkDataset` (`conditionPreviewFormatter.js`), and the
+  `_condition.html.erb` data-attrs. Miss one and the role silently
+  half-works.
+- `app/javascript/vitest.setup.js` holds a test-scoped mirror of
+  `SENTENCE_SPEC`. Drift is silent — JS tests pass against stale
+  structure while production uses the served spec. `node_presenter_spec`
+  locks the Ruby side; keep the mirror in step.
+- Wording lives only in the JS formatter (`subjectLabel`,
+  `operatorLabel`, `positionAxisPreview`, …). Ruby chunks carry raw
+  enum tokens, never display strings.

--- a/app/javascript/editorV2/__tests__/CensusRegionPbsExampleGenerator.test.js
+++ b/app/javascript/editorV2/__tests__/CensusRegionPbsExampleGenerator.test.js
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+
+import ConditionEvaluatorV2 from 'bot_execution/condition_evaluator_v2'
+import generateConditionExamples from '../panels/condition_preview/orchestrator'
+
+// NEW-TDD-RED: end-to-end efficacy. These assert the whole condition_preview
+// pipeline can produce legal, satisfying examples for region-constrained
+// census conditions compared against prior_board_state — the hardest cell
+// (the "cart"): census must be a supported plan, regionFromPlan must carry
+// the spatial region into both frames, and the cross-frame generator must
+// force the prior/after delta to land inside the region. Expected to FAIL
+// until both the evaluator restructure and the generator fix land.
+
+function seededRandom(seed = 12345) {
+  let current = seed >>> 0
+  return () => {
+    current = (current * 1664525 + 1013904223) >>> 0
+    return current / 0x100000000
+  }
+}
+
+function evaluateExample(payload, example) {
+  const evaluator = new ConditionEvaluatorV2()
+  return evaluator.evaluate(payload, {
+    board: example.priorBoard,
+    moveObject: example.moveObject
+  })
+}
+
+describe('condition_preview generates region-constrained PBS census examples (NEW-TDD-RED)', () => {
+  it('generates satisfying examples for an increasing single-rank census against prior_board_state', () => {
+    const payload = {
+      version: 2, kind: 'census', subject: 'allied', subjectFilter: 'rook',
+      subjectFilterMode: 'include',
+      positionAxis: 'rank', positionComparator: 'equal_to', positionTarget: 5,
+      operator: 'count', comparator: 'greater_than', target: 'prior_board_state'
+    }
+
+    const preview = generateConditionExamples([payload], { random: seededRandom(31) })
+
+    expect(preview.status).toBe('ready')
+    expect(preview.examples.length).toBeGreaterThan(0)
+    preview.examples.forEach(example => {
+      expect(evaluateExample(payload, example)).toBe(true)
+    })
+  })
+
+  it('generates satisfying examples for a decreasing single-file census against prior_board_state', () => {
+    const payload = {
+      version: 2, kind: 'census', subject: 'enemy', subjectFilter: 'any',
+      positionAxis: 'file', positionComparator: 'equal_to', positionTarget: 4,
+      operator: 'count', comparator: 'less_than', target: 'prior_board_state'
+    }
+
+    const preview = generateConditionExamples([payload], { random: seededRandom(53) })
+
+    expect(preview.status).toBe('ready')
+    expect(preview.examples.length).toBeGreaterThan(0)
+    preview.examples.forEach(example => {
+      expect(evaluateExample(payload, example)).toBe(true)
+    })
+  })
+})

--- a/app/javascript/editorV2/__tests__/ConditionChainExampleGenerator.test.js
+++ b/app/javascript/editorV2/__tests__/ConditionChainExampleGenerator.test.js
@@ -53,7 +53,7 @@ describe('ConditionChainExampleGenerator', () => {
 
   it('generates examples for a single unary condition', () => {
     const payload = {
-      kind: 'unary',
+      kind: 'census',
       subject: 'allied',
       subjectFilter: 'any',
       operator: 'count',

--- a/app/javascript/editorV2/__tests__/ConditionExampleGenerator.test.js
+++ b/app/javascript/editorV2/__tests__/ConditionExampleGenerator.test.js
@@ -1183,10 +1183,9 @@ describe('ConditionExampleGenerator', () => {
     // sets movedPieceEndPosition = capturedSquare, which the samePiece
     // predicate compares against the captured piece's position.
     const payload = {
-      version: 2, kind: 'relational',
-      subject: 'enemy_moved_piece', subjectFilter: 'any',
-      operator: 'same_piece',
-      target: 'captured_piece', targetFilter: 'any'
+      version: 2, kind: 'identity',
+      subject: 'enemy_moved_piece',
+      target: 'captured_piece'
     }
 
     const preview = generateConditionExamples(payload, {
@@ -1208,10 +1207,9 @@ describe('ConditionExampleGenerator', () => {
     // Standard reverse-gen path also benefits from the same_piece skip in
     // seed_builder. Restricting moveKinds to 'standard' isolates this path.
     const payload = {
-      version: 2, kind: 'relational',
-      subject: 'enemy_moved_piece', subjectFilter: 'any',
-      operator: 'same_piece',
-      target: 'captured_piece', targetFilter: 'any'
+      version: 2, kind: 'identity',
+      subject: 'enemy_moved_piece',
+      target: 'captured_piece'
     }
 
     const preview = generateConditionExamples(payload, {
@@ -1232,10 +1230,9 @@ describe('ConditionExampleGenerator', () => {
     // attack runs through skeleton building.
     const payloads = [
       {
-        version: 2, kind: 'relational',
-        subject: 'enemy_moved_piece', subjectFilter: 'any',
-        operator: 'same_piece',
-        target: 'captured_piece', targetFilter: 'any'
+        version: 2, kind: 'identity',
+        subject: 'enemy_moved_piece',
+        target: 'captured_piece'
       },
       {
         version: 2, kind: 'relational',
@@ -1494,10 +1491,9 @@ describe('ConditionExampleGenerator', () => {
   })
   it('routes a same_piece chain (enemy_moved_piece + captured_piece) through forward generation (8f)', () => {
     const payload = {
-      version: 2, kind: 'relational',
-      subject: 'enemy_moved_piece', subjectFilter: 'any',
-      operator: 'same_piece',
-      target: 'captured_piece', targetFilter: 'any'
+      version: 2, kind: 'identity',
+      subject: 'enemy_moved_piece',
+      target: 'captured_piece'
     }
     const preview = generateConditionExamples(payload, { random: seededRandom(2015) })
     expect(preview.status).toBe('ready')

--- a/app/javascript/editorV2/__tests__/ConditionExampleGenerator.test.js
+++ b/app/javascript/editorV2/__tests__/ConditionExampleGenerator.test.js
@@ -439,7 +439,7 @@ describe('ConditionExampleGenerator', () => {
 
   it('uses forward generation for moved_piece mobility < prior_board_state', () => {
     const payload = {
-      version: 2, kind: 'unary',
+      version: 2, kind: 'census',
       subject: 'moved_piece', subjectFilter: 'any',
       operator: 'mobility', comparator: 'less_than',
       target: 'prior_board_state'
@@ -518,7 +518,7 @@ describe('ConditionExampleGenerator', () => {
 
   it('flags contradiction when a pawn is required on an illegal rank', () => {
     const payload = {
-      version: 2, kind: 'position',
+      version: 2, kind: 'census', target: 'exact_number',
       subject: 'allied', subjectFilter: 'pawn', operator: 'count',
       positionAxis: 'rank', positionComparator: 'equal_to', positionTarget: 0,
       comparator: 'greater_than_or_equal_to', targetTotal: 1
@@ -530,7 +530,7 @@ describe('ConditionExampleGenerator', () => {
 
   it('flags contradiction when a directional rank constraint resolves to only an illegal pawn rank', () => {
     const payload = {
-      version: 2, kind: 'position',
+      version: 2, kind: 'census', target: 'exact_number',
       subject: 'allied', subjectFilter: 'pawn', operator: 'count',
       positionAxis: 'rank', positionComparator: 'less_than', positionTarget: 1,
       comparator: 'greater_than_or_equal_to', targetTotal: 1
@@ -542,7 +542,7 @@ describe('ConditionExampleGenerator', () => {
 
   it('flags contradiction when a unary singular actor has count > 1', () => {
     const payload = {
-      version: 2, kind: 'unary',
+      version: 2, kind: 'census',
       subject: 'moved_piece', subjectFilter: 'any',
       operator: 'count', comparator: 'equal_to',
       target: 'exact_number', targetTotal: 2
@@ -554,7 +554,7 @@ describe('ConditionExampleGenerator', () => {
 
   it('flags contradiction when moved_piece is required to have count = 0', () => {
     const payload = {
-      version: 2, kind: 'unary',
+      version: 2, kind: 'census',
       subject: 'moved_piece', subjectFilter: 'any',
       operator: 'count', comparator: 'equal_to',
       target: 'exact_number', targetTotal: 0
@@ -566,7 +566,7 @@ describe('ConditionExampleGenerator', () => {
 
   it('uses forward generation for allied any mobility > prior_board_state via group-mobility-increase pattern', () => {
     const payload = {
-      version: 2, kind: 'unary',
+      version: 2, kind: 'census',
       subject: 'allied', subjectFilter: 'any',
       operator: 'mobility', comparator: 'greater_than',
       target: 'prior_board_state'
@@ -578,7 +578,7 @@ describe('ConditionExampleGenerator', () => {
 
   it('falls back to Strategy A direct-blocking when no king is available to put in check', () => {
     const payload = {
-      version: 2, kind: 'unary',
+      version: 2, kind: 'census',
       subject: 'enemy', subjectFilter: 'pawn',
       operator: 'mobility', comparator: 'equal_to',
       target: 'exact_number', targetTotal: 0
@@ -606,7 +606,7 @@ describe('ConditionExampleGenerator', () => {
 
   it('builds verified examples via hint resolver for lone enemy mobility = 0', () => {
     const payload = {
-      version: 2, kind: 'unary',
+      version: 2, kind: 'census',
       subject: 'enemy', subjectFilter: 'any',
       operator: 'mobility', comparator: 'equal_to',
       target: 'exact_number', targetTotal: 0
@@ -622,7 +622,7 @@ describe('ConditionExampleGenerator', () => {
   it('builds verified examples via hint resolver for the checkmate chain', () => {
     const payloads = [
       { version: 2, kind: 'relational', subject: 'allied', subjectFilter: 'any', operator: 'attack', target: 'enemy', targetFilter: 'king' },
-      { version: 2, kind: 'unary', subject: 'enemy', subjectFilter: 'any', operator: 'mobility', comparator: 'equal_to', target: 'exact_number', targetTotal: 0 }
+      { version: 2, kind: 'census', subject: 'enemy', subjectFilter: 'any', operator: 'mobility', comparator: 'equal_to', target: 'exact_number', targetTotal: 0 }
     ]
     const seeds = [1001, 1002, 1003, 1004, 1005]
     const success = seeds.some(seed => {
@@ -660,7 +660,7 @@ describe('ConditionExampleGenerator', () => {
 
   it('uses forward generation for moved_piece mobility > prior_board_state', () => {
     const payload = {
-      version: 2, kind: 'unary',
+      version: 2, kind: 'census',
       subject: 'moved_piece', subjectFilter: 'any',
       operator: 'mobility', comparator: 'greater_than',
       target: 'prior_board_state'
@@ -672,7 +672,7 @@ describe('ConditionExampleGenerator', () => {
 
   it('uses forward generation for moved_piece value > prior_board_state via promotion', () => {
     const payload = {
-      version: 2, kind: 'unary',
+      version: 2, kind: 'census',
       subject: 'moved_piece', subjectFilter: 'any',
       operator: 'value', comparator: 'greater_than',
       target: 'prior_board_state'
@@ -727,7 +727,7 @@ describe('ConditionExampleGenerator', () => {
   it('builds verified examples for unary captured piece count equal to 1', () => {
     const payload = {
       version: 2,
-      kind: 'unary',
+      kind: 'census',
       subject: 'captured_piece',
       subjectFilter: 'any',
       operator: 'count',
@@ -748,7 +748,7 @@ describe('ConditionExampleGenerator', () => {
   it('builds verified examples for unary captured piece count greater than 0', () => {
     const payload = {
       version: 2,
-      kind: 'unary',
+      kind: 'census',
       subject: 'captured_piece',
       subjectFilter: 'any',
       operator: 'count',
@@ -769,7 +769,7 @@ describe('ConditionExampleGenerator', () => {
   it('builds verified examples for unary enemy_captured_piece count equal to 1', () => {
     const payload = {
       version: 2,
-      kind: 'unary',
+      kind: 'census',
       subject: 'enemy_captured_piece',
       subjectFilter: 'any',
       operator: 'count',
@@ -790,7 +790,7 @@ describe('ConditionExampleGenerator', () => {
   it('builds verified examples for unary enemy_captured_piece count greater than 0', () => {
     const payload = {
       version: 2,
-      kind: 'unary',
+      kind: 'census',
       subject: 'enemy_captured_piece',
       subjectFilter: 'any',
       operator: 'count',
@@ -1131,7 +1131,7 @@ describe('ConditionExampleGenerator', () => {
 
   it('produces en-passant examples for a chain where moved_piece IS the relation subject (involved variant)', () => {
     const payload = {
-      version: 2, kind: 'unary',
+      version: 2, kind: 'census',
       subject: 'moved_piece', subjectFilter: 'any',
       operator: 'count', comparator: 'equal_to',
       target: 'exact_number', targetTotal: 1
@@ -1154,7 +1154,7 @@ describe('ConditionExampleGenerator', () => {
 
   it('produces en-passant examples for a chain where captured_piece (not moved_piece) is the relation subject (separate variant)', () => {
     const payload = {
-      version: 2, kind: 'unary',
+      version: 2, kind: 'census',
       subject: 'captured_piece', subjectFilter: 'pawn',
       subjectFilterMode: 'include',
       operator: 'count', comparator: 'equal_to',
@@ -1258,7 +1258,7 @@ describe('ConditionExampleGenerator', () => {
     // The condition is about the enemy king's count — independent of which
     // move occurred. En-passant should still appear in the example mix.
     const payload = {
-      version: 2, kind: 'unary',
+      version: 2, kind: 'census',
       subject: 'enemy', subjectFilter: 'king',
       subjectFilterMode: 'include',
       operator: 'count', comparator: 'equal_to',
@@ -1282,7 +1282,7 @@ describe('ConditionExampleGenerator', () => {
 
   it('generates verified examples for a position count condition on rank', () => {
     const payload = {
-      kind: 'position',
+      kind: 'census', target: 'exact_number',
       subject: 'allied',
       subjectFilter: 'any',
       positionAxis: 'rank',
@@ -1304,7 +1304,7 @@ describe('ConditionExampleGenerator', () => {
 
   it('generates verified examples for a position count condition on file', () => {
     const payload = {
-      kind: 'position',
+      kind: 'census', target: 'exact_number',
       subject: 'enemy',
       subjectFilter: 'any',
       positionAxis: 'file',
@@ -1326,7 +1326,7 @@ describe('ConditionExampleGenerator', () => {
 
   it('generates verified examples for a position count condition on moved_piece', () => {
     const payload = {
-      kind: 'position',
+      kind: 'census', target: 'exact_number',
       subject: 'moved_piece',
       subjectFilter: 'any',
       positionAxis: 'rank',
@@ -1348,7 +1348,7 @@ describe('ConditionExampleGenerator', () => {
 
   it('generates verified examples for a position value condition', () => {
     const payload = {
-      kind: 'position',
+      kind: 'census', target: 'exact_number',
       subject: 'allied',
       subjectFilter: 'any',
       positionAxis: 'rank',
@@ -1370,7 +1370,7 @@ describe('ConditionExampleGenerator', () => {
 
   it('generates verified examples for an enemy_moved_piece position condition', () => {
     const payload = {
-      kind: 'position',
+      kind: 'census', target: 'exact_number',
       subject: 'enemy_moved_piece',
       subjectFilter: 'any',
       positionAxis: 'rank',
@@ -1392,7 +1392,7 @@ describe('ConditionExampleGenerator', () => {
 
   it('generates verified examples for a position count condition on square (a1)', () => {
     const payload = {
-      kind: 'position',
+      kind: 'census', target: 'exact_number',
       subject: 'allied',
       subjectFilter: 'any',
       positionAxis: 'square',
@@ -1414,7 +1414,7 @@ describe('ConditionExampleGenerator', () => {
 
   it('generates verified examples for an enemy position count condition on square (a1)', () => {
     const payload = {
-      kind: 'position',
+      kind: 'census', target: 'exact_number',
       subject: 'enemy',
       subjectFilter: 'any',
       positionAxis: 'square',
@@ -1436,7 +1436,7 @@ describe('ConditionExampleGenerator', () => {
 
   it('generates promotion examples for a position count condition on rank 8', () => {
     const payload = {
-      kind: 'position',
+      kind: 'census', target: 'exact_number',
       subject: 'moved_piece',
       subjectFilter: 'any',
       positionAxis: 'rank',
@@ -1474,7 +1474,7 @@ describe('ConditionExampleGenerator', () => {
 
   it('generates castle examples for a chain that does not preclude castle (allied bishop on rank 4 count = 1)', () => {
     const payload = {
-      kind: 'position',
+      kind: 'census', target: 'exact_number',
       subject: 'allied',
       subjectFilter: 'bishop',
       positionAxis: 'rank',
@@ -1546,7 +1546,7 @@ describe('ConditionExampleGenerator', () => {
 
   it('routes a PBS-direction equal mobility chain through forward generation (M8)', () => {
     const payload = {
-      version: 2, kind: 'unary',
+      version: 2, kind: 'census',
       subject: 'moved_piece', subjectFilter: 'knight', subjectFilterMode: 'include',
       operator: 'mobility', comparator: 'equal_to',
       target: 'prior_board_state'
@@ -1562,7 +1562,7 @@ describe('ConditionExampleGenerator', () => {
 
   it('routes a PBS-direction less-than mobility chain through forward generation (M8)', () => {
     const payload = {
-      version: 2, kind: 'unary',
+      version: 2, kind: 'census',
       subject: 'moved_piece', subjectFilter: 'knight', subjectFilterMode: 'include',
       operator: 'mobility', comparator: 'less_than',
       target: 'prior_board_state'
@@ -1578,7 +1578,7 @@ describe('ConditionExampleGenerator', () => {
 
   it('routes a moved_piece PBS mobility chain through forward generation (M6)', () => {
     const payload = {
-      version: 2, kind: 'unary',
+      version: 2, kind: 'census',
       subject: 'moved_piece', subjectFilter: 'knight', subjectFilterMode: 'include',
       operator: 'mobility', comparator: 'greater_than',
       target: 'prior_board_state'
@@ -1735,13 +1735,13 @@ describe('ConditionExampleGenerator', () => {
     // unary value hints must be satisfied jointly. Caps at value > 34 per side.
     const payloads = [
       {
-        version: 2, kind: 'unary',
+        version: 2, kind: 'census',
         subject: 'allied', subjectFilter: 'any',
         operator: 'value', comparator: 'greater_than',
         target: 'exact_number', targetTotal: 34
       },
       {
-        version: 2, kind: 'unary',
+        version: 2, kind: 'census',
         subject: 'enemy', subjectFilter: 'any',
         operator: 'value', comparator: 'greater_than',
         target: 'exact_number', targetTotal: 34
@@ -1781,7 +1781,7 @@ describe('ConditionExampleGenerator', () => {
 
   it('routes a unary value pair chain (captured_piece >= moved_piece) through forward generation (8c-cleanup)', () => {
     const payload = {
-      version: 2, kind: 'unary',
+      version: 2, kind: 'census',
       subject: 'captured_piece', subjectFilter: 'any',
       operator: 'value', comparator: 'greater_than_or_equal_to',
       target: 'moved_piece', targetFilter: 'any'
@@ -1797,7 +1797,7 @@ describe('ConditionExampleGenerator', () => {
 
   it('routes a unary value pair chain (enemy_moved_piece > enemy_captured_piece) through forward generation (8c-cleanup)', () => {
     const payload = {
-      version: 2, kind: 'unary',
+      version: 2, kind: 'census',
       subject: 'enemy_moved_piece', subjectFilter: 'any',
       operator: 'value', comparator: 'greater_than',
       target: 'enemy_captured_piece', targetFilter: 'any'
@@ -1812,7 +1812,7 @@ describe('ConditionExampleGenerator', () => {
 
   it('routes a unary count pair chain (captured_piece = enemy_moved_piece, capture present) through forward generation (8c-cleanup)', () => {
     const payload = {
-      version: 2, kind: 'unary',
+      version: 2, kind: 'census',
       subject: 'captured_piece', subjectFilter: 'any',
       operator: 'count', comparator: 'equal_to',
       target: 'enemy_moved_piece', targetFilter: 'any'
@@ -1833,13 +1833,13 @@ describe('ConditionExampleGenerator', () => {
     // inventory's range arithmetic returning null from buildChainConstraints).
     const payloads = [
       {
-        version: 2, kind: 'unary',
+        version: 2, kind: 'census',
         subject: 'allied', subjectFilter: 'any',
         operator: 'count', comparator: 'equal_to',
         target: 'exact_number', targetTotal: 5
       },
       {
-        version: 2, kind: 'unary',
+        version: 2, kind: 'census',
         subject: 'allied', subjectFilter: 'any',
         operator: 'count', comparator: 'equal_to',
         target: 'exact_number', targetTotal: 0
@@ -1855,13 +1855,13 @@ describe('ConditionExampleGenerator', () => {
     // (from bishop), but allied/any count.max = 0. Empty range → unsat.
     const payloads = [
       {
-        version: 2, kind: 'unary',
+        version: 2, kind: 'census',
         subject: 'allied', subjectFilter: 'bishop',
         operator: 'count', comparator: 'equal_to',
         target: 'exact_number', targetTotal: 2
       },
       {
-        version: 2, kind: 'unary',
+        version: 2, kind: 'census',
         subject: 'allied', subjectFilter: 'any',
         operator: 'count', comparator: 'equal_to',
         target: 'exact_number', targetTotal: 0
@@ -1888,7 +1888,7 @@ describe('ConditionExampleGenerator', () => {
         subjectComparisonSource: 'prior_board_state'
       },
       {
-        version: 2, kind: 'unary',
+        version: 2, kind: 'census',
         subject: 'enemy', subjectFilter: 'any',
         operator: 'count', comparator: 'equal_to',
         target: 'exact_number', targetTotal: 0
@@ -1913,7 +1913,7 @@ describe('ConditionExampleGenerator', () => {
         subjectComparisonSourceTotal: 3
       },
       {
-        version: 2, kind: 'unary',
+        version: 2, kind: 'census',
         subject: 'enemy', subjectFilter: 'pawn',
         operator: 'count', comparator: 'equal_to',
         target: 'exact_number', targetTotal: 0
@@ -1928,13 +1928,13 @@ describe('ConditionExampleGenerator', () => {
     // exist (some at rank ≥ 5). Plan B: allied/pawn count = 0. Range [2, 0] → unsat.
     const payloads = [
       {
-        version: 2, kind: 'position',
+        version: 2, kind: 'census', target: 'exact_number',
         subject: 'allied', subjectFilter: 'pawn',
         positionAxis: 'rank', positionComparator: 'greater_than_or_equal_to', positionTarget: 5,
         operator: 'count', comparator: 'greater_than_or_equal_to', targetTotal: 2
       },
       {
-        version: 2, kind: 'unary',
+        version: 2, kind: 'census',
         subject: 'allied', subjectFilter: 'pawn',
         operator: 'count', comparator: 'equal_to',
         target: 'exact_number', targetTotal: 0
@@ -1953,13 +1953,13 @@ describe('ConditionExampleGenerator', () => {
     // [1, 0] → unsat.
     const payloads = [
       {
-        version: 2, kind: 'unary',
+        version: 2, kind: 'census',
         subject: 'moved_piece', subjectFilter: 'any',
         operator: 'value', comparator: 'equal_to',
         target: 'exact_number', targetTotal: 9
       },
       {
-        version: 2, kind: 'unary',
+        version: 2, kind: 'census',
         subject: 'allied', subjectFilter: 'queen',
         operator: 'count', comparator: 'equal_to',
         target: 'exact_number', targetTotal: 0
@@ -1977,7 +1977,7 @@ describe('ConditionExampleGenerator', () => {
     // unary value pair strategy picks from that narrowed set.
     const payloads = [
       {
-        version: 2, kind: 'unary',
+        version: 2, kind: 'census',
         subject: 'captured_piece', subjectFilter: 'any',
         operator: 'value', comparator: 'greater_than',
         target: 'moved_piece', targetFilter: 'any'
@@ -2028,7 +2028,7 @@ describe('ConditionExampleGenerator', () => {
     // until patch-2 enforcement makes other paths consult the new constraint.
     // For now we just verify the chain stays satisfiable end-to-end.
     const payload = {
-      version: 2, kind: 'position',
+      version: 2, kind: 'census',
       subject: 'enemy', subjectFilter: 'pawn', subjectFilterMode: 'include',
       positionAxis: 'rank', positionComparator: 'less_than', positionTarget: 4,
       operator: 'count', comparator: 'equal_to', target: 'exact_number', targetTotal: 0

--- a/app/javascript/editorV2/__tests__/ConditionForm.test.js
+++ b/app/javascript/editorV2/__tests__/ConditionForm.test.js
@@ -9,7 +9,13 @@ function option(value, label = value) {
 const subjectOptions = ['allied', 'enemy', 'moved_piece', 'captured_piece', 'enemy_moved_piece', 'enemy_captured_piece']
   .map(value => option(value))
   .join('')
-const relationalOperatorOptions = ['targets', 'shield', 'adjacent', 'same_piece']
+const relationalOperatorOptions = ['targets', 'shield', 'adjacent']
+  .map(value => option(value))
+  .join('')
+const identitySubjectOptions = ['enemy_moved_piece', 'captured_piece']
+  .map(value => option(value))
+  .join('')
+const identityTargetOptions = ['captured_piece', 'enemy_moved_piece']
   .map(value => option(value))
   .join('')
 const censusOperatorOptions = ['count', 'mobility', 'value']
@@ -28,8 +34,9 @@ function buildPanel() {
   const panel = document.createElement('div')
   panel.id = 'node-form-panel'
   panel.innerHTML = `
-    <button type="button" id="cond-mode-relational" class="active">Relational</button>
     <button type="button" id="cond-mode-census">Positions</button>
+    <button type="button" id="cond-mode-relational" class="active">Attack/Defend</button>
+    <button type="button" id="cond-mode-identity">Identity</button>
 
     <div class="condition-form-layout">
       <select id="cond-left-subject">${subjectOptions}</select>
@@ -153,6 +160,11 @@ function buildPanel() {
           <div id="cond-census-square-rank">${radioList('cond-census-square-rank')}</div>
         </div>
       </section>
+    </div>
+
+    <div class="condition-form-layout condition-form-identity-layout hidden" id="cond-identity-layout">
+      <select id="cond-identity-subject">${identitySubjectOptions}</select>
+      <select id="cond-identity-target">${identityTargetOptions}</select>
     </div>
 
     <div id="cond-formulation-preview"></div>
@@ -849,5 +861,64 @@ describe('ConditionForm', () => {
     expect(payload).not.toHaveProperty('targetComparisonMetric')
     expect(payload).not.toHaveProperty('targetComparator')
     expect(payload).not.toHaveProperty('targetComparisonSource')
+  })
+
+  describe('identity mode', () => {
+    it('loads an identity node and builds a minimal identity payload', () => {
+      const panel = buildPanel()
+      const form = new ConditionForm(panel)
+      form.attach()
+
+      form.populate({
+        version: 2,
+        kind: 'identity',
+        subject: 'enemy_moved_piece',
+        target: 'captured_piece'
+      })
+
+      expect(form.state.mode).toBe('identity')
+      expect(panel.querySelector('#cond-identity-layout').classList.contains('hidden')).toBe(false)
+      expect(form.buildPayload()).toEqual({
+        version: 2,
+        kind: 'identity',
+        subject: 'enemy_moved_piece',
+        target: 'captured_piece'
+      })
+    })
+
+    it('switches to identity mode via the mode picker', () => {
+      const panel = buildPanel()
+      const form = new ConditionForm(panel)
+      form.attach()
+
+      panel.querySelector('#cond-mode-identity').dispatchEvent(new Event('click'))
+
+      expect(form.state.mode).toBe('identity')
+      expect(form.buildPayload()).toMatchObject({ kind: 'identity' })
+    })
+
+    it('reconstrains the target to the subject pairing when the subject changes', () => {
+      const panel = buildPanel()
+      const form = new ConditionForm(panel)
+      form.attach()
+
+      form.populate({
+        version: 2,
+        kind: 'identity',
+        subject: 'enemy_moved_piece',
+        target: 'captured_piece'
+      })
+
+      const subject = panel.querySelector('#cond-identity-subject')
+      subject.value = 'captured_piece'
+      subject.dispatchEvent(new Event('change'))
+
+      expect(form.buildPayload()).toEqual({
+        version: 2,
+        kind: 'identity',
+        subject: 'captured_piece',
+        target: 'enemy_moved_piece'
+      })
+    })
   })
 })

--- a/app/javascript/editorV2/__tests__/ConditionForm.test.js
+++ b/app/javascript/editorV2/__tests__/ConditionForm.test.js
@@ -12,95 +12,150 @@ const subjectOptions = ['allied', 'enemy', 'moved_piece', 'captured_piece', 'ene
 const relationalOperatorOptions = ['targets', 'shield', 'adjacent', 'same_piece']
   .map(value => option(value))
   .join('')
-const measureOperatorOptions = ['count', 'mobility', 'value']
+const censusOperatorOptions = ['count', 'mobility', 'value']
   .map(value => option(value))
   .join('')
+const censusTargetOptions = ['exact_number', 'allied', 'enemy', 'moved_piece', 'captured_piece', 'enemy_moved_piece', 'enemy_captured_piece', 'prior_board_state']
+  .map(value => option(value))
+  .join('')
+function radioList(name) {
+  return [1, 2, 3, 4, 5, 6, 7, 8]
+    .map(v => `<label class="condition-form-checkbox"><input type="radio" name="${name}" value="${v}"${v === 1 ? ' checked' : ''}><span>${v}</span></label>`)
+    .join('')
+}
 
 function buildPanel() {
   const panel = document.createElement('div')
   panel.id = 'node-form-panel'
   panel.innerHTML = `
     <button type="button" id="cond-mode-relational" class="active">Relational</button>
-    <button type="button" id="cond-mode-measure">Measure</button>
+    <button type="button" id="cond-mode-census">Positions</button>
 
-    <select id="cond-left-subject">${subjectOptions}</select>
-    <label class="condition-form-checkbox">
-      <input id="cond-left-filter-mode" type="checkbox">
-      <span>Non-</span>
-    </label>
-    <select id="cond-left-filter">${option('any')}${option('pawn')}${option('rook')}</select>
-    <p id="cond-measure-subject-note" class="hidden"></p>
-    <select id="cond-left-comparison-metric">${option('count')}</select>
-    <select id="cond-left-comparator">${option('equal_to', '=')}</select>
-    <div id="cond-left-comparison-section" class="condition-form-comparison">
-      <button type="button" id="cond-left-comparison-toggle"></button>
-      <div id="cond-left-comparison-body" class="hidden"></div>
-    </div>
-    <div id="cond-left-comparison-source-stack" class="condition-form-comparison-source-stack">
-      <select id="cond-left-comparison-source">
-        ${option('exact_number', 'Integer')}
-        ${option('prior_board_state', 'Prior Board State')}
-      </select>
-      <input id="cond-left-comparison-source-total" type="number">
+    <div class="condition-form-layout">
+      <select id="cond-left-subject">${subjectOptions}</select>
+      <label class="condition-form-checkbox">
+        <input id="cond-left-filter-mode" type="checkbox">
+        <span>Non-</span>
+      </label>
+      <select id="cond-left-filter">${option('any')}${option('pawn')}${option('rook')}</select>
+      <select id="cond-left-comparison-metric">${option('count')}</select>
+      <div id="cond-left-comparator">
+        <label class="condition-form-checkbox"><input type="radio" name="cond-left-comparator" value="equal_to" checked><span>=</span></label>
+        <label class="condition-form-checkbox"><input type="radio" name="cond-left-comparator" value="greater_than"><span>></span></label>
+        <label class="condition-form-checkbox"><input type="radio" name="cond-left-comparator" value="less_than"><span><</span></label>
+      </div>
+      <div id="cond-left-comparison-section" class="condition-form-comparison">
+        <button type="button" id="cond-left-comparison-toggle"></button>
+        <div id="cond-left-comparison-body" class="hidden"></div>
+      </div>
+      <div id="cond-left-comparison-source-stack" class="condition-form-comparison-source-stack">
+        <select id="cond-left-comparison-source">
+          ${option('exact_number', 'Integer')}
+          ${option('prior_board_state', 'Prior Board State')}
+        </select>
+        <input id="cond-left-comparison-source-total" type="number">
+      </div>
+
+      <select id="cond-relational-operator">${relationalOperatorOptions}</select>
+
+      <select id="cond-right-subject">${subjectOptions}</select>
+      <label class="condition-form-checkbox">
+        <input id="cond-right-filter-mode" type="checkbox">
+        <span>Non-</span>
+      </label>
+      <select id="cond-right-filter">${option('any')}${option('pawn')}${option('rook')}</select>
+      <select id="cond-right-comparison-metric">${option('count')}</select>
+      <div id="cond-right-comparator">
+        <label class="condition-form-checkbox"><input type="radio" name="cond-right-comparator" value="equal_to" checked><span>=</span></label>
+        <label class="condition-form-checkbox"><input type="radio" name="cond-right-comparator" value="greater_than"><span>></span></label>
+        <label class="condition-form-checkbox"><input type="radio" name="cond-right-comparator" value="less_than"><span><</span></label>
+      </div>
+      <div id="cond-right-comparison-section" class="condition-form-comparison">
+        <button type="button" id="cond-right-comparison-toggle"></button>
+        <div id="cond-right-comparison-body" class="hidden"></div>
+      </div>
+      <div id="cond-right-comparison-source-stack" class="condition-form-comparison-source-stack">
+        <select id="cond-right-comparison-source">
+          ${option('exact_number', 'Integer')}
+          ${option('prior_board_state', 'Prior Board State')}
+        </select>
+        <input id="cond-right-comparison-source-total" type="number">
+      </div>
+
+      <div id="cond-right-card-label"></div>
+      <div id="cond-right-relational-fields"></div>
+      <div id="cond-left-filter-row"></div>
+      <div id="cond-right-filter-row"></div>
+      <p id="cond-relational-target-note" class="hidden"></p>
     </div>
 
-    <select id="cond-relational-operator">${relationalOperatorOptions}</select>
-    <select id="cond-measure-operator" class="hidden">${measureOperatorOptions}</select>
-
-    <select id="cond-right-subject">${subjectOptions}</select>
-    <label class="condition-form-checkbox">
-      <input id="cond-right-filter-mode" type="checkbox">
-      <span>Non-</span>
-    </label>
-    <select id="cond-right-filter">${option('any')}${option('pawn')}${option('rook')}</select>
-    <p id="cond-relational-target-note" class="hidden"></p>
-    <select id="cond-right-comparison-metric">${option('count')}</select>
-    <select id="cond-right-comparator">${option('equal_to', '=')}</select>
-    <div id="cond-right-comparison-section" class="condition-form-comparison">
-      <button type="button" id="cond-right-comparison-toggle"></button>
-      <div id="cond-right-comparison-body" class="hidden"></div>
-    </div>
-    <div id="cond-right-comparison-source-stack" class="condition-form-comparison-source-stack">
-      <select id="cond-right-comparison-source">
-        ${option('exact_number', 'Integer')}
-        ${option('prior_board_state', 'Prior Board State')}
-      </select>
-      <input id="cond-right-comparison-source-total" type="number">
-    </div>
-
-    <div id="cond-right-card-label"></div>
-    <div id="cond-right-relational-fields"></div>
-    <div id="cond-unary-comparison-section" class="hidden">
-      <label>Comparator</label>
-      <select id="cond-unary-comparator">${option('greater_than', '>')}</select>
-    </div>
-    <div id="cond-unary-target-section" class="hidden">
-      <label>Target</label>
-      <select id="cond-unary-target">
-        ${option('exact_number', 'Integer')}
-        ${option('allied', 'Allied')}
-        ${option('enemy', 'Enemy')}
-        ${option('moved_piece', 'Moved Piece')}
-        ${option('captured_piece', 'Captured Piece')}
-        ${option('enemy_moved_piece', 'Enemy Moved Piece')}
-        ${option('enemy_captured_piece', 'Enemy Captured Piece')}
-        ${option('prior_board_state', 'Prior Board State')}
-      </select>
-    </div>
-    <div id="cond-left-filter-row"></div>
-    <div id="cond-right-filter-row"></div>
-    <div id="cond-formulation-preview"></div>
-
-    <div id="cond-unary-target-stack" class="condition-form-comparison-source-stack">
-      <input id="cond-unary-target-total" type="number">
-      <div class="condition-form-inline-pair" id="cond-unary-target-filter-row">
+    <div class="condition-form-layout condition-form-position-layout hidden" id="cond-census-layout">
+      <select id="cond-census-subject">${subjectOptions}</select>
+      <div id="cond-census-filter-row">
         <label class="condition-form-checkbox">
-          <input id="cond-unary-target-filter-mode" type="checkbox">
+          <input id="cond-census-filter-mode" type="checkbox">
           <span>Non-</span>
         </label>
-        <select id="cond-unary-target-filter">${option('any')}${option('pawn')}${option('rook')}</select>
+        <select id="cond-census-filter">${option('any')}${option('pawn')}${option('rook')}</select>
       </div>
+      <div id="cond-census-comparison" class="condition-form-comparison">
+        <button type="button" id="cond-census-comparison-toggle"></button>
+        <div id="cond-census-comparison-body" class="hidden">
+          <select id="cond-census-operator">${censusOperatorOptions}</select>
+          <div id="cond-census-comparator">
+            <label class="condition-form-checkbox"><input type="radio" name="cond-census-comparator" value="equal_to" checked><span>=</span></label>
+            <label class="condition-form-checkbox"><input type="radio" name="cond-census-comparator" value="greater_than"><span>></span></label>
+            <label class="condition-form-checkbox"><input type="radio" name="cond-census-comparator" value="less_than"><span><</span></label>
+          </div>
+          <div id="cond-census-target-stack" class="condition-form-comparison-source-stack">
+            <select id="cond-census-target">${censusTargetOptions}</select>
+            <div id="cond-census-target-filter-row">
+              <label class="condition-form-checkbox">
+                <input id="cond-census-target-filter-mode" type="checkbox">
+                <span>Non-</span>
+              </label>
+              <select id="cond-census-target-filter">${option('any')}${option('pawn')}${option('rook')}</select>
+            </div>
+            <input id="cond-census-target-total" type="number">
+          </div>
+        </div>
+      </div>
+
+      <div id="cond-census-scope">
+        <label class="condition-form-checkbox">
+          <input type="radio" name="cond-census-scope" id="cond-census-scope-whole" value="whole">
+          <span>Whole board</span>
+        </label>
+        <label class="condition-form-checkbox">
+          <input type="radio" name="cond-census-scope" id="cond-census-axis-rank" value="rank" checked>
+          <span>Rank</span>
+        </label>
+        <label class="condition-form-checkbox">
+          <input type="radio" name="cond-census-scope" id="cond-census-axis-file" value="file">
+          <span>File</span>
+        </label>
+        <label class="condition-form-checkbox">
+          <input type="radio" name="cond-census-scope" id="cond-census-axis-square" value="square">
+          <span>Square</span>
+        </label>
+      </div>
+      <div id="cond-census-region-comparator">
+        <label class="condition-form-checkbox"><input type="radio" name="cond-census-region-comparator" value="equal_to" checked><span>=</span></label>
+        <label class="condition-form-checkbox"><input type="radio" name="cond-census-region-comparator" value="greater_than"><span>></span></label>
+        <label class="condition-form-checkbox"><input type="radio" name="cond-census-region-comparator" value="less_than"><span><</span></label>
+      </div>
+
+      <section id="cond-census-region-target">
+        <div id="cond-census-rank-input">${radioList('cond-census-rank-input')}</div>
+        <div id="cond-census-file-input" class="hidden">${radioList('cond-census-file-input')}</div>
+        <div id="cond-census-square-inputs" class="hidden">
+          <div id="cond-census-square-file">${radioList('cond-census-square-file')}</div>
+          <div id="cond-census-square-rank">${radioList('cond-census-square-rank')}</div>
+        </div>
+      </section>
     </div>
+
+    <div id="cond-formulation-preview"></div>
   `
   document.body.appendChild(panel)
   return panel
@@ -133,10 +188,8 @@ describe('ConditionForm', () => {
     expect(panel.querySelector('#cond-left-comparison-source').classList.contains('hidden')).toBe(false)
     expect(panel.querySelector('#cond-left-comparison-source-total').classList.contains('hidden')).toBe(false)
     expect(panel.querySelector('#cond-right-comparison-source-total').classList.contains('hidden')).toBe(false)
-    expect(panel.querySelector('#cond-unary-target-total').classList.contains('hidden')).toBe(false)
     expect(panel.querySelector('#cond-left-comparison-source-stack').classList.contains('condition-form-comparison-source-stack--inline-number')).toBe(true)
     expect(panel.querySelector('#cond-right-comparison-source-stack').classList.contains('condition-form-comparison-source-stack--inline-number')).toBe(true)
-    expect(panel.querySelector('#cond-unary-target-stack').classList.contains('condition-form-comparison-source-stack--inline-number')).toBe(true)
 
     const rightSource = panel.querySelector('#cond-right-comparison-source')
     rightSource.value = 'prior_board_state'
@@ -144,7 +197,6 @@ describe('ConditionForm', () => {
 
     expect(panel.querySelector('#cond-left-comparison-source-total').classList.contains('hidden')).toBe(false)
     expect(panel.querySelector('#cond-right-comparison-source-total').classList.contains('hidden')).toBe(true)
-    expect(panel.querySelector('#cond-unary-target-total').classList.contains('hidden')).toBe(false)
     expect(panel.querySelector('#cond-right-comparison-source').classList.contains('hidden')).toBe(false)
     expect(panel.querySelector('#cond-right-comparison-source-stack').classList.contains('condition-form-comparison-source-stack--inline-number')).toBe(false)
   })
@@ -365,14 +417,14 @@ describe('ConditionForm', () => {
     expect(form.buildPayload().target).toBe('enemy')
   })
 
-  it('builds unary actor-target payloads with target filters', () => {
+  it('loads a whole-board census and builds an actor-target payload with filters', () => {
     const panel = buildPanel()
     const form = new ConditionForm(panel)
     form.attach()
 
     form.populate({
       version: 2,
-      kind: 'unary',
+      kind: 'census',
       subject: 'allied',
       subjectFilter: 'any',
       operator: 'value',
@@ -382,11 +434,19 @@ describe('ConditionForm', () => {
       targetFilterMode: 'exclude'
     })
 
-    expect(panel.querySelector('#cond-unary-target-total').classList.contains('hidden')).toBe(true)
-    expect(panel.querySelector('#cond-unary-target-filter-row').classList.contains('hidden')).toBe(false)
-    expect(form.buildPayload()).toMatchObject({
+    expect(panel.querySelector('#cond-census-scope-whole').checked).toBe(true)
+    expect(panel.querySelector('#cond-census-region-target').classList.contains('hidden')).toBe(false)
+    const squareInputs = panel.querySelector('#cond-census-square-inputs')
+    expect(squareInputs.classList.contains('hidden')).toBe(false)
+    expect(squareInputs.classList.contains('condition-form-radio-list--disabled')).toBe(true)
+    expect(panel.querySelector('#cond-census-square-rank input').disabled).toBe(true)
+    expect(panel.querySelector('#cond-census-target-total').classList.contains('hidden')).toBe(true)
+    expect(panel.querySelector('#cond-census-target-filter-row').classList.contains('hidden')).toBe(false)
+
+    const payload = form.buildPayload()
+    expect(payload).toMatchObject({
       version: 2,
-      kind: 'unary',
+      kind: 'census',
       subject: 'allied',
       subjectFilter: 'any',
       operator: 'value',
@@ -394,17 +454,50 @@ describe('ConditionForm', () => {
       target: 'enemy',
       targetFilter: 'rook',
       targetFilterMode: 'exclude'
+    })
+    expect(payload).not.toHaveProperty('positionAxis')
+    expect(payload).not.toHaveProperty('positionComparator')
+    expect(payload).not.toHaveProperty('positionTarget')
+  })
+
+  it('loads a whole-board prior_board_state census round-trip', () => {
+    const panel = buildPanel()
+    const form = new ConditionForm(panel)
+    form.attach()
+
+    form.populate({
+      version: 2,
+      kind: 'census',
+      subject: 'moved_piece',
+      subjectFilter: 'rook',
+      subjectFilterMode: 'include',
+      operator: 'mobility',
+      comparator: 'greater_than',
+      target: 'prior_board_state'
+    })
+
+    expect(panel.querySelector('#cond-census-scope-whole').checked).toBe(true)
+    const payload = form.buildPayload()
+    expect(payload).toEqual({
+      version: 2,
+      kind: 'census',
+      subject: 'moved_piece',
+      subjectFilter: 'rook',
+      subjectFilterMode: 'include',
+      operator: 'mobility',
+      comparator: 'greater_than',
+      target: 'prior_board_state'
     })
   })
 
-  it('hides and clears the unary target non toggle when the target filter is any', () => {
+  it('hides and clears the whole-board target non toggle when the target filter is any', () => {
     const panel = buildPanel()
     const form = new ConditionForm(panel)
     form.attach()
 
     form.populate({
       version: 2,
-      kind: 'unary',
+      kind: 'census',
       subject: 'allied',
       subjectFilter: 'any',
       operator: 'value',
@@ -414,28 +507,28 @@ describe('ConditionForm', () => {
       targetFilterMode: 'exclude'
     })
 
-    const targetFilterMode = panel.querySelector('#cond-unary-target-filter-mode')
-    const targetFilterModeControl = targetFilterMode.closest('.condition-form-checkbox')
+    const targetFilterMode = panel.querySelector('#cond-census-target-filter-mode')
+    const control = targetFilterMode.closest('.condition-form-checkbox')
     expect(targetFilterMode.checked).toBe(true)
-    expect(targetFilterModeControl.classList.contains('condition-form-checkbox--unavailable')).toBe(false)
+    expect(control.classList.contains('condition-form-checkbox--unavailable')).toBe(false)
 
-    const targetFilter = panel.querySelector('#cond-unary-target-filter')
+    const targetFilter = panel.querySelector('#cond-census-target-filter')
     targetFilter.value = 'any'
     targetFilter.dispatchEvent(new Event('change', { bubbles: true }))
 
     expect(targetFilterMode.checked).toBe(false)
-    expect(targetFilterModeControl.classList.contains('condition-form-checkbox--unavailable')).toBe(true)
+    expect(control.classList.contains('condition-form-checkbox--unavailable')).toBe(true)
     expect(form.buildPayload()).not.toHaveProperty('targetFilterMode')
   })
 
-  it('disallows captured-piece unary targets for mobility', () => {
+  it('disallows captured-piece whole-board census targets for mobility', () => {
     const panel = buildPanel()
     const form = new ConditionForm(panel)
     form.attach()
 
     form.populate({
       version: 2,
-      kind: 'unary',
+      kind: 'census',
       subject: 'allied',
       subjectFilter: 'any',
       operator: 'mobility',
@@ -444,14 +537,86 @@ describe('ConditionForm', () => {
       targetFilter: 'any'
     })
 
-    const targetSource = panel.querySelector('#cond-unary-target')
+    const targetSelect = panel.querySelector('#cond-census-target')
     expect(form.buildPayload().target).toBe('exact_number')
-    expect(targetSource.querySelector('option[value="captured_piece"]').disabled).toBe(true)
-    expect(targetSource.querySelector('option[value="enemy_captured_piece"]').disabled).toBe(true)
-    expect(targetSource.querySelector('option[value="enemy"]').disabled).toBe(false)
+    expect(targetSelect.querySelector('option[value="captured_piece"]').disabled).toBe(true)
+    expect(targetSelect.querySelector('option[value="enemy_captured_piece"]').disabled).toBe(true)
+    expect(targetSelect.querySelector('option[value="enemy"]').disabled).toBe(false)
   })
 
-  it('preserves relational state when switching to measure mode and back', () => {
+  it('loads a region census and emits spatial keys with an exact_number target', () => {
+    const panel = buildPanel()
+    const form = new ConditionForm(panel)
+    form.attach()
+
+    form.populate({
+      version: 2,
+      kind: 'census',
+      subject: 'allied',
+      subjectFilter: 'any',
+      positionAxis: 'rank',
+      positionComparator: 'equal_to',
+      positionTarget: 5,
+      operator: 'count',
+      comparator: 'greater_than',
+      target: 'exact_number',
+      targetTotal: 2
+    })
+
+    expect(panel.querySelector('#cond-census-axis-rank').checked).toBe(true)
+    expect(panel.querySelector('#cond-census-region-target').classList.contains('hidden')).toBe(false)
+
+    expect(form.buildPayload()).toEqual({
+      version: 2,
+      kind: 'census',
+      subject: 'allied',
+      subjectFilter: 'any',
+      positionAxis: 'rank',
+      positionComparator: 'equal_to',
+      positionTarget: 5,
+      operator: 'count',
+      comparator: 'greater_than',
+      target: 'exact_number',
+      targetTotal: 2
+    })
+  })
+
+  it('keeps a Simple region census on exact_number and hides the target select', () => {
+    const panel = buildPanel()
+    const form = new ConditionForm(panel)
+    form.attach()
+
+    form.populate({
+      version: 2,
+      kind: 'census',
+      subject: 'allied',
+      subjectFilter: 'any',
+      positionAxis: 'file',
+      positionComparator: 'equal_to',
+      positionTarget: 3,
+      operator: 'count',
+      comparator: 'greater_than',
+      target: 'exact_number',
+      targetTotal: 0
+    })
+
+    expect(panel.querySelector('#cond-census-comparison-toggle').textContent).toBe('+ Advanced options')
+    expect(panel.querySelector('#cond-census-target').classList.contains('hidden')).toBe(true)
+
+    const targetSelect = panel.querySelector('#cond-census-target')
+    targetSelect.value = 'prior_board_state'
+    targetSelect.dispatchEvent(new Event('change', { bubbles: true }))
+
+    expect(form.buildPayload()).toMatchObject({
+      kind: 'census',
+      positionAxis: 'file',
+      positionTarget: 3,
+      target: 'exact_number',
+      targetTotal: 0
+    })
+  })
+
+  it('preserves relational state when switching to the census tab and back', () => {
     const panel = buildPanel()
     const form = new ConditionForm(panel)
     form.attach()
@@ -466,7 +631,7 @@ describe('ConditionForm', () => {
       targetFilter: 'any'
     })
 
-    panel.querySelector('#cond-mode-measure').dispatchEvent(new Event('click'))
+    panel.querySelector('#cond-mode-census').dispatchEvent(new Event('click'))
     panel.querySelector('#cond-mode-relational').dispatchEvent(new Event('click'))
 
     const payload = form.buildPayload()
@@ -477,14 +642,14 @@ describe('ConditionForm', () => {
     expect(payload.target).toBe('moved_piece')
   })
 
-  it('preserves measure state when switching to relational mode and back', () => {
+  it('preserves census state when switching to relational and back', () => {
     const panel = buildPanel()
     const form = new ConditionForm(panel)
     form.attach()
 
     form.populate({
       version: 2,
-      kind: 'unary',
+      kind: 'census',
       subject: 'enemy',
       subjectFilter: 'any',
       operator: 'count',
@@ -494,12 +659,195 @@ describe('ConditionForm', () => {
     })
 
     panel.querySelector('#cond-mode-relational').dispatchEvent(new Event('click'))
-    panel.querySelector('#cond-mode-measure').dispatchEvent(new Event('click'))
+    panel.querySelector('#cond-mode-census').dispatchEvent(new Event('click'))
 
     const payload = form.buildPayload()
-    expect(payload.kind).toBe('unary')
+    expect(payload.kind).toBe('census')
     expect(payload.subject).toBe('enemy')
     expect(payload.operator).toBe('count')
     expect(payload.targetTotal).toBe(3)
+  })
+
+  it('defaults whole-board to Simple (no target select) and reveals it via Advanced', () => {
+    const panel = buildPanel()
+    const form = new ConditionForm(panel)
+    form.attach()
+
+    form.populate({
+      version: 2,
+      kind: 'census',
+      subject: 'allied',
+      subjectFilter: 'any',
+      operator: 'count',
+      comparator: 'greater_than',
+      target: 'exact_number',
+      targetTotal: 2
+    })
+
+    const toggle = panel.querySelector('#cond-census-comparison-toggle')
+    expect(panel.querySelector('#cond-census-scope-whole').checked).toBe(true)
+    expect(panel.querySelector('#cond-census-comparison-body').classList.contains('hidden')).toBe(false)
+    expect(toggle.classList.contains('hidden')).toBe(false)
+    expect(toggle.textContent).toBe('+ Advanced options')
+    expect(panel.querySelector('#cond-census-target').classList.contains('hidden')).toBe(true)
+    expect(form.buildPayload()).toMatchObject({ kind: 'census', target: 'exact_number', targetTotal: 2 })
+
+    toggle.dispatchEvent(new Event('click'))
+
+    expect(toggle.textContent).toBe('Simplify')
+    expect(panel.querySelector('#cond-census-target').classList.contains('hidden')).toBe(false)
+  })
+
+  it('keeps the Advanced toggle available in region scope', () => {
+    const panel = buildPanel()
+    const form = new ConditionForm(panel)
+    form.attach()
+
+    form.populate({
+      version: 2,
+      kind: 'census',
+      subject: 'allied',
+      subjectFilter: 'any',
+      positionAxis: 'rank',
+      positionComparator: 'equal_to',
+      positionTarget: 5,
+      operator: 'count',
+      comparator: 'greater_than',
+      target: 'exact_number',
+      targetTotal: 0
+    })
+
+    const toggle = panel.querySelector('#cond-census-comparison-toggle')
+    expect(toggle.classList.contains('hidden')).toBe(false)
+    expect(panel.querySelector('#cond-census-target').classList.contains('hidden')).toBe(true)
+
+    toggle.dispatchEvent(new Event('click'))
+    expect(panel.querySelector('#cond-census-target').classList.contains('hidden')).toBe(false)
+  })
+
+  it('loads a region prior_board_state census straight into Advanced and round-trips spatial keys', () => {
+    const panel = buildPanel()
+    const form = new ConditionForm(panel)
+    form.attach()
+
+    form.populate({
+      version: 2,
+      kind: 'census',
+      subject: 'allied',
+      subjectFilter: 'rook',
+      subjectFilterMode: 'include',
+      positionAxis: 'rank',
+      positionComparator: 'equal_to',
+      positionTarget: 5,
+      operator: 'count',
+      comparator: 'greater_than',
+      target: 'prior_board_state'
+    })
+
+    expect(panel.querySelector('#cond-census-comparison-toggle').textContent).toBe('Simplify')
+    expect(panel.querySelector('#cond-census-target').classList.contains('hidden')).toBe(false)
+    expect(form.buildPayload()).toEqual({
+      version: 2,
+      kind: 'census',
+      subject: 'allied',
+      subjectFilter: 'rook',
+      subjectFilterMode: 'include',
+      positionAxis: 'rank',
+      positionComparator: 'equal_to',
+      positionTarget: 5,
+      operator: 'count',
+      comparator: 'greater_than',
+      target: 'prior_board_state'
+    })
+  })
+
+  it('loads an actor-target whole-board census straight into Advanced', () => {
+    const panel = buildPanel()
+    const form = new ConditionForm(panel)
+    form.attach()
+
+    form.populate({
+      version: 2,
+      kind: 'census',
+      subject: 'allied',
+      subjectFilter: 'any',
+      operator: 'value',
+      comparator: 'greater_than',
+      target: 'enemy',
+      targetFilter: 'rook'
+    })
+
+    expect(panel.querySelector('#cond-census-comparison-toggle').textContent).toBe('Simplify')
+    expect(panel.querySelector('#cond-census-target').classList.contains('hidden')).toBe(false)
+    expect(form.buildPayload().target).toBe('enemy')
+  })
+
+  it('round-trips a non-default relational comparator through the pill', () => {
+    const panel = buildPanel()
+    const form = new ConditionForm(panel)
+    form.attach()
+
+    form.populate({
+      version: 2,
+      kind: 'relational',
+      subject: 'allied',
+      subjectFilter: 'any',
+      subjectComparisonMetric: 'count',
+      subjectComparator: 'greater_than',
+      subjectComparisonSource: 'exact_number',
+      subjectComparisonSourceTotal: 2,
+      operator: 'attack',
+      target: 'enemy',
+      targetFilter: 'any'
+    })
+
+    expect(panel.querySelector('#cond-left-comparator input[value="greater_than"]').checked).toBe(true)
+    expect(form.buildPayload().subjectComparator).toBe('greater_than')
+  })
+
+  it('relabels the relational comparison toggle to "+ comparison (advanced)"', () => {
+    const panel = buildPanel()
+    const form = new ConditionForm(panel)
+    form.attach()
+
+    form.populate({
+      version: 2,
+      kind: 'relational',
+      subject: 'allied',
+      subjectFilter: 'any',
+      operator: 'attack',
+      target: 'enemy',
+      targetFilter: 'any'
+    })
+
+    const toggle = panel.querySelector('#cond-left-comparison-toggle')
+    expect(toggle.textContent).toBe('+ comparison (advanced)')
+
+    toggle.dispatchEvent(new Event('click'))
+    expect(toggle.textContent).toBe('Hide comparison')
+  })
+
+  it('a collapsed relational comparison emits no comparison fields', () => {
+    const panel = buildPanel()
+    const form = new ConditionForm(panel)
+    form.attach()
+
+    form.populate({
+      version: 2,
+      kind: 'relational',
+      subject: 'allied',
+      subjectFilter: 'any',
+      operator: 'attack',
+      target: 'enemy',
+      targetFilter: 'any'
+    })
+
+    const payload = form.buildPayload()
+    expect(payload).not.toHaveProperty('subjectComparisonMetric')
+    expect(payload).not.toHaveProperty('subjectComparator')
+    expect(payload).not.toHaveProperty('subjectComparisonSource')
+    expect(payload).not.toHaveProperty('targetComparisonMetric')
+    expect(payload).not.toHaveProperty('targetComparator')
+    expect(payload).not.toHaveProperty('targetComparisonSource')
   })
 })

--- a/app/javascript/editorV2/__tests__/conditionPreviewFormatter.test.js
+++ b/app/javascript/editorV2/__tests__/conditionPreviewFormatter.test.js
@@ -179,6 +179,46 @@ describe('conditionPreviewFormatter', () => {
       ).toBe('= Captured Piece')
     })
 
+    it('formats a region chunk via the position-axis preview', () => {
+      expect(
+        formatConditionPreviewChunk({
+          role: 'region',
+          positionAxis: 'file',
+          positionComparator: 'equal_to',
+          positionTarget: 1
+        })
+      ).toBe('file = a')
+
+      expect(
+        formatConditionPreviewChunk({
+          role: 'region',
+          positionAxis: 'rank',
+          positionComparator: 'greater_than',
+          positionTarget: 5
+        })
+      ).toBe('rank > 5')
+
+      expect(
+        formatConditionPreviewChunk({
+          role: 'region',
+          positionAxis: 'square',
+          positionComparator: 'equal_to',
+          positionTarget: 0
+        })
+      ).toBe('square a1')
+    })
+
+    it('formats a metric chunk as operator comparator total', () => {
+      expect(
+        formatConditionPreviewChunk({
+          role: 'metric',
+          operator: 'count',
+          comparator: 'greater_than',
+          targetTotal: 0
+        })
+      ).toBe('count > 0')
+    })
+
     it('formats excluded major and minor filters', () => {
       expect(
         formatConditionPreviewChunk({

--- a/app/javascript/editorV2/__tests__/conditionPreviewFormatter.test.js
+++ b/app/javascript/editorV2/__tests__/conditionPreviewFormatter.test.js
@@ -60,11 +60,11 @@ describe('conditionPreviewFormatter', () => {
       ).toBe('Allied pawn/s (value > 3) : attack : Enemy bishop/s')
     })
 
-    it('formats unary previews in a three-block layout', () => {
+    it('formats a whole-board census preview in a three-block layout', () => {
       expect(
         formatConditionPreview({
           version: 2,
-          kind: 'unary',
+          kind: 'census',
           subject: 'enemy_moved_piece',
           subjectFilter: 'pawn',
           operator: 'mobility',
@@ -74,11 +74,11 @@ describe('conditionPreviewFormatter', () => {
       ).toBe('Enemy Moved Piece pawn/s : mobility : < Prior Board State')
     })
 
-    it('formats unary actor targets with filters', () => {
+    it('formats whole-board census actor targets with filters', () => {
       expect(
         formatConditionPreview({
           version: 2,
-          kind: 'unary',
+          kind: 'census',
           subject: 'allied',
           subjectFilter: 'any',
           operator: 'value',
@@ -87,6 +87,24 @@ describe('conditionPreviewFormatter', () => {
           targetFilter: 'rook'
         }).text
       ).toBe('Allies any : value : > Enemy rook/s')
+    })
+
+    it('formats a region census preview with the position-axis block', () => {
+      expect(
+        formatConditionPreview({
+          version: 2,
+          kind: 'census',
+          subject: 'allied',
+          subjectFilter: 'any',
+          positionAxis: 'rank',
+          positionComparator: 'equal_to',
+          positionTarget: 5,
+          operator: 'count',
+          comparator: 'greater_than',
+          target: 'exact_number',
+          targetTotal: 0
+        }).text
+      ).toBe('Allies any : rank = 5 : count > 0')
     })
 
     it('formats same_piece with the explicit operator phrase', () => {

--- a/app/javascript/editorV2/__tests__/conditionPreviewFormatter.test.js
+++ b/app/javascript/editorV2/__tests__/conditionPreviewFormatter.test.js
@@ -107,16 +107,13 @@ describe('conditionPreviewFormatter', () => {
       ).toBe('Allies any : rank = 5 : count > 0')
     })
 
-    it('formats same_piece with the explicit operator phrase', () => {
+    it('formats an identity condition with the explicit same-piece phrase', () => {
       expect(
         formatConditionPreview({
           version: 2,
-          kind: 'relational',
+          kind: 'identity',
           subject: 'enemy_moved_piece',
-          subjectFilter: 'any',
-          operator: 'same_piece',
-          target: 'captured_piece',
-          targetFilter: 'any'
+          target: 'captured_piece'
         }).text
       ).toBe('Enemy Moved Piece : is same-piece-as : Captured Piece')
     })

--- a/app/javascript/editorV2/panels/ConditionForm.js
+++ b/app/javascript/editorV2/panels/ConditionForm.js
@@ -70,6 +70,11 @@ const DEFAULT_CENSUS_STATE = {
   targetTotal: 0
 }
 
+const DEFAULT_IDENTITY_STATE = {
+  subject: 'enemy_moved_piece',
+  target: 'captured_piece'
+}
+
 const DEFAULT_GRAMMAR_RULES = Object.freeze({
   editorSubjects: ['allied', 'enemy', 'moved_piece', 'captured_piece', 'enemy_moved_piece', 'enemy_captured_piece'],
   positionSubjects: ['allied', 'enemy', 'moved_piece', 'enemy_moved_piece'],
@@ -106,6 +111,7 @@ class ConditionForm {
     this.boundHandleRightComparisonToggle = this.toggleRightComparison.bind(this)
     this.boundHandleModeRelational = () => this.handleModeChange('relational')
     this.boundHandleModeCensus = () => this.handleModeChange('census')
+    this.boundHandleModeIdentity = () => this.handleModeChange('identity')
     this.boundHandleCensusComparisonToggle = this.toggleCensusComparison.bind(this)
   }
 
@@ -113,7 +119,8 @@ class ConditionForm {
     return {
       mode: 'census',
       relational: structuredClone(DEFAULT_RELATIONAL_STATE),
-      census: structuredClone(DEFAULT_CENSUS_STATE)
+      census: structuredClone(DEFAULT_CENSUS_STATE),
+      identity: structuredClone(DEFAULT_IDENTITY_STATE)
     }
   }
 
@@ -135,6 +142,7 @@ class ConditionForm {
     fields.rightComparisonToggle?.addEventListener('click', this.boundHandleRightComparisonToggle)
     fields.modeRelationalBtn?.addEventListener('click', this.boundHandleModeRelational)
     fields.modeCensusBtn?.addEventListener('click', this.boundHandleModeCensus)
+    fields.modeIdentityBtn?.addEventListener('click', this.boundHandleModeIdentity)
     fields.censusComparisonToggle?.addEventListener('click', this.boundHandleCensusComparisonToggle)
   }
 
@@ -146,6 +154,7 @@ class ConditionForm {
     fields.rightComparisonToggle?.removeEventListener('click', this.boundHandleRightComparisonToggle)
     fields.modeRelationalBtn?.removeEventListener('click', this.boundHandleModeRelational)
     fields.modeCensusBtn?.removeEventListener('click', this.boundHandleModeCensus)
+    fields.modeIdentityBtn?.removeEventListener('click', this.boundHandleModeIdentity)
     fields.censusComparisonToggle?.removeEventListener('click', this.boundHandleCensusComparisonToggle)
   }
 
@@ -187,6 +196,8 @@ class ConditionForm {
     const censusFileInput = this.editorPanel.querySelector('#cond-census-file-input')
     const censusSquareFile = this.editorPanel.querySelector('#cond-census-square-file')
     const censusSquareRank = this.editorPanel.querySelector('#cond-census-square-rank')
+    const identitySubject = this.editorPanel.querySelector('#cond-identity-subject')
+    const identityTarget = this.editorPanel.querySelector('#cond-identity-target')
     const censusRankInputs = pillInputs(censusRankInput)
     const censusFileInputs = pillInputs(censusFileInput)
     const censusSquareFileInputs = pillInputs(censusSquareFile)
@@ -235,6 +246,8 @@ class ConditionForm {
       censusFileInputs,
       censusSquareFileInputs,
       censusSquareRankInputs,
+      identitySubject,
+      identityTarget,
       leftComparisonToggle: this.editorPanel.querySelector('#cond-left-comparison-toggle'),
       leftComparisonBody: this.editorPanel.querySelector('#cond-left-comparison-body'),
       leftComparisonSourceStack: this.editorPanel.querySelector('#cond-left-comparison-source-stack'),
@@ -251,11 +264,13 @@ class ConditionForm {
       formulationPreview: this.editorPanel.querySelector('#cond-formulation-preview'),
       modeRelationalBtn: this.editorPanel.querySelector('#cond-mode-relational'),
       modeCensusBtn: this.editorPanel.querySelector('#cond-mode-census'),
+      modeIdentityBtn: this.editorPanel.querySelector('#cond-mode-identity'),
       relationalTargetNote: this.editorPanel.querySelector('#cond-relational-target-note'),
       leftAggregateNote: this.editorPanel.querySelector('#cond-left-aggregate-note'),
       rightAggregateNote: this.editorPanel.querySelector('#cond-right-aggregate-note'),
-      mainLayout: this.editorPanel.querySelector('.condition-form-layout:not(.condition-form-position-layout)'),
+      mainLayout: this.editorPanel.querySelector('.condition-form-layout:not(.condition-form-position-layout):not(.condition-form-identity-layout)'),
       censusLayout: this.editorPanel.querySelector('#cond-census-layout'),
+      identityLayout: this.editorPanel.querySelector('#cond-identity-layout'),
       censusFilterRow: this.editorPanel.querySelector('#cond-census-filter-row'),
       censusFilterModeControl: censusFilterMode?.closest('.condition-form-checkbox'),
       censusComparisonToggle: this.editorPanel.querySelector('#cond-census-comparison-toggle'),
@@ -273,7 +288,8 @@ class ConditionForm {
         censusSubject, censusFilterMode, censusFilter, censusOperator, ...censusComparatorInputs,
         censusTarget, censusTargetFilter, censusTargetFilterMode,
         censusScopeWhole, censusAxisRank, censusAxisFile, censusAxisSquare, ...censusRegionComparatorInputs,
-        ...censusRankInputs, ...censusFileInputs, ...censusSquareFileInputs, ...censusSquareRankInputs
+        ...censusRankInputs, ...censusFileInputs, ...censusSquareFileInputs, ...censusSquareRankInputs,
+        identitySubject, identityTarget
       ],
       numberInputs: [
         leftComparisonSourceTotal,
@@ -291,6 +307,8 @@ class ConditionForm {
     }
     if (this.state.mode === 'census') {
       this.applyCensusCompatibilityRules()
+    } else if (this.state.mode === 'identity') {
+      this.applyIdentityCompatibilityRules()
     } else {
       this.applyRelationalCompatibilityRules()
     }
@@ -298,10 +316,21 @@ class ConditionForm {
   }
 
   isValidV2Node(nodeData = {}) {
-    return nodeData.version === 2 && (nodeData.kind === 'relational' || nodeData.kind === 'census')
+    return nodeData.version === 2 && (nodeData.kind === 'relational' || nodeData.kind === 'census' || nodeData.kind === 'identity')
   }
 
   stateFromNodeData(nodeData) {
+    if (nodeData.kind === 'identity') {
+      return {
+        mode: 'identity',
+        relational: structuredClone(DEFAULT_RELATIONAL_STATE),
+        census: structuredClone(DEFAULT_CENSUS_STATE),
+        identity: {
+          subject: nodeData.subject || DEFAULT_IDENTITY_STATE.subject,
+          target: nodeData.target || DEFAULT_IDENTITY_STATE.target
+        }
+      }
+    }
     if (nodeData.kind === 'census') {
       const hasRegion = nodeData.positionAxis !== undefined && nodeData.positionAxis !== null
       const isSquare = nodeData.positionAxis === 'square'
@@ -310,6 +339,7 @@ class ConditionForm {
       return {
         mode: 'census',
         relational: structuredClone(DEFAULT_RELATIONAL_STATE),
+        identity: structuredClone(DEFAULT_IDENTITY_STATE),
         census: {
           left: {
             subject: nodeData.subject || 'allied',
@@ -336,6 +366,7 @@ class ConditionForm {
       return {
         mode: 'relational',
         census: structuredClone(DEFAULT_CENSUS_STATE),
+        identity: structuredClone(DEFAULT_IDENTITY_STATE),
         relational: {
           left: this.relationalSideState({
             subject: nodeData.subject,
@@ -388,18 +419,23 @@ class ConditionForm {
     const fields = this.fields()
     const isRelational = this.state.mode === 'relational'
     const isCensus = this.state.mode === 'census'
+    const isIdentity = this.state.mode === 'identity'
 
     fields.modeRelationalBtn?.classList.toggle('active', isRelational)
     fields.modeCensusBtn?.classList.toggle('active', isCensus)
+    fields.modeIdentityBtn?.classList.toggle('active', isIdentity)
 
     fields.relationalOperatorSelect?.classList.toggle('hidden', !isRelational)
     fields.rightRelationalFields?.classList.toggle('hidden', !isRelational)
-    fields.leftComparisonSection?.classList.toggle('hidden', !isRelational || this.usesSamePiece())
-    fields.mainLayout?.classList.toggle('hidden', isCensus)
+    fields.leftComparisonSection?.classList.toggle('hidden', !isRelational)
+    fields.mainLayout?.classList.toggle('hidden', !isRelational)
     fields.censusLayout?.classList.toggle('hidden', !isCensus)
+    fields.identityLayout?.classList.toggle('hidden', !isIdentity)
 
     if (isCensus) {
       this.renderCensus(fields)
+    } else if (isIdentity) {
+      this.renderIdentity(fields)
     } else {
       this.renderRelational(fields)
     }
@@ -413,9 +449,8 @@ class ConditionForm {
 
   renderRelational(fields) {
     const rel = this.state.relational
-    const samePieceMode = this.usesSamePiece()
-    const leftComparisonActive = !samePieceMode && rel.ui.leftComparisonOpen
-    const rightComparisonActive = !samePieceMode && rel.ui.rightComparisonOpen
+    const leftComparisonActive = rel.ui.leftComparisonOpen
+    const rightComparisonActive = rel.ui.rightComparisonOpen
     const leftFilterModeAvailable = rel.left.filter !== 'any'
     const rightFilterModeAvailable = rel.right.filter !== 'any'
 
@@ -443,11 +478,11 @@ class ConditionForm {
     fields.leftComparisonSourceStack?.classList.toggle('condition-form-comparison-source-stack--inline-number', rel.left.comparisonSource === 'exact_number')
     fields.rightComparisonSourceStack?.classList.toggle('condition-form-comparison-source-stack--inline-number', rel.right.comparisonSource === 'exact_number')
 
-    fields.leftFilterRow.classList.toggle('hidden', samePieceMode)
-    fields.rightFilterRow.classList.toggle('hidden', samePieceMode)
+    fields.leftFilterRow.classList.toggle('hidden', false)
+    fields.rightFilterRow.classList.toggle('hidden', false)
     fields.leftFilterModeControl?.classList.toggle('condition-form-checkbox--unavailable', !leftFilterModeAvailable)
     fields.rightFilterModeControl?.classList.toggle('condition-form-checkbox--unavailable', !rightFilterModeAvailable)
-    fields.rightComparisonToggle.closest('.condition-form-comparison').classList.toggle('hidden', samePieceMode)
+    fields.rightComparisonToggle.closest('.condition-form-comparison').classList.toggle('hidden', false)
 
     const leftLocked = this.comparisonLocked('left')
     const rightLocked = this.comparisonLocked('right')
@@ -461,7 +496,7 @@ class ConditionForm {
 
     this.showAllOptions(fields.leftSubject)
     this.showAllOptions(fields.rightSubject)
-    this.disableRelationalSubjectOptions(fields, samePieceMode)
+    this.disableRelationalSubjectOptions(fields)
     this.disableRelationalComparisonSourceOptions(fields)
     this.disableRelationalComparisonMetricOptions(fields)
 
@@ -531,6 +566,20 @@ class ConditionForm {
     this.disableCensusTargetOptions(fields)
   }
 
+  renderIdentity(fields) {
+    const id = this.state.identity
+    if (fields.identitySubject) fields.identitySubject.value = id.subject
+    if (fields.identityTarget) {
+      fields.identityTarget.value = id.target
+      const allowed = this.samePieceTargetsFor(id.subject)
+      this.showAllOptions(fields.identityTarget)
+      this.disableOptions(
+        fields.identityTarget,
+        Array.from(fields.identityTarget.options).map(o => o.value).filter(v => !allowed.includes(v))
+      )
+    }
+  }
+
   toggleLeftComparison() {
     if (this.state.mode !== 'relational') { return }
     if (this.comparisonLocked('left')) { return }
@@ -596,6 +645,10 @@ class ConditionForm {
       this.state.relational.right.comparisonSource = fields.rightComparisonSource?.value || 'exact_number'
       this.state.relational.right.comparisonSourceTotal = Number(fields.rightComparisonSourceTotal?.value || 1)
       this.applyRelationalCompatibilityRules()
+    } else if (this.state.mode === 'identity') {
+      this.state.identity.subject = fields.identitySubject?.value || DEFAULT_IDENTITY_STATE.subject
+      this.state.identity.target = fields.identityTarget?.value || DEFAULT_IDENTITY_STATE.target
+      this.applyIdentityCompatibilityRules()
     } else {
       const cen = this.state.census
       cen.left.subject = fields.censusSubject?.value || 'allied'
@@ -659,6 +712,13 @@ class ConditionForm {
         }
       }
       return payload
+    } else if (this.state.mode === 'identity') {
+      return {
+        version: 2,
+        kind: 'identity',
+        subject: this.state.identity.subject,
+        target: this.state.identity.target
+      }
     } else {
       const rel = this.state.relational
       const payload = {
@@ -711,8 +771,16 @@ class ConditionForm {
 
   // -------------------------------- GRAMMAR RULES ----------------------------------
 
-  usesSamePiece() {
-    return this.state.mode === 'relational' && this.state.relational.operator === 'same_piece'
+  applyIdentityCompatibilityRules() {
+    const id = this.state.identity
+    const allowedSubjects = Object.keys(this.grammarRules.samePieceTargets)
+    if (!allowedSubjects.includes(id.subject)) {
+      id.subject = allowedSubjects[0]
+    }
+    const allowedTargets = this.samePieceTargetsFor(id.subject)
+    if (!allowedTargets.includes(id.target)) {
+      id.target = allowedTargets[0]
+    }
   }
 
   clearRelationalComparator(side) {
@@ -725,23 +793,6 @@ class ConditionForm {
 
   applyRelationalCompatibilityRules() {
     const rel = this.state.relational
-
-    if (this.usesSamePiece()) {
-      const allowedLeft = Object.keys(this.grammarRules.samePieceTargets)
-      if (!allowedLeft.includes(rel.left.subject)) {
-        rel.left.subject = allowedLeft[0]
-      }
-      rel.right.subject = this.samePieceTargetsFor(rel.left.subject)[0]
-      rel.left.filter = 'any'
-      rel.left.filterMode = 'include'
-      rel.right.filter = 'any'
-      rel.right.filterMode = 'include'
-      this.clearRelationalComparator('left')
-      this.clearRelationalComparator('right')
-      rel.ui.leftComparisonOpen = false
-      rel.ui.rightComparisonOpen = false
-      return
-    }
 
     if (rel.right.subject === 'captured_piece') {
       rel.right.subject = 'enemy'
@@ -1010,17 +1061,9 @@ class ConditionForm {
     this.disableOptions(select, otherUsesAggregate ? ['aggregate_value'] : [])
   }
 
-  disableRelationalSubjectOptions(fields, samePieceMode) {
+  disableRelationalSubjectOptions(fields) {
     this.enableAllOptions(fields.leftSubject)
     this.enableAllOptions(fields.rightSubject)
-
-    if (samePieceMode) {
-      const leftAllowed = Object.keys(this.grammarRules.samePieceTargets)
-      const rightAllowed = this.samePieceTargetsFor(this.state.relational.left.subject)
-      this.disableOptions(fields.leftSubject, this.editorSubjects().filter(v => !leftAllowed.includes(v)))
-      this.disableOptions(fields.rightSubject, this.editorSubjects().filter(v => !rightAllowed.includes(v)))
-      return
-    }
 
     this.disableOptions(fields.leftSubject, this.editorSubjects().filter(v => !this.regularRelationalSubjects().includes(v)))
     this.disableOptions(fields.rightSubject, this.editorSubjects().filter(v => !this.regularRelationalTargets().includes(v)))

--- a/app/javascript/editorV2/panels/ConditionForm.js
+++ b/app/javascript/editorV2/panels/ConditionForm.js
@@ -1,5 +1,27 @@
 import { formatConditionPreview } from 'editorV2/utils/conditionPreviewFormatter'
 
+const PILL_INPUT_CACHE = new WeakMap()
+
+function pillInputs(container) {
+  if (!container) { return [] }
+  let inputs = PILL_INPUT_CACHE.get(container)
+  if (!inputs) {
+    inputs = Array.from(container.querySelectorAll('input[type="radio"]'))
+    PILL_INPUT_CACHE.set(container, inputs)
+  }
+  return inputs
+}
+
+function pillValue(inputs) {
+  return inputs?.find(input => input.checked)?.value
+}
+
+function setPillChecked(inputs, value, numeric = false) {
+  inputs?.forEach(input => {
+    input.checked = (numeric ? Number(input.value) : input.value) === value
+  })
+}
+
 const DEFAULT_RELATIONAL_STATE = {
   left: {
     subject: 'allied',
@@ -26,37 +48,25 @@ const DEFAULT_RELATIONAL_STATE = {
   }
 }
 
-const DEFAULT_MEASURE_STATE = {
-  left: {
-    subject: 'allied',
-    filter: 'any',
-    filterMode: 'include',
-  },
-  operator: 'count',
-  unary: {
-    comparator: 'greater_than',
-    target: 'exact_number',
-    targetFilter: 'any',
-    targetFilterMode: 'include',
-    targetTotal: 0
-  }
-}
-
-const DEFAULT_POSITION_STATE = {
+const DEFAULT_CENSUS_STATE = {
   left: {
     subject: 'allied',
     filter: 'any',
     filterMode: 'include'
   },
+  scope: 'region',
   positionAxis: 'rank',
   positionComparator: 'equal_to',
   positionRankTarget: 1,
   positionFileTarget: 1,
   positionSquareFile: 1,
   positionSquareRank: 1,
-  comparisonOpen: false,
+  advanced: false,
   operator: 'count',
   comparator: 'greater_than',
+  target: 'exact_number',
+  targetFilter: 'any',
+  targetFilterMode: 'include',
   targetTotal: 0
 }
 
@@ -95,17 +105,15 @@ class ConditionForm {
     this.boundHandleLeftComparisonToggle = this.toggleLeftComparison.bind(this)
     this.boundHandleRightComparisonToggle = this.toggleRightComparison.bind(this)
     this.boundHandleModeRelational = () => this.handleModeChange('relational')
-    this.boundHandleModeMeasure = () => this.handleModeChange('measure')
-    this.boundHandleModePosition = () => this.handleModeChange('position')
-    this.boundHandlePositionComparisonToggle = this.togglePositionComparison.bind(this)
+    this.boundHandleModeCensus = () => this.handleModeChange('census')
+    this.boundHandleCensusComparisonToggle = this.toggleCensusComparison.bind(this)
   }
 
   defaultState() {
     return {
-      mode: 'relational',
+      mode: 'census',
       relational: structuredClone(DEFAULT_RELATIONAL_STATE),
-      measure: structuredClone(DEFAULT_MEASURE_STATE),
-      position: structuredClone(DEFAULT_POSITION_STATE)
+      census: structuredClone(DEFAULT_CENSUS_STATE)
     }
   }
 
@@ -126,9 +134,8 @@ class ConditionForm {
     fields.leftComparisonToggle?.addEventListener('click', this.boundHandleLeftComparisonToggle)
     fields.rightComparisonToggle?.addEventListener('click', this.boundHandleRightComparisonToggle)
     fields.modeRelationalBtn?.addEventListener('click', this.boundHandleModeRelational)
-    fields.modeMeasureBtn?.addEventListener('click', this.boundHandleModeMeasure)
-    fields.modePositionBtn?.addEventListener('click', this.boundHandleModePosition)
-    fields.positionComparisonToggle?.addEventListener('click', this.boundHandlePositionComparisonToggle)
+    fields.modeCensusBtn?.addEventListener('click', this.boundHandleModeCensus)
+    fields.censusComparisonToggle?.addEventListener('click', this.boundHandleCensusComparisonToggle)
   }
 
   detach() {
@@ -138,9 +145,8 @@ class ConditionForm {
     fields.leftComparisonToggle?.removeEventListener('click', this.boundHandleLeftComparisonToggle)
     fields.rightComparisonToggle?.removeEventListener('click', this.boundHandleRightComparisonToggle)
     fields.modeRelationalBtn?.removeEventListener('click', this.boundHandleModeRelational)
-    fields.modeMeasureBtn?.removeEventListener('click', this.boundHandleModeMeasure)
-    fields.modePositionBtn?.removeEventListener('click', this.boundHandleModePosition)
-    fields.positionComparisonToggle?.removeEventListener('click', this.boundHandlePositionComparisonToggle)
+    fields.modeCensusBtn?.removeEventListener('click', this.boundHandleModeCensus)
+    fields.censusComparisonToggle?.removeEventListener('click', this.boundHandleCensusComparisonToggle)
   }
 
   fields() {
@@ -149,22 +155,42 @@ class ConditionForm {
     const leftFilter = this.editorPanel.querySelector('#cond-left-filter')
     const leftComparisonMetric = this.editorPanel.querySelector('#cond-left-comparison-metric')
     const leftComparator = this.editorPanel.querySelector('#cond-left-comparator')
+    const leftComparatorInputs = pillInputs(leftComparator)
     const leftComparisonSource = this.editorPanel.querySelector('#cond-left-comparison-source')
     const leftComparisonSourceTotal = this.editorPanel.querySelector('#cond-left-comparison-source-total')
     const relationalOperatorSelect = this.editorPanel.querySelector('#cond-relational-operator')
-    const measureOperatorSelect = this.editorPanel.querySelector('#cond-measure-operator')
     const rightSubject = this.editorPanel.querySelector('#cond-right-subject')
     const rightFilterMode = this.editorPanel.querySelector('#cond-right-filter-mode')
     const rightFilter = this.editorPanel.querySelector('#cond-right-filter')
     const rightComparisonMetric = this.editorPanel.querySelector('#cond-right-comparison-metric')
     const rightComparator = this.editorPanel.querySelector('#cond-right-comparator')
+    const rightComparatorInputs = pillInputs(rightComparator)
     const rightComparisonSource = this.editorPanel.querySelector('#cond-right-comparison-source')
     const rightComparisonSourceTotal = this.editorPanel.querySelector('#cond-right-comparison-source-total')
-    const unaryComparator = this.editorPanel.querySelector('#cond-unary-comparator')
-    const unaryTarget = this.editorPanel.querySelector('#cond-unary-target')
-    const unaryTargetTotal = this.editorPanel.querySelector('#cond-unary-target-total')
-    const unaryTargetFilterMode = this.editorPanel.querySelector('#cond-unary-target-filter-mode')
-    const unaryTargetFilter = this.editorPanel.querySelector('#cond-unary-target-filter')
+    const censusSubject = this.editorPanel.querySelector('#cond-census-subject')
+    const censusFilterMode = this.editorPanel.querySelector('#cond-census-filter-mode')
+    const censusFilter = this.editorPanel.querySelector('#cond-census-filter')
+    const censusOperator = this.editorPanel.querySelector('#cond-census-operator')
+    const censusComparator = this.editorPanel.querySelector('#cond-census-comparator')
+    const censusComparatorInputs = pillInputs(censusComparator)
+    const censusTarget = this.editorPanel.querySelector('#cond-census-target')
+    const censusTargetTotal = this.editorPanel.querySelector('#cond-census-target-total')
+    const censusTargetFilter = this.editorPanel.querySelector('#cond-census-target-filter')
+    const censusTargetFilterMode = this.editorPanel.querySelector('#cond-census-target-filter-mode')
+    const censusScopeWhole = this.editorPanel.querySelector('#cond-census-scope-whole')
+    const censusAxisRank = this.editorPanel.querySelector('#cond-census-axis-rank')
+    const censusAxisFile = this.editorPanel.querySelector('#cond-census-axis-file')
+    const censusAxisSquare = this.editorPanel.querySelector('#cond-census-axis-square')
+    const censusRegionComparator = this.editorPanel.querySelector('#cond-census-region-comparator')
+    const censusRegionComparatorInputs = pillInputs(censusRegionComparator)
+    const censusRankInput = this.editorPanel.querySelector('#cond-census-rank-input')
+    const censusFileInput = this.editorPanel.querySelector('#cond-census-file-input')
+    const censusSquareFile = this.editorPanel.querySelector('#cond-census-square-file')
+    const censusSquareRank = this.editorPanel.querySelector('#cond-census-square-rank')
+    const censusRankInputs = pillInputs(censusRankInput)
+    const censusFileInputs = pillInputs(censusFileInput)
+    const censusSquareFileInputs = pillInputs(censusSquareFile)
+    const censusSquareRankInputs = pillInputs(censusSquareRank)
 
     return {
       leftSubject,
@@ -172,23 +198,43 @@ class ConditionForm {
       leftFilter,
       leftComparisonMetric,
       leftComparator,
+      leftComparatorInputs,
       leftComparisonSource,
       leftComparisonSourceTotal,
       relationalOperatorSelect,
-      measureOperatorSelect,
-      operatorSelect: this.state.mode === 'relational' ? relationalOperatorSelect : measureOperatorSelect,
+      operatorSelect: this.state.mode === 'relational' ? relationalOperatorSelect : censusOperator,
       rightSubject,
       rightFilterMode,
       rightFilter,
       rightComparisonMetric,
       rightComparator,
+      rightComparatorInputs,
       rightComparisonSource,
       rightComparisonSourceTotal,
-      unaryComparator,
-      unaryTarget,
-      unaryTargetTotal,
-      unaryTargetFilterMode,
-      unaryTargetFilter,
+      censusSubject,
+      censusFilterMode,
+      censusFilter,
+      censusOperator,
+      censusComparator,
+      censusComparatorInputs,
+      censusTarget,
+      censusTargetTotal,
+      censusTargetFilter,
+      censusTargetFilterMode,
+      censusScopeWhole,
+      censusAxisRank,
+      censusAxisFile,
+      censusAxisSquare,
+      censusRegionComparator,
+      censusRegionComparatorInputs,
+      censusRankInput,
+      censusFileInput,
+      censusSquareFile,
+      censusSquareRank,
+      censusRankInputs,
+      censusFileInputs,
+      censusSquareFileInputs,
+      censusSquareRankInputs,
       leftComparisonToggle: this.editorPanel.querySelector('#cond-left-comparison-toggle'),
       leftComparisonBody: this.editorPanel.querySelector('#cond-left-comparison-body'),
       leftComparisonSourceStack: this.editorPanel.querySelector('#cond-left-comparison-source-stack'),
@@ -199,63 +245,40 @@ class ConditionForm {
       rightFilterModeControl: rightFilterMode?.closest('.condition-form-checkbox'),
       rightCardLabel: this.editorPanel.querySelector('#cond-right-card-label'),
       rightRelationalFields: this.editorPanel.querySelector('#cond-right-relational-fields'),
-      unaryComparisonSection: this.editorPanel.querySelector('#cond-unary-comparison-section'),
-      unaryTargetStack: this.editorPanel.querySelector('#cond-unary-target-stack'),
-      unaryTargetFilterRow: this.editorPanel.querySelector('#cond-unary-target-filter-row'),
-      unaryTargetFilterModeControl: unaryTargetFilterMode?.closest('.condition-form-checkbox'),
       leftComparisonSection: this.editorPanel.querySelector('#cond-left-comparison-section'),
       leftFilterRow: this.editorPanel.querySelector('#cond-left-filter-row'),
       rightFilterRow: this.editorPanel.querySelector('#cond-right-filter-row'),
-      unaryTargetSection: this.editorPanel.querySelector('#cond-unary-target-section'),
       formulationPreview: this.editorPanel.querySelector('#cond-formulation-preview'),
       modeRelationalBtn: this.editorPanel.querySelector('#cond-mode-relational'),
-      modeMeasureBtn: this.editorPanel.querySelector('#cond-mode-measure'),
-      modePositionBtn: this.editorPanel.querySelector('#cond-mode-position'),
-      measureSubjectNote: this.editorPanel.querySelector('#cond-measure-subject-note'),
+      modeCensusBtn: this.editorPanel.querySelector('#cond-mode-census'),
       relationalTargetNote: this.editorPanel.querySelector('#cond-relational-target-note'),
       leftAggregateNote: this.editorPanel.querySelector('#cond-left-aggregate-note'),
       rightAggregateNote: this.editorPanel.querySelector('#cond-right-aggregate-note'),
       mainLayout: this.editorPanel.querySelector('.condition-form-layout:not(.condition-form-position-layout)'),
-      positionLayout: this.editorPanel.querySelector('#cond-position-layout'),
-      positionSubject: this.editorPanel.querySelector('#cond-position-subject'),
-      positionFilterMode: this.editorPanel.querySelector('#cond-position-filter-mode'),
-      positionFilter: this.editorPanel.querySelector('#cond-position-filter'),
-      positionFilterRow: this.editorPanel.querySelector('#cond-position-filter-row'),
-      positionFilterModeControl: this.editorPanel.querySelector('#cond-position-filter-mode')?.closest('.condition-form-checkbox'),
-      positionComparisonToggle: this.editorPanel.querySelector('#cond-position-comparison-toggle'),
-      positionComparisonBody: this.editorPanel.querySelector('#cond-position-comparison-body'),
-      positionAxis: this.editorPanel.querySelector('#cond-position-axis'),
-      positionComparator: this.editorPanel.querySelector('#cond-position-comparator'),
-      positionRankInput: this.editorPanel.querySelector('#cond-position-rank-input'),
-      positionFileInput: this.editorPanel.querySelector('#cond-position-file-input'),
-      positionSquareInputs: this.editorPanel.querySelector('#cond-position-square-inputs'),
-      positionSquareFile: this.editorPanel.querySelector('#cond-position-square-file'),
-      positionSquareRank: this.editorPanel.querySelector('#cond-position-square-rank'),
-      positionOperator: this.editorPanel.querySelector('#cond-position-operator'),
-      positionMetricComparator: this.editorPanel.querySelector('#cond-position-metric-comparator'),
-      positionTargetTotal: this.editorPanel.querySelector('#cond-position-target-total'),
+      censusLayout: this.editorPanel.querySelector('#cond-census-layout'),
+      censusFilterRow: this.editorPanel.querySelector('#cond-census-filter-row'),
+      censusFilterModeControl: censusFilterMode?.closest('.condition-form-checkbox'),
+      censusComparisonToggle: this.editorPanel.querySelector('#cond-census-comparison-toggle'),
+      censusComparisonBody: this.editorPanel.querySelector('#cond-census-comparison-body'),
+      censusTargetStack: this.editorPanel.querySelector('#cond-census-target-stack'),
+      censusTargetFilterRow: this.editorPanel.querySelector('#cond-census-target-filter-row'),
+      censusTargetFilterModeControl: censusTargetFilterMode?.closest('.condition-form-checkbox'),
+      censusScope: this.editorPanel.querySelector('#cond-census-scope'),
+      censusSquareInputs: this.editorPanel.querySelector('#cond-census-square-inputs'),
+      censusRegionTarget: this.editorPanel.querySelector('#cond-census-region-target'),
       all: [
-        leftSubject, leftFilterMode, leftFilter, leftComparisonMetric, leftComparator, leftComparisonSource,
-        relationalOperatorSelect, measureOperatorSelect,
-        rightSubject, rightFilterMode, rightFilter, rightComparisonMetric, rightComparator, rightComparisonSource,
-        unaryComparator, unaryTarget, unaryTargetFilterMode, unaryTargetFilter,
-        this.editorPanel.querySelector('#cond-position-subject'),
-        this.editorPanel.querySelector('#cond-position-filter-mode'),
-        this.editorPanel.querySelector('#cond-position-filter'),
-        this.editorPanel.querySelector('#cond-position-axis'),
-        this.editorPanel.querySelector('#cond-position-comparator'),
-        this.editorPanel.querySelector('#cond-position-rank-input'),
-        this.editorPanel.querySelector('#cond-position-file-input'),
-        this.editorPanel.querySelector('#cond-position-square-file'),
-        this.editorPanel.querySelector('#cond-position-square-rank'),
-        this.editorPanel.querySelector('#cond-position-operator'),
-        this.editorPanel.querySelector('#cond-position-metric-comparator')
+        leftSubject, leftFilterMode, leftFilter, leftComparisonMetric, ...leftComparatorInputs, leftComparisonSource,
+        relationalOperatorSelect,
+        rightSubject, rightFilterMode, rightFilter, rightComparisonMetric, ...rightComparatorInputs, rightComparisonSource,
+        censusSubject, censusFilterMode, censusFilter, censusOperator, ...censusComparatorInputs,
+        censusTarget, censusTargetFilter, censusTargetFilterMode,
+        censusScopeWhole, censusAxisRank, censusAxisFile, censusAxisSquare, ...censusRegionComparatorInputs,
+        ...censusRankInputs, ...censusFileInputs, ...censusSquareFileInputs, ...censusSquareRankInputs
       ],
       numberInputs: [
         leftComparisonSourceTotal,
         rightComparisonSourceTotal,
-        unaryTargetTotal,
-        this.editorPanel.querySelector('#cond-position-target-total')
+        censusTargetTotal
       ]
     }
   }
@@ -266,10 +289,8 @@ class ConditionForm {
     } else {
       this.state = this.defaultState()
     }
-    if (this.state.mode === 'measure') {
-      this.applyUnaryCompatibilityRules()
-    } else if (this.state.mode === 'position') {
-      this.applyPositionCompatibilityRules()
+    if (this.state.mode === 'census') {
+      this.applyCensusCompatibilityRules()
     } else {
       this.applyRelationalCompatibilityRules()
     }
@@ -277,55 +298,44 @@ class ConditionForm {
   }
 
   isValidV2Node(nodeData = {}) {
-    return nodeData.version === 2 && (nodeData.kind === 'relational' || nodeData.kind === 'unary' || nodeData.kind === 'position')
+    return nodeData.version === 2 && (nodeData.kind === 'relational' || nodeData.kind === 'census')
   }
 
   stateFromNodeData(nodeData) {
-    if (nodeData.kind === 'position') {
+    if (nodeData.kind === 'census') {
+      const hasRegion = nodeData.positionAxis !== undefined && nodeData.positionAxis !== null
       const isSquare = nodeData.positionAxis === 'square'
       const squareFile = isSquare ? ((nodeData.positionTarget % 8) + 1) : 1
       const squareRank = isSquare ? (Math.floor(nodeData.positionTarget / 8) + 1) : 1
       return {
-        mode: 'position',
+        mode: 'census',
         relational: structuredClone(DEFAULT_RELATIONAL_STATE),
-        measure: structuredClone(DEFAULT_MEASURE_STATE),
-        position: {
+        census: {
           left: {
             subject: nodeData.subject || 'allied',
             filter: nodeData.subjectFilter || 'any',
             filterMode: nodeData.subjectFilterMode || 'include'
           },
+          scope: hasRegion ? 'region' : 'whole',
           positionAxis: nodeData.positionAxis || 'rank',
           positionComparator: nodeData.positionComparator || 'equal_to',
           positionRankTarget: nodeData.positionAxis === 'rank' ? (nodeData.positionTarget || 1) : 1,
           positionFileTarget: nodeData.positionAxis === 'file' ? (nodeData.positionTarget || 1) : 1,
           positionSquareFile: squareFile,
           positionSquareRank: squareRank,
+          advanced: Boolean(nodeData.target) && nodeData.target !== 'exact_number',
           operator: nodeData.operator || 'count',
           comparator: nodeData.comparator || 'greater_than',
+          target: nodeData.target || 'exact_number',
+          targetFilter: nodeData.targetFilter || 'any',
+          targetFilterMode: nodeData.targetFilterMode || 'include',
           targetTotal: typeof nodeData.targetTotal === 'number' ? nodeData.targetTotal : 0
-        }
-      }
-    }
-    if (nodeData.kind === 'unary') {
-      return {
-        mode: 'measure',
-        relational: structuredClone(DEFAULT_RELATIONAL_STATE),
-        position: structuredClone(DEFAULT_POSITION_STATE),
-        measure: {
-          left: {
-            subject: nodeData.subject || 'allied',
-            filter: nodeData.subjectFilter || 'any',
-            filterMode: nodeData.subjectFilterMode || 'include',
-          },
-          operator: nodeData.operator || 'count',
-          unary: this.unaryStateFromNodeData(nodeData)
         }
       }
     } else {
       return {
         mode: 'relational',
-        position: structuredClone(DEFAULT_POSITION_STATE),
+        census: structuredClone(DEFAULT_CENSUS_STATE),
         relational: {
           left: this.relationalSideState({
             subject: nodeData.subject,
@@ -350,8 +360,7 @@ class ConditionForm {
             leftComparisonOpen: Boolean(nodeData.subjectComparisonMetric),
             rightComparisonOpen: Boolean(nodeData.targetComparisonMetric),
           }
-        },
-        measure: structuredClone(DEFAULT_MEASURE_STATE)
+        }
       }
     }
   }
@@ -375,42 +384,24 @@ class ConditionForm {
     }
   }
 
-  unaryStateFromNodeData(nodeData) {
-    return {
-      comparator: nodeData.comparator || 'greater_than',
-      target: nodeData.target || 'exact_number',
-      targetFilter: nodeData.targetFilter || 'any',
-      targetFilterMode: nodeData.targetFilterMode || 'include',
-      targetTotal: typeof nodeData.targetTotal === 'number' ? nodeData.targetTotal : 0
-    }
-  }
-
   render() {
     const fields = this.fields()
     const isRelational = this.state.mode === 'relational'
-    const isMeasure = this.state.mode === 'measure'
-    const isPosition = this.state.mode === 'position'
+    const isCensus = this.state.mode === 'census'
 
     fields.modeRelationalBtn?.classList.toggle('active', isRelational)
-    fields.modeMeasureBtn?.classList.toggle('active', isMeasure)
-    fields.modePositionBtn?.classList.toggle('active', isPosition)
+    fields.modeCensusBtn?.classList.toggle('active', isCensus)
 
     fields.relationalOperatorSelect?.classList.toggle('hidden', !isRelational)
-    fields.measureOperatorSelect?.classList.toggle('hidden', isRelational)
-    fields.rightRelationalFields.classList.toggle('hidden', !isRelational)
-    fields.unaryComparisonSection.classList.toggle('hidden', isRelational)
-    fields.unaryTargetSection?.classList.toggle('hidden', isRelational)
-    fields.leftComparisonSection.classList.toggle('hidden', !isRelational || this.usesSamePiece())
-    fields.unaryTargetStack?.classList.toggle('condition-form-comparison-source-stack--inline-number', this.state.measure.unary.target === 'exact_number')
-    fields.mainLayout?.classList.toggle('hidden', isPosition)
-    fields.positionLayout?.classList.toggle('hidden', !isPosition)
+    fields.rightRelationalFields?.classList.toggle('hidden', !isRelational)
+    fields.leftComparisonSection?.classList.toggle('hidden', !isRelational || this.usesSamePiece())
+    fields.mainLayout?.classList.toggle('hidden', isCensus)
+    fields.censusLayout?.classList.toggle('hidden', !isCensus)
 
-    if (isPosition) {
-      this.renderPosition(fields)
-    } else if (isRelational) {
-      this.renderRelational(fields)
+    if (isCensus) {
+      this.renderCensus(fields)
     } else {
-      this.renderMeasure(fields)
+      this.renderRelational(fields)
     }
 
     if (fields.formulationPreview) {
@@ -433,7 +424,7 @@ class ConditionForm {
     if (fields.leftFilterMode) fields.leftFilterMode.checked = leftFilterModeAvailable && rel.left.filterMode === 'exclude'
     if (fields.leftFilter) fields.leftFilter.value = rel.left.filter
     if (fields.leftComparisonMetric) fields.leftComparisonMetric.value = rel.left.comparisonMetric || 'count'
-    if (fields.leftComparator) fields.leftComparator.value = rel.left.comparator
+    setPillChecked(fields.leftComparatorInputs, rel.left.comparator)
     if (fields.leftComparisonSource) fields.leftComparisonSource.value = rel.left.comparisonSource
     if (fields.leftComparisonSourceTotal) fields.leftComparisonSourceTotal.value = rel.left.comparisonSourceTotal
 
@@ -441,7 +432,7 @@ class ConditionForm {
     if (fields.rightFilterMode) fields.rightFilterMode.checked = rightFilterModeAvailable && rel.right.filterMode === 'exclude'
     if (fields.rightFilter) fields.rightFilter.value = rel.right.filter
     if (fields.rightComparisonMetric) fields.rightComparisonMetric.value = rel.right.comparisonMetric || 'count'
-    if (fields.rightComparator) fields.rightComparator.value = rel.right.comparator
+    setPillChecked(fields.rightComparatorInputs, rel.right.comparator)
     if (fields.rightComparisonSource) fields.rightComparisonSource.value = rel.right.comparisonSource
     if (fields.rightComparisonSourceTotal) fields.rightComparisonSourceTotal.value = rel.right.comparisonSourceTotal
 
@@ -462,8 +453,8 @@ class ConditionForm {
     const rightLocked = this.comparisonLocked('right')
     fields.leftComparisonToggle.disabled = leftLocked
     fields.rightComparisonToggle.disabled = rightLocked
-    fields.leftComparisonToggle.textContent = leftLocked ? this.comparisonUnavailableText('left') : (rel.ui.leftComparisonOpen ? 'Hide comparison' : '+ comparison')
-    fields.rightComparisonToggle.textContent = rightLocked ? this.comparisonUnavailableText('right') : (rel.ui.rightComparisonOpen ? 'Hide comparison' : '+ comparison')
+    fields.leftComparisonToggle.textContent = leftLocked ? this.comparisonUnavailableText('left') : (rel.ui.leftComparisonOpen ? 'Hide comparison' : '+ comparison (advanced)')
+    fields.rightComparisonToggle.textContent = rightLocked ? this.comparisonUnavailableText('right') : (rel.ui.rightComparisonOpen ? 'Hide comparison' : '+ comparison (advanced)')
 
     this.setComparisonInputsDisabled('left', fields, !leftComparisonActive)
     this.setComparisonInputsDisabled('right', fields, !rightComparisonActive)
@@ -475,76 +466,69 @@ class ConditionForm {
     this.disableRelationalComparisonMetricOptions(fields)
 
     fields.relationalTargetNote?.classList.toggle('hidden', rel.operator !== 'shield')
-    fields.measureSubjectNote?.classList.toggle('hidden', true)
     fields.rightAggregateNote?.classList.toggle('hidden', !this.leftUsesAggregateValue())
     fields.leftAggregateNote?.classList.toggle('hidden', !this.rightUsesAggregateValue())
   }
 
-  renderMeasure(fields) {
-    const meas = this.state.measure
-    const unaryTargetFilterAvailable = this.unaryTargetUsesActor()
-    const unaryTargetFilterModeAvailable = unaryTargetFilterAvailable && meas.unary.targetFilter !== 'any'
+  renderCensus(fields) {
+    const cen = this.state.census
+    const region = cen.scope === 'region'
+    const isSquare = region && cen.positionAxis === 'square'
+    const filterModeAvailable = cen.left.filter !== 'any'
+    const targetUsesActor = this.censusTargetUsesActor()
+    const targetFilterModeAvailable = targetUsesActor && cen.targetFilter !== 'any'
 
-    if (fields.measureOperatorSelect) fields.measureOperatorSelect.value = meas.operator
-    if (fields.leftSubject) fields.leftSubject.value = meas.left.subject
-    if (fields.leftFilterMode) fields.leftFilterMode.checked = meas.left.filter !== 'any' && meas.left.filterMode === 'exclude'
-    if (fields.leftFilter) fields.leftFilter.value = meas.left.filter
-    if (fields.unaryComparator) fields.unaryComparator.value = meas.unary.comparator
-    if (fields.unaryTarget) fields.unaryTarget.value = meas.unary.target
-    if (fields.unaryTargetTotal) fields.unaryTargetTotal.value = meas.unary.targetTotal
-    if (fields.unaryTargetFilter) fields.unaryTargetFilter.value = meas.unary.targetFilter
-    if (fields.unaryTargetFilterMode) fields.unaryTargetFilterMode.checked = unaryTargetFilterModeAvailable && meas.unary.targetFilterMode === 'exclude'
+    if (fields.censusSubject) fields.censusSubject.value = cen.left.subject
+    if (fields.censusFilterMode) fields.censusFilterMode.checked = filterModeAvailable && cen.left.filterMode === 'exclude'
+    if (fields.censusFilter) fields.censusFilter.value = cen.left.filter
+    if (fields.censusScopeWhole) fields.censusScopeWhole.checked = !region
+    if (fields.censusAxisRank) fields.censusAxisRank.checked = region && cen.positionAxis === 'rank'
+    if (fields.censusAxisFile) fields.censusAxisFile.checked = region && cen.positionAxis === 'file'
+    if (fields.censusAxisSquare) fields.censusAxisSquare.checked = region && cen.positionAxis === 'square'
+    fields.censusRegionComparatorInputs?.forEach(input => {
+      input.checked = input.value === cen.positionComparator
+      input.disabled = isSquare && input.value !== 'equal_to'
+    })
+    setPillChecked(fields.censusRankInputs, cen.positionRankTarget, true)
+    setPillChecked(fields.censusFileInputs, cen.positionFileTarget, true)
+    setPillChecked(fields.censusSquareFileInputs, cen.positionSquareFile, true)
+    setPillChecked(fields.censusSquareRankInputs, cen.positionSquareRank, true)
+    if (fields.censusOperator) fields.censusOperator.value = cen.operator
+    setPillChecked(fields.censusComparatorInputs, cen.comparator)
+    if (fields.censusTarget) fields.censusTarget.value = cen.target
+    if (fields.censusTargetTotal) fields.censusTargetTotal.value = cen.targetTotal
+    if (fields.censusTargetFilter) fields.censusTargetFilter.value = cen.targetFilter
+    if (fields.censusTargetFilterMode) fields.censusTargetFilterMode.checked = targetFilterModeAvailable && cen.targetFilterMode === 'exclude'
 
-    fields.unaryTargetTotal?.classList.toggle('hidden', meas.unary.target !== 'exact_number')
-    fields.unaryTargetFilterRow?.classList.toggle('hidden', !unaryTargetFilterAvailable)
-    fields.leftFilterRow.classList.toggle('hidden', false)
-    fields.leftFilterModeControl?.classList.toggle('condition-form-checkbox--unavailable', meas.left.filter === 'any')
-    fields.unaryTargetFilterModeControl?.classList.toggle('condition-form-checkbox--unavailable', !unaryTargetFilterModeAvailable)
+    fields.censusRegionComparator?.classList.toggle('hidden', !region)
+    fields.censusRegionComparator?.classList.toggle('condition-form-comparator-toggle--locked', isSquare)
+    fields.censusRegionTarget?.classList.toggle('hidden', false)
+    fields.censusRankInput?.classList.toggle('hidden', !region || isSquare || cen.positionAxis === 'file')
+    fields.censusFileInput?.classList.toggle('hidden', !region || isSquare || cen.positionAxis === 'rank')
+    fields.censusSquareInputs?.classList.toggle('hidden', region && !isSquare)
+    fields.censusSquareInputs?.classList.toggle('condition-form-radio-list--disabled', !region)
+    const squareTargetInputs = [...(fields.censusSquareFileInputs || []), ...(fields.censusSquareRankInputs || [])]
+    squareTargetInputs.forEach(input => { input.disabled = !region })
 
-    this.setUnaryComparisonInputsDisabled(fields, false)
+    fields.censusTarget?.classList.toggle('hidden', !cen.advanced)
+    fields.censusTargetTotal?.classList.toggle('hidden', cen.target !== 'exact_number')
+    fields.censusTargetFilterRow?.classList.toggle('hidden', !targetUsesActor)
+    fields.censusTargetStack?.classList.toggle('condition-form-comparison-source-stack--inline-number', cen.target === 'exact_number')
 
-    this.showAllOptions(fields.leftSubject)
-    this.showAllOptions(fields.unaryTarget)
-    this.disableMeasureSubjectOptions(fields)
-    this.disableUnaryTargetOptions(fields)
-
-    fields.measureSubjectNote?.classList.toggle('hidden', meas.operator !== 'mobility')
-    fields.relationalTargetNote?.classList.toggle('hidden', true)
-  }
-
-  renderPosition(fields) {
-    const pos = this.state.position
-    const isSquare = pos.positionAxis === 'square'
-    const filterModeAvailable = pos.left.filter !== 'any'
-
-    if (fields.positionSubject) fields.positionSubject.value = pos.left.subject
-    if (fields.positionFilterMode) fields.positionFilterMode.checked = filterModeAvailable && pos.left.filterMode === 'exclude'
-    if (fields.positionFilter) fields.positionFilter.value = pos.left.filter
-    if (fields.positionAxis) fields.positionAxis.value = pos.positionAxis
-    if (fields.positionComparator) fields.positionComparator.value = pos.positionComparator
-    if (fields.positionRankInput) fields.positionRankInput.value = pos.positionRankTarget
-    if (fields.positionFileInput) fields.positionFileInput.value = pos.positionFileTarget
-    if (fields.positionSquareFile) fields.positionSquareFile.value = pos.positionSquareFile
-    if (fields.positionSquareRank) fields.positionSquareRank.value = pos.positionSquareRank
-    if (fields.positionOperator) fields.positionOperator.value = pos.operator
-    if (fields.positionMetricComparator) fields.positionMetricComparator.value = pos.comparator
-    if (fields.positionTargetTotal) fields.positionTargetTotal.value = pos.targetTotal
-
-    fields.positionRankInput?.classList.toggle('hidden', isSquare || pos.positionAxis === 'file')
-    fields.positionFileInput?.classList.toggle('hidden', isSquare || pos.positionAxis === 'rank')
-    fields.positionSquareInputs?.classList.toggle('hidden', !isSquare)
-    fields.positionComparator?.classList.toggle('hidden', isSquare)
-
-    fields.positionComparisonBody?.classList.toggle('hidden', !pos.comparisonOpen)
-    if (fields.positionComparisonToggle) {
-      fields.positionComparisonToggle.textContent = pos.comparisonOpen ? 'Hide comparison' : '+ comparison'
+    fields.censusComparisonBody?.classList.toggle('hidden', false)
+    fields.censusComparisonToggle?.classList.toggle('hidden', false)
+    if (fields.censusComparisonToggle) {
+      fields.censusComparisonToggle.textContent = cen.advanced ? 'Simplify' : '+ Advanced options'
     }
 
-    fields.positionFilterModeControl?.classList.toggle('condition-form-checkbox--unavailable', !filterModeAvailable)
+    fields.censusFilterModeControl?.classList.toggle('condition-form-checkbox--unavailable', !filterModeAvailable)
+    fields.censusTargetFilterModeControl?.classList.toggle('condition-form-checkbox--unavailable', !targetFilterModeAvailable)
 
-    this.showAllOptions(fields.positionSubject)
-    this.disablePositionSubjectOptions(fields)
-    this.disablePositionOperatorOptions(fields)
+    this.showAllOptions(fields.censusSubject)
+    this.showAllOptions(fields.censusTarget)
+    this.disableCensusSubjectOptions(fields)
+    this.disableCensusOperatorOptions(fields)
+    this.disableCensusTargetOptions(fields)
   }
 
   toggleLeftComparison() {
@@ -563,9 +547,10 @@ class ConditionForm {
     this.render()
   }
 
-  togglePositionComparison() {
-    if (this.state.mode !== 'position') { return }
-    this.state.position.comparisonOpen = !this.state.position.comparisonOpen
+  toggleCensusComparison() {
+    if (this.state.mode !== 'census') { return }
+    this.state.census.advanced = !this.state.census.advanced
+    this.applyCensusCompatibilityRules()
     this.render()
   }
 
@@ -591,16 +576,15 @@ class ConditionForm {
     this.render()
   }
 
-  handleFieldChange(event) {
+  handleFieldChange() {
     const fields = this.fields()
-    const changedId = event?.target?.id
 
     if (this.state.mode === 'relational') {
       this.state.relational.left.subject = fields.leftSubject?.value || 'allied'
       this.state.relational.left.filterMode = fields.leftFilterMode?.checked ? 'exclude' : 'include'
       this.state.relational.left.filter = fields.leftFilter?.value || 'any'
       this.state.relational.left.comparisonMetric = fields.leftComparisonMetric?.value || ''
-      this.state.relational.left.comparator = fields.leftComparator?.value || 'equal_to'
+      this.state.relational.left.comparator = pillValue(fields.leftComparatorInputs) || 'equal_to'
       this.state.relational.left.comparisonSource = fields.leftComparisonSource?.value || 'exact_number'
       this.state.relational.left.comparisonSourceTotal = Number(fields.leftComparisonSourceTotal?.value || 1)
       this.state.relational.operator = fields.relationalOperatorSelect?.value || 'targets'
@@ -608,83 +592,72 @@ class ConditionForm {
       this.state.relational.right.filterMode = fields.rightFilterMode?.checked ? 'exclude' : 'include'
       this.state.relational.right.filter = fields.rightFilter?.value || 'any'
       this.state.relational.right.comparisonMetric = fields.rightComparisonMetric?.value || ''
-      this.state.relational.right.comparator = fields.rightComparator?.value || 'equal_to'
+      this.state.relational.right.comparator = pillValue(fields.rightComparatorInputs) || 'equal_to'
       this.state.relational.right.comparisonSource = fields.rightComparisonSource?.value || 'exact_number'
       this.state.relational.right.comparisonSourceTotal = Number(fields.rightComparisonSourceTotal?.value || 1)
       this.applyRelationalCompatibilityRules()
-    } else if (this.state.mode === 'measure') {
-      this.state.measure.left.subject = fields.leftSubject?.value || 'allied'
-      this.state.measure.left.filterMode = fields.leftFilterMode?.checked ? 'exclude' : 'include'
-      this.state.measure.left.filter = fields.leftFilter?.value || 'any'
-      this.state.measure.operator = fields.measureOperatorSelect?.value || 'count'
-      this.state.measure.unary.comparator = fields.unaryComparator?.value || 'greater_than'
-      this.state.measure.unary.target = fields.unaryTarget?.value || 'exact_number'
-      this.state.measure.unary.targetFilterMode = fields.unaryTargetFilterMode?.checked ? 'exclude' : 'include'
-      this.state.measure.unary.targetFilter = fields.unaryTargetFilter?.value || 'any'
-      this.state.measure.unary.targetTotal = Number(fields.unaryTargetTotal?.value || 0)
-      this.applyUnaryCompatibilityRules(changedId)
     } else {
-      this.state.position.left.subject = fields.positionSubject?.value || 'allied'
-      this.state.position.left.filterMode = fields.positionFilterMode?.checked ? 'exclude' : 'include'
-      this.state.position.left.filter = fields.positionFilter?.value || 'any'
-      this.state.position.positionAxis = fields.positionAxis?.value || 'rank'
-      this.state.position.positionComparator = fields.positionComparator?.value || 'equal_to'
-      this.state.position.positionRankTarget = Number(fields.positionRankInput?.value || 1)
-      this.state.position.positionFileTarget = Number(fields.positionFileInput?.value || 1)
-      this.state.position.positionSquareFile = Number(fields.positionSquareFile?.value || 1)
-      this.state.position.positionSquareRank = Number(fields.positionSquareRank?.value || 1)
-      this.state.position.operator = fields.positionOperator?.value || 'count'
-      this.state.position.comparator = fields.positionMetricComparator?.value || 'greater_than'
-      this.state.position.targetTotal = Number(fields.positionTargetTotal?.value || 0)
-      this.applyPositionCompatibilityRules()
+      const cen = this.state.census
+      cen.left.subject = fields.censusSubject?.value || 'allied'
+      cen.left.filterMode = fields.censusFilterMode?.checked ? 'exclude' : 'include'
+      cen.left.filter = fields.censusFilter?.value || 'any'
+      if (fields.censusScopeWhole?.checked) {
+        cen.scope = 'whole'
+      } else if (fields.censusAxisFile?.checked) {
+        cen.scope = 'region'
+        cen.positionAxis = 'file'
+      } else if (fields.censusAxisSquare?.checked) {
+        cen.scope = 'region'
+        cen.positionAxis = 'square'
+      } else {
+        cen.scope = 'region'
+        cen.positionAxis = 'rank'
+      }
+      cen.positionComparator = pillValue(fields.censusRegionComparatorInputs) || 'equal_to'
+      cen.positionRankTarget = Number(pillValue(fields.censusRankInputs) || 1)
+      cen.positionFileTarget = Number(pillValue(fields.censusFileInputs) || 1)
+      cen.positionSquareFile = Number(pillValue(fields.censusSquareFileInputs) || 1)
+      cen.positionSquareRank = Number(pillValue(fields.censusSquareRankInputs) || 1)
+      cen.operator = fields.censusOperator?.value || 'count'
+      cen.comparator = pillValue(fields.censusComparatorInputs) || 'greater_than'
+      cen.target = fields.censusTarget?.value || 'exact_number'
+      cen.targetFilter = fields.censusTargetFilter?.value || 'any'
+      cen.targetFilterMode = fields.censusTargetFilterMode?.checked ? 'exclude' : 'include'
+      cen.targetTotal = Number(fields.censusTargetTotal?.value || 0)
+      this.applyCensusCompatibilityRules()
     }
 
     this.render()
   }
 
   buildPayload() {
-    if (this.state.mode === 'position') {
-      const pos = this.state.position
-      const positionTarget = this.resolvedPositionTarget(pos)
+    if (this.state.mode === 'census') {
+      const cen = this.state.census
       const payload = {
         version: 2,
-        kind: 'position',
-        subject: pos.left.subject,
-        subjectFilter: pos.left.filter,
-        positionAxis: pos.positionAxis,
-        positionComparator: pos.positionAxis === 'square' ? 'equal_to' : pos.positionComparator,
-        positionTarget,
-        operator: pos.operator,
-        comparator: pos.comparator,
-        targetTotal: pos.targetTotal
+        kind: 'census',
+        subject: cen.left.subject,
+        subjectFilter: cen.left.filter,
+        operator: cen.operator,
+        comparator: cen.comparator
       }
-      if (pos.left.filter !== 'any') {
-        payload.subjectFilterMode = pos.left.filterMode
+      if (cen.left.filter !== 'any') {
+        payload.subjectFilterMode = cen.left.filterMode
       }
-      return payload
-    }
-    if (this.state.mode === 'measure') {
-      const meas = this.state.measure
-      const payload = {
-        version: 2,
-        kind: 'unary',
-        subject: meas.left.subject,
-        subjectFilter: meas.left.filter,
-        operator: meas.operator,
-        comparator: meas.unary.comparator,
-        target: meas.unary.target,
-        ...(meas.left.filter !== 'any' ? { subjectFilterMode: meas.left.filterMode } : {})
+      if (cen.scope === 'region') {
+        payload.positionAxis = cen.positionAxis
+        payload.positionComparator = cen.positionAxis === 'square' ? 'equal_to' : cen.positionComparator
+        payload.positionTarget = this.resolvedPositionTarget(cen)
       }
-
-      if (meas.unary.target === 'exact_number') {
-        payload.targetTotal = meas.unary.targetTotal
-      } else if (this.unaryTargetUsesActor()) {
-        payload.targetFilter = meas.unary.targetFilter
-        if (meas.unary.targetFilter !== 'any') {
-          payload.targetFilterMode = meas.unary.targetFilterMode
+      payload.target = cen.target
+      if (cen.target === 'exact_number') {
+        payload.targetTotal = cen.targetTotal
+      } else if (this.censusTargetUsesActor()) {
+        payload.targetFilter = cen.targetFilter
+        if (cen.targetFilter !== 'any') {
+          payload.targetFilterMode = cen.targetFilterMode
         }
       }
-
       return payload
     } else {
       const rel = this.state.relational
@@ -884,7 +857,7 @@ class ConditionForm {
     })
   }
 
-  allowedUnaryOperatorsForSubject(subject) {
+  allowedCensusOperatorsForSubject(subject) {
     if (['captured_piece', 'enemy_captured_piece'].includes(subject)) {
       return ['count', 'value']
     } else {
@@ -892,23 +865,53 @@ class ConditionForm {
     }
   }
 
-  applyUnaryCompatibilityRules(changedId) {
-    const meas = this.state.measure
-    const allowedUnaryOperators = this.allowedUnaryOperatorsForSubject(meas.left.subject)
+  censusSubjectsForScope() {
+    const census = this.grammarRules.census || {}
+    if (this.state.census.scope === 'region') {
+      return census.regionSubjects || this.grammarRules.positionSubjects || ['allied', 'enemy', 'moved_piece', 'enemy_moved_piece']
+    }
+    return census.wholeBoardSubjects || this.editorSubjects()
+  }
+
+  censusTargetUsesActor() {
+    const cen = this.state.census
+    return cen.advanced && !['exact_number', 'prior_board_state'].includes(cen.target)
+  }
+
+  allowedCensusTargetsForOperator(operator) {
+    return [
+      'exact_number',
+      ...this.editorSubjects().filter(subject => this.allowedCensusOperatorsForSubject(subject).includes(operator)),
+      'prior_board_state'
+    ]
+  }
+
+  applyCensusCompatibilityRules() {
+    const cen = this.state.census
+    const allowedSubjects = this.censusSubjectsForScope()
+    if (!allowedSubjects.includes(cen.left.subject)) {
+      cen.left.subject = 'allied'
+    }
+    const allowedOperators = this.allowedCensusOperatorsForSubject(cen.left.subject)
+    if (!allowedOperators.includes(cen.operator)) {
+      cen.operator = 'count'
+    }
+    if (cen.scope === 'region' && cen.positionAxis === 'square') {
+      cen.positionComparator = 'equal_to'
+    }
+    if (!cen.advanced) {
+      cen.target = 'exact_number'
+      cen.targetFilter = 'any'
+      cen.targetFilterMode = 'include'
+    } else {
+      const allowedTargets = this.allowedCensusTargetsForOperator(cen.operator)
+      if (!allowedTargets.includes(cen.target)) {
+        cen.target = 'exact_number'
+        cen.targetFilter = 'any'
+        cen.targetFilterMode = 'include'
+      }
+    }
     this.applyFilterModeCompatibilityRules()
-
-    if (!allowedUnaryOperators.includes(meas.operator) && changedId === 'cond-measure-operator') {
-      meas.left.subject = 'allied'
-    } else if (!allowedUnaryOperators.includes(meas.operator)) {
-      meas.operator = allowedUnaryOperators[0]
-    }
-
-    const allowedTargets = this.allowedUnaryTargetsForOperator(meas.operator)
-    if (!allowedTargets.includes(meas.unary.target)) {
-      meas.unary.target = 'exact_number'
-      meas.unary.targetFilter = 'any'
-      meas.unary.targetFilterMode = 'include'
-    }
   }
 
   resolvedPositionTarget(pos) {
@@ -917,39 +920,22 @@ class ConditionForm {
     return (pos.positionSquareRank - 1) * 8 + (pos.positionSquareFile - 1)
   }
 
-  applyPositionCompatibilityRules() {
-    const pos = this.state.position
-    const allowedSubjects = this.positionSubjects()
-    if (!allowedSubjects.includes(pos.left.subject)) {
-      pos.left.subject = 'allied'
-    }
-    if (pos.positionAxis === 'square') {
-      pos.positionComparator = 'equal_to'
-    }
-    const allowedOperators = this.allowedPositionOperatorsForSubject(pos.left.subject)
-    if (!allowedOperators.includes(pos.operator)) {
-      pos.operator = 'count'
-    }
-    this.applyFilterModeCompatibilityRules()
+  disableCensusSubjectOptions(fields) {
+    const allowed = this.censusSubjectsForScope()
+    this.disableOptions(fields.censusSubject, this.editorSubjects().filter(v => !allowed.includes(v)))
   }
 
-  positionSubjects() {
-    return this.grammarRules.positionSubjects || ['allied', 'enemy', 'moved_piece', 'enemy_moved_piece']
+  disableCensusOperatorOptions(fields) {
+    const allowed = this.allowedCensusOperatorsForSubject(this.state.census.left.subject)
+    const all = Array.from(fields.censusOperator?.options || []).map(o => o.value)
+    this.disableOptions(fields.censusOperator, all.filter(v => !allowed.includes(v)))
   }
 
-  allowedPositionOperatorsForSubject(subject) {
-    return ['count', 'value', 'mobility']
-  }
-
-  disablePositionSubjectOptions(fields) {
-    const allowed = this.positionSubjects()
-    this.disableOptions(fields.positionSubject, this.editorSubjects().filter(v => !allowed.includes(v)))
-  }
-
-  disablePositionOperatorOptions(fields) {
-    const allowed = this.allowedPositionOperatorsForSubject(this.state.position.left.subject)
-    const all = Array.from(fields.positionOperator?.options || []).map(o => o.value)
-    this.disableOptions(fields.positionOperator, all.filter(v => !allowed.includes(v)))
+  disableCensusTargetOptions(fields) {
+    if (!fields.censusTarget) { return }
+    const all = Array.from(fields.censusTarget.options).map(o => o.value)
+    const allowed = this.allowedCensusTargetsForOperator(this.state.census.operator)
+    this.disableOptions(fields.censusTarget, all.filter(v => !allowed.includes(v)))
   }
 
   applyFilterModeCompatibilityRules() {
@@ -960,16 +946,12 @@ class ConditionForm {
       if (this.state.relational.right.filter === 'any') {
         this.state.relational.right.filterMode = 'include'
       }
-    } else if (this.state.mode === 'position') {
-      if (this.state.position.left.filter === 'any') {
-        this.state.position.left.filterMode = 'include'
-      }
     } else {
-      if (this.state.measure.left.filter === 'any') {
-        this.state.measure.left.filterMode = 'include'
+      if (this.state.census.left.filter === 'any') {
+        this.state.census.left.filterMode = 'include'
       }
-      if (this.state.measure.unary.targetFilter === 'any') {
-        this.state.measure.unary.targetFilterMode = 'include'
+      if (this.state.census.targetFilter === 'any') {
+        this.state.census.targetFilterMode = 'include'
       }
     }
   }
@@ -986,36 +968,18 @@ class ConditionForm {
     })
   }
 
-  allowedUnarySubjectsForOperator(operator) {
-    if (operator === 'mobility') {
-      return ['allied', 'enemy', 'moved_piece', 'enemy_moved_piece']
-    } else {
-      return this.editorSubjects()
-    }
-  }
-
-  unaryTargetUsesActor() {
-    return !['exact_number', 'prior_board_state'].includes(this.state.measure.unary.target)
-  }
-
-  allowedUnaryTargetsForOperator(operator) {
-    return [
-      'exact_number',
-      ...this.editorSubjects().filter(subject => this.allowedUnaryOperatorsForSubject(subject).includes(operator)),
-      'prior_board_state'
-    ]
-  }
-
   setComparisonInputsDisabled(side, fields, disabled) {
     const metricKey = side === 'left' ? 'leftComparisonMetric' : 'rightComparisonMetric'
     const comparatorKey = side === 'left' ? 'leftComparator' : 'rightComparator'
+    const comparatorInputsKey = side === 'left' ? 'leftComparatorInputs' : 'rightComparatorInputs'
     const sourceKey = side === 'left' ? 'leftComparisonSource' : 'rightComparisonSource'
     const sourceTotalKey = side === 'left' ? 'leftComparisonSourceTotal' : 'rightComparisonSourceTotal'
 
     fields[metricKey].disabled = disabled
-    fields[comparatorKey].disabled = disabled
     fields[sourceKey].disabled = disabled
     fields[sourceTotalKey].disabled = disabled
+    fields[comparatorInputsKey]?.forEach(input => { input.disabled = disabled })
+    fields[comparatorKey]?.classList.toggle('condition-form-radio-row--disabled', disabled)
   }
 
   allowedRelationalComparisonSourcesForMetric(metric) {
@@ -1046,14 +1010,6 @@ class ConditionForm {
     this.disableOptions(select, otherUsesAggregate ? ['aggregate_value'] : [])
   }
 
-  setUnaryComparisonInputsDisabled(fields, disabled) {
-    fields.unaryComparator.disabled = disabled
-    fields.unaryTarget.disabled = disabled
-    fields.unaryTargetTotal.disabled = disabled
-    fields.unaryTargetFilterMode.disabled = disabled
-    fields.unaryTargetFilter.disabled = disabled
-  }
-
   disableRelationalSubjectOptions(fields, samePieceMode) {
     this.enableAllOptions(fields.leftSubject)
     this.enableAllOptions(fields.rightSubject)
@@ -1068,17 +1024,6 @@ class ConditionForm {
 
     this.disableOptions(fields.leftSubject, this.editorSubjects().filter(v => !this.regularRelationalSubjects().includes(v)))
     this.disableOptions(fields.rightSubject, this.editorSubjects().filter(v => !this.regularRelationalTargets().includes(v)))
-  }
-
-  disableMeasureSubjectOptions(fields) {
-    const allowedSubjects = this.allowedUnarySubjectsForOperator(this.state.measure.operator)
-    this.disableOptions(fields.leftSubject, this.editorSubjects().filter(v => !allowedSubjects.includes(v)))
-  }
-
-  disableUnaryTargetOptions(fields) {
-    const allowedTargets = this.allowedUnaryTargetsForOperator(this.state.measure.operator)
-    const allTargets = Array.from(fields.unaryTarget.options).map(option => option.value)
-    this.disableOptions(fields.unaryTarget, allTargets.filter(value => !allowedTargets.includes(value)))
   }
 
   showAllOptions(select) {

--- a/app/javascript/editorV2/panels/ConditionForm.js
+++ b/app/javascript/editorV2/panels/ConditionForm.js
@@ -1,79 +1,8 @@
 import { formatConditionPreview } from 'editorV2/utils/conditionPreviewFormatter'
-
-const PILL_INPUT_CACHE = new WeakMap()
-
-function pillInputs(container) {
-  if (!container) { return [] }
-  let inputs = PILL_INPUT_CACHE.get(container)
-  if (!inputs) {
-    inputs = Array.from(container.querySelectorAll('input[type="radio"]'))
-    PILL_INPUT_CACHE.set(container, inputs)
-  }
-  return inputs
-}
-
-function pillValue(inputs) {
-  return inputs?.find(input => input.checked)?.value
-}
-
-function setPillChecked(inputs, value, numeric = false) {
-  inputs?.forEach(input => {
-    input.checked = (numeric ? Number(input.value) : input.value) === value
-  })
-}
-
-const DEFAULT_RELATIONAL_STATE = {
-  left: {
-    subject: 'allied',
-    filter: 'any',
-    filterMode: 'include',
-    comparisonMetric: '',
-    comparator: 'equal_to',
-    comparisonSource: 'exact_number',
-    comparisonSourceTotal: 1
-  },
-  operator: 'targets',
-  right: {
-    subject: 'enemy',
-    filter: 'any',
-    filterMode: 'include',
-    comparisonMetric: '',
-    comparator: 'equal_to',
-    comparisonSource: 'exact_number',
-    comparisonSourceTotal: 1
-  },
-  ui: {
-    leftComparisonOpen: false,
-    rightComparisonOpen: false,
-  }
-}
-
-const DEFAULT_CENSUS_STATE = {
-  left: {
-    subject: 'allied',
-    filter: 'any',
-    filterMode: 'include'
-  },
-  scope: 'region',
-  positionAxis: 'rank',
-  positionComparator: 'equal_to',
-  positionRankTarget: 1,
-  positionFileTarget: 1,
-  positionSquareFile: 1,
-  positionSquareRank: 1,
-  advanced: false,
-  operator: 'count',
-  comparator: 'greater_than',
-  target: 'exact_number',
-  targetFilter: 'any',
-  targetFilterMode: 'include',
-  targetTotal: 0
-}
-
-const DEFAULT_IDENTITY_STATE = {
-  subject: 'enemy_moved_piece',
-  target: 'captured_piece'
-}
+import { pillInputs } from 'editorV2/panels/condition_form/dom_helpers'
+import RelationalMode from 'editorV2/panels/condition_form/relational_mode'
+import CensusMode from 'editorV2/panels/condition_form/census_mode'
+import IdentityMode from 'editorV2/panels/condition_form/identity_mode'
 
 const DEFAULT_GRAMMAR_RULES = Object.freeze({
   editorSubjects: ['allied', 'enemy', 'moved_piece', 'captured_piece', 'enemy_moved_piece', 'enemy_captured_piece'],
@@ -105,6 +34,11 @@ class ConditionForm {
   constructor(editorPanel) {
     this.editorPanel = editorPanel
     this.grammarRules = this.readGrammarRules()
+    this.modes = {
+      relational: new RelationalMode(this.grammarRules),
+      census: new CensusMode(this.grammarRules),
+      identity: new IdentityMode(this.grammarRules)
+    }
     this.state = this.defaultState()
     this.boundHandleFieldChange = this.handleFieldChange.bind(this)
     this.boundHandleLeftComparisonToggle = this.toggleLeftComparison.bind(this)
@@ -118,9 +52,9 @@ class ConditionForm {
   defaultState() {
     return {
       mode: 'census',
-      relational: structuredClone(DEFAULT_RELATIONAL_STATE),
-      census: structuredClone(DEFAULT_CENSUS_STATE),
-      identity: structuredClone(DEFAULT_IDENTITY_STATE)
+      relational: this.modes.relational.defaultState(),
+      census: this.modes.census.defaultState(),
+      identity: this.modes.identity.defaultState()
     }
   }
 
@@ -213,7 +147,6 @@ class ConditionForm {
       leftComparisonSource,
       leftComparisonSourceTotal,
       relationalOperatorSelect,
-      operatorSelect: this.state.mode === 'relational' ? relationalOperatorSelect : censusOperator,
       rightSubject,
       rightFilterMode,
       rightFilter,
@@ -305,114 +238,24 @@ class ConditionForm {
     } else {
       this.state = this.defaultState()
     }
-    if (this.state.mode === 'census') {
-      this.applyCensusCompatibilityRules()
-    } else if (this.state.mode === 'identity') {
-      this.applyIdentityCompatibilityRules()
-    } else {
-      this.applyRelationalCompatibilityRules()
-    }
+    const mode = this.state.mode
+    this.modes[mode].applyCompatibilityRules(this.state[mode])
     this.render()
   }
 
   isValidV2Node(nodeData = {}) {
-    return nodeData.version === 2 && (nodeData.kind === 'relational' || nodeData.kind === 'census' || nodeData.kind === 'identity')
+    return nodeData.version === 2 && Object.keys(this.modes).includes(nodeData.kind)
   }
 
   stateFromNodeData(nodeData) {
-    if (nodeData.kind === 'identity') {
-      return {
-        mode: 'identity',
-        relational: structuredClone(DEFAULT_RELATIONAL_STATE),
-        census: structuredClone(DEFAULT_CENSUS_STATE),
-        identity: {
-          subject: nodeData.subject || DEFAULT_IDENTITY_STATE.subject,
-          target: nodeData.target || DEFAULT_IDENTITY_STATE.target
-        }
-      }
+    const state = {
+      mode: nodeData.kind,
+      relational: this.modes.relational.defaultState(),
+      census: this.modes.census.defaultState(),
+      identity: this.modes.identity.defaultState()
     }
-    if (nodeData.kind === 'census') {
-      const hasRegion = nodeData.positionAxis !== undefined && nodeData.positionAxis !== null
-      const isSquare = nodeData.positionAxis === 'square'
-      const squareFile = isSquare ? ((nodeData.positionTarget % 8) + 1) : 1
-      const squareRank = isSquare ? (Math.floor(nodeData.positionTarget / 8) + 1) : 1
-      return {
-        mode: 'census',
-        relational: structuredClone(DEFAULT_RELATIONAL_STATE),
-        identity: structuredClone(DEFAULT_IDENTITY_STATE),
-        census: {
-          left: {
-            subject: nodeData.subject || 'allied',
-            filter: nodeData.subjectFilter || 'any',
-            filterMode: nodeData.subjectFilterMode || 'include'
-          },
-          scope: hasRegion ? 'region' : 'whole',
-          positionAxis: nodeData.positionAxis || 'rank',
-          positionComparator: nodeData.positionComparator || 'equal_to',
-          positionRankTarget: nodeData.positionAxis === 'rank' ? (nodeData.positionTarget || 1) : 1,
-          positionFileTarget: nodeData.positionAxis === 'file' ? (nodeData.positionTarget || 1) : 1,
-          positionSquareFile: squareFile,
-          positionSquareRank: squareRank,
-          advanced: Boolean(nodeData.target) && nodeData.target !== 'exact_number',
-          operator: nodeData.operator || 'count',
-          comparator: nodeData.comparator || 'greater_than',
-          target: nodeData.target || 'exact_number',
-          targetFilter: nodeData.targetFilter || 'any',
-          targetFilterMode: nodeData.targetFilterMode || 'include',
-          targetTotal: typeof nodeData.targetTotal === 'number' ? nodeData.targetTotal : 0
-        }
-      }
-    } else {
-      return {
-        mode: 'relational',
-        census: structuredClone(DEFAULT_CENSUS_STATE),
-        identity: structuredClone(DEFAULT_IDENTITY_STATE),
-        relational: {
-          left: this.relationalSideState({
-            subject: nodeData.subject,
-            filter: nodeData.subjectFilter,
-            filterMode: nodeData.subjectFilterMode,
-            comparisonMetric: nodeData.subjectComparisonMetric,
-            comparator: nodeData.subjectComparator,
-            comparisonSource: nodeData.subjectComparisonSource,
-            comparisonSourceTotal: nodeData.subjectComparisonSourceTotal
-          }),
-          operator: this.uiOperatorFromPayload(nodeData.operator),
-          right: this.relationalSideState({
-            subject: nodeData.target,
-            filter: nodeData.targetFilter,
-            filterMode: nodeData.targetFilterMode,
-            comparisonMetric: nodeData.targetComparisonMetric,
-            comparator: nodeData.targetComparator,
-            comparisonSource: nodeData.targetComparisonSource,
-            comparisonSourceTotal: nodeData.targetComparisonSourceTotal
-          }),
-          ui: {
-            leftComparisonOpen: Boolean(nodeData.subjectComparisonMetric),
-            rightComparisonOpen: Boolean(nodeData.targetComparisonMetric),
-          }
-        }
-      }
-    }
-  }
-
-  uiOperatorFromPayload(operator) {
-    if (operator === 'attack' || operator === 'defend') { return 'targets' }
-    if (operator === 'cover') { return 'shield' }
-    return operator || 'targets'
-  }
-
-  relationalSideState({ subject, filter, filterMode, comparisonMetric, comparator, comparisonSource, comparisonSourceTotal }) {
-    const source = comparisonSource || 'exact_number'
-    return {
-      subject: subject || 'allied',
-      filter: filter || 'any',
-      filterMode: filterMode || 'include',
-      comparisonMetric: comparisonMetric || '',
-      comparator: comparator || 'equal_to',
-      comparisonSource: source,
-      comparisonSourceTotal: source === 'exact_number' && typeof comparisonSourceTotal === 'number' ? comparisonSourceTotal : 1
-    }
+    state[nodeData.kind] = this.modes[nodeData.kind].fromNodeData(nodeData)
+    return state
   }
 
   render() {
@@ -432,13 +275,7 @@ class ConditionForm {
     fields.censusLayout?.classList.toggle('hidden', !isCensus)
     fields.identityLayout?.classList.toggle('hidden', !isIdentity)
 
-    if (isCensus) {
-      this.renderCensus(fields)
-    } else if (isIdentity) {
-      this.renderIdentity(fields)
-    } else {
-      this.renderRelational(fields)
-    }
+    this.modes[this.state.mode].render(this.state[this.state.mode], fields)
 
     if (fields.formulationPreview) {
       fields.formulationPreview.textContent = formatConditionPreview(this.buildPayload()).text
@@ -447,176 +284,21 @@ class ConditionForm {
     if (this.onStateChange) { this.onStateChange(this.buildPayload()) }
   }
 
-  renderRelational(fields) {
-    const rel = this.state.relational
-    const leftComparisonActive = rel.ui.leftComparisonOpen
-    const rightComparisonActive = rel.ui.rightComparisonOpen
-    const leftFilterModeAvailable = rel.left.filter !== 'any'
-    const rightFilterModeAvailable = rel.right.filter !== 'any'
-
-    if (fields.relationalOperatorSelect) fields.relationalOperatorSelect.value = rel.operator
-    if (fields.leftSubject) fields.leftSubject.value = rel.left.subject
-    if (fields.leftFilterMode) fields.leftFilterMode.checked = leftFilterModeAvailable && rel.left.filterMode === 'exclude'
-    if (fields.leftFilter) fields.leftFilter.value = rel.left.filter
-    if (fields.leftComparisonMetric) fields.leftComparisonMetric.value = rel.left.comparisonMetric || 'count'
-    setPillChecked(fields.leftComparatorInputs, rel.left.comparator)
-    if (fields.leftComparisonSource) fields.leftComparisonSource.value = rel.left.comparisonSource
-    if (fields.leftComparisonSourceTotal) fields.leftComparisonSourceTotal.value = rel.left.comparisonSourceTotal
-
-    if (fields.rightSubject) fields.rightSubject.value = rel.right.subject
-    if (fields.rightFilterMode) fields.rightFilterMode.checked = rightFilterModeAvailable && rel.right.filterMode === 'exclude'
-    if (fields.rightFilter) fields.rightFilter.value = rel.right.filter
-    if (fields.rightComparisonMetric) fields.rightComparisonMetric.value = rel.right.comparisonMetric || 'count'
-    setPillChecked(fields.rightComparatorInputs, rel.right.comparator)
-    if (fields.rightComparisonSource) fields.rightComparisonSource.value = rel.right.comparisonSource
-    if (fields.rightComparisonSourceTotal) fields.rightComparisonSourceTotal.value = rel.right.comparisonSourceTotal
-
-    fields.leftComparisonBody.classList.toggle('hidden', !rel.ui.leftComparisonOpen)
-    fields.rightComparisonBody.classList.toggle('hidden', !rel.ui.rightComparisonOpen)
-    fields.leftComparisonSourceTotal?.classList.toggle('hidden', rel.left.comparisonSource !== 'exact_number')
-    fields.rightComparisonSourceTotal?.classList.toggle('hidden', rel.right.comparisonSource !== 'exact_number')
-    fields.leftComparisonSourceStack?.classList.toggle('condition-form-comparison-source-stack--inline-number', rel.left.comparisonSource === 'exact_number')
-    fields.rightComparisonSourceStack?.classList.toggle('condition-form-comparison-source-stack--inline-number', rel.right.comparisonSource === 'exact_number')
-
-    fields.leftFilterRow.classList.toggle('hidden', false)
-    fields.rightFilterRow.classList.toggle('hidden', false)
-    fields.leftFilterModeControl?.classList.toggle('condition-form-checkbox--unavailable', !leftFilterModeAvailable)
-    fields.rightFilterModeControl?.classList.toggle('condition-form-checkbox--unavailable', !rightFilterModeAvailable)
-    fields.rightComparisonToggle.closest('.condition-form-comparison').classList.toggle('hidden', false)
-
-    const leftLocked = this.comparisonLocked('left')
-    const rightLocked = this.comparisonLocked('right')
-    fields.leftComparisonToggle.disabled = leftLocked
-    fields.rightComparisonToggle.disabled = rightLocked
-    fields.leftComparisonToggle.textContent = leftLocked ? this.comparisonUnavailableText('left') : (rel.ui.leftComparisonOpen ? 'Hide comparison' : '+ comparison (advanced)')
-    fields.rightComparisonToggle.textContent = rightLocked ? this.comparisonUnavailableText('right') : (rel.ui.rightComparisonOpen ? 'Hide comparison' : '+ comparison (advanced)')
-
-    this.setComparisonInputsDisabled('left', fields, !leftComparisonActive)
-    this.setComparisonInputsDisabled('right', fields, !rightComparisonActive)
-
-    this.showAllOptions(fields.leftSubject)
-    this.showAllOptions(fields.rightSubject)
-    this.disableRelationalSubjectOptions(fields)
-    this.disableRelationalComparisonSourceOptions(fields)
-    this.disableRelationalComparisonMetricOptions(fields)
-
-    fields.relationalTargetNote?.classList.toggle('hidden', rel.operator !== 'shield')
-    fields.rightAggregateNote?.classList.toggle('hidden', !this.leftUsesAggregateValue())
-    fields.leftAggregateNote?.classList.toggle('hidden', !this.rightUsesAggregateValue())
-  }
-
-  renderCensus(fields) {
-    const cen = this.state.census
-    const region = cen.scope === 'region'
-    const isSquare = region && cen.positionAxis === 'square'
-    const filterModeAvailable = cen.left.filter !== 'any'
-    const targetUsesActor = this.censusTargetUsesActor()
-    const targetFilterModeAvailable = targetUsesActor && cen.targetFilter !== 'any'
-
-    if (fields.censusSubject) fields.censusSubject.value = cen.left.subject
-    if (fields.censusFilterMode) fields.censusFilterMode.checked = filterModeAvailable && cen.left.filterMode === 'exclude'
-    if (fields.censusFilter) fields.censusFilter.value = cen.left.filter
-    if (fields.censusScopeWhole) fields.censusScopeWhole.checked = !region
-    if (fields.censusAxisRank) fields.censusAxisRank.checked = region && cen.positionAxis === 'rank'
-    if (fields.censusAxisFile) fields.censusAxisFile.checked = region && cen.positionAxis === 'file'
-    if (fields.censusAxisSquare) fields.censusAxisSquare.checked = region && cen.positionAxis === 'square'
-    fields.censusRegionComparatorInputs?.forEach(input => {
-      input.checked = input.value === cen.positionComparator
-      input.disabled = isSquare && input.value !== 'equal_to'
-    })
-    setPillChecked(fields.censusRankInputs, cen.positionRankTarget, true)
-    setPillChecked(fields.censusFileInputs, cen.positionFileTarget, true)
-    setPillChecked(fields.censusSquareFileInputs, cen.positionSquareFile, true)
-    setPillChecked(fields.censusSquareRankInputs, cen.positionSquareRank, true)
-    if (fields.censusOperator) fields.censusOperator.value = cen.operator
-    setPillChecked(fields.censusComparatorInputs, cen.comparator)
-    if (fields.censusTarget) fields.censusTarget.value = cen.target
-    if (fields.censusTargetTotal) fields.censusTargetTotal.value = cen.targetTotal
-    if (fields.censusTargetFilter) fields.censusTargetFilter.value = cen.targetFilter
-    if (fields.censusTargetFilterMode) fields.censusTargetFilterMode.checked = targetFilterModeAvailable && cen.targetFilterMode === 'exclude'
-
-    fields.censusRegionComparator?.classList.toggle('hidden', !region)
-    fields.censusRegionComparator?.classList.toggle('condition-form-comparator-toggle--locked', isSquare)
-    fields.censusRegionTarget?.classList.toggle('hidden', false)
-    fields.censusRankInput?.classList.toggle('hidden', !region || isSquare || cen.positionAxis === 'file')
-    fields.censusFileInput?.classList.toggle('hidden', !region || isSquare || cen.positionAxis === 'rank')
-    fields.censusSquareInputs?.classList.toggle('hidden', region && !isSquare)
-    fields.censusSquareInputs?.classList.toggle('condition-form-radio-list--disabled', !region)
-    const squareTargetInputs = [...(fields.censusSquareFileInputs || []), ...(fields.censusSquareRankInputs || [])]
-    squareTargetInputs.forEach(input => { input.disabled = !region })
-
-    fields.censusTarget?.classList.toggle('hidden', !cen.advanced)
-    fields.censusTargetTotal?.classList.toggle('hidden', cen.target !== 'exact_number')
-    fields.censusTargetFilterRow?.classList.toggle('hidden', !targetUsesActor)
-    fields.censusTargetStack?.classList.toggle('condition-form-comparison-source-stack--inline-number', cen.target === 'exact_number')
-
-    fields.censusComparisonBody?.classList.toggle('hidden', false)
-    fields.censusComparisonToggle?.classList.toggle('hidden', false)
-    if (fields.censusComparisonToggle) {
-      fields.censusComparisonToggle.textContent = cen.advanced ? 'Simplify' : '+ Advanced options'
-    }
-
-    fields.censusFilterModeControl?.classList.toggle('condition-form-checkbox--unavailable', !filterModeAvailable)
-    fields.censusTargetFilterModeControl?.classList.toggle('condition-form-checkbox--unavailable', !targetFilterModeAvailable)
-
-    this.showAllOptions(fields.censusSubject)
-    this.showAllOptions(fields.censusTarget)
-    this.disableCensusSubjectOptions(fields)
-    this.disableCensusOperatorOptions(fields)
-    this.disableCensusTargetOptions(fields)
-  }
-
-  renderIdentity(fields) {
-    const id = this.state.identity
-    if (fields.identitySubject) fields.identitySubject.value = id.subject
-    if (fields.identityTarget) {
-      fields.identityTarget.value = id.target
-      const allowed = this.samePieceTargetsFor(id.subject)
-      this.showAllOptions(fields.identityTarget)
-      this.disableOptions(
-        fields.identityTarget,
-        Array.from(fields.identityTarget.options).map(o => o.value).filter(v => !allowed.includes(v))
-      )
-    }
-  }
-
   toggleLeftComparison() {
     if (this.state.mode !== 'relational') { return }
-    if (this.comparisonLocked('left')) { return }
-    const rel = this.state.relational
-
-    if (!rel.ui.leftComparisonOpen && !rel.left.comparisonMetric) {
-      rel.left.comparisonMetric = 'count'
-      rel.left.comparator = 'equal_to'
-      rel.left.comparisonSource = 'exact_number'
-      rel.left.comparisonSourceTotal ||= 1
-    }
-
-    rel.ui.leftComparisonOpen = !rel.ui.leftComparisonOpen
-    this.render()
+    if (this.modes.relational.toggleComparison('left', this.state.relational)) { this.render() }
   }
 
   toggleCensusComparison() {
     if (this.state.mode !== 'census') { return }
-    this.state.census.advanced = !this.state.census.advanced
-    this.applyCensusCompatibilityRules()
+    this.modes.census.toggleAdvanced(this.state.census)
+    this.modes.census.applyCompatibilityRules(this.state.census)
     this.render()
   }
 
   toggleRightComparison() {
     if (this.state.mode !== 'relational') { return }
-    if (this.comparisonLocked('right')) { return }
-    const rel = this.state.relational
-
-    if (!rel.ui.rightComparisonOpen && !rel.right.comparisonMetric) {
-      rel.right.comparisonMetric = 'count'
-      rel.right.comparator = 'equal_to'
-      rel.right.comparisonSource = 'exact_number'
-      rel.right.comparisonSourceTotal ||= 1
-    }
-
-    rel.ui.rightComparisonOpen = !rel.ui.rightComparisonOpen
-    this.render()
+    if (this.modes.relational.toggleComparison('right', this.state.relational)) { this.render() }
   }
 
   handleModeChange(mode) {
@@ -628,456 +310,15 @@ class ConditionForm {
   handleFieldChange() {
     const fields = this.fields()
 
-    if (this.state.mode === 'relational') {
-      this.state.relational.left.subject = fields.leftSubject?.value || 'allied'
-      this.state.relational.left.filterMode = fields.leftFilterMode?.checked ? 'exclude' : 'include'
-      this.state.relational.left.filter = fields.leftFilter?.value || 'any'
-      this.state.relational.left.comparisonMetric = fields.leftComparisonMetric?.value || ''
-      this.state.relational.left.comparator = pillValue(fields.leftComparatorInputs) || 'equal_to'
-      this.state.relational.left.comparisonSource = fields.leftComparisonSource?.value || 'exact_number'
-      this.state.relational.left.comparisonSourceTotal = Number(fields.leftComparisonSourceTotal?.value || 1)
-      this.state.relational.operator = fields.relationalOperatorSelect?.value || 'targets'
-      this.state.relational.right.subject = fields.rightSubject?.value || 'enemy'
-      this.state.relational.right.filterMode = fields.rightFilterMode?.checked ? 'exclude' : 'include'
-      this.state.relational.right.filter = fields.rightFilter?.value || 'any'
-      this.state.relational.right.comparisonMetric = fields.rightComparisonMetric?.value || ''
-      this.state.relational.right.comparator = pillValue(fields.rightComparatorInputs) || 'equal_to'
-      this.state.relational.right.comparisonSource = fields.rightComparisonSource?.value || 'exact_number'
-      this.state.relational.right.comparisonSourceTotal = Number(fields.rightComparisonSourceTotal?.value || 1)
-      this.applyRelationalCompatibilityRules()
-    } else if (this.state.mode === 'identity') {
-      this.state.identity.subject = fields.identitySubject?.value || DEFAULT_IDENTITY_STATE.subject
-      this.state.identity.target = fields.identityTarget?.value || DEFAULT_IDENTITY_STATE.target
-      this.applyIdentityCompatibilityRules()
-    } else {
-      const cen = this.state.census
-      cen.left.subject = fields.censusSubject?.value || 'allied'
-      cen.left.filterMode = fields.censusFilterMode?.checked ? 'exclude' : 'include'
-      cen.left.filter = fields.censusFilter?.value || 'any'
-      if (fields.censusScopeWhole?.checked) {
-        cen.scope = 'whole'
-      } else if (fields.censusAxisFile?.checked) {
-        cen.scope = 'region'
-        cen.positionAxis = 'file'
-      } else if (fields.censusAxisSquare?.checked) {
-        cen.scope = 'region'
-        cen.positionAxis = 'square'
-      } else {
-        cen.scope = 'region'
-        cen.positionAxis = 'rank'
-      }
-      cen.positionComparator = pillValue(fields.censusRegionComparatorInputs) || 'equal_to'
-      cen.positionRankTarget = Number(pillValue(fields.censusRankInputs) || 1)
-      cen.positionFileTarget = Number(pillValue(fields.censusFileInputs) || 1)
-      cen.positionSquareFile = Number(pillValue(fields.censusSquareFileInputs) || 1)
-      cen.positionSquareRank = Number(pillValue(fields.censusSquareRankInputs) || 1)
-      cen.operator = fields.censusOperator?.value || 'count'
-      cen.comparator = pillValue(fields.censusComparatorInputs) || 'greater_than'
-      cen.target = fields.censusTarget?.value || 'exact_number'
-      cen.targetFilter = fields.censusTargetFilter?.value || 'any'
-      cen.targetFilterMode = fields.censusTargetFilterMode?.checked ? 'exclude' : 'include'
-      cen.targetTotal = Number(fields.censusTargetTotal?.value || 0)
-      this.applyCensusCompatibilityRules()
-    }
+    const mode = this.state.mode
+    this.modes[mode].readFields(this.state[mode], fields)
+    this.modes[mode].applyCompatibilityRules(this.state[mode])
 
     this.render()
   }
 
   buildPayload() {
-    if (this.state.mode === 'census') {
-      const cen = this.state.census
-      const payload = {
-        version: 2,
-        kind: 'census',
-        subject: cen.left.subject,
-        subjectFilter: cen.left.filter,
-        operator: cen.operator,
-        comparator: cen.comparator
-      }
-      if (cen.left.filter !== 'any') {
-        payload.subjectFilterMode = cen.left.filterMode
-      }
-      if (cen.scope === 'region') {
-        payload.positionAxis = cen.positionAxis
-        payload.positionComparator = cen.positionAxis === 'square' ? 'equal_to' : cen.positionComparator
-        payload.positionTarget = this.resolvedPositionTarget(cen)
-      }
-      payload.target = cen.target
-      if (cen.target === 'exact_number') {
-        payload.targetTotal = cen.targetTotal
-      } else if (this.censusTargetUsesActor()) {
-        payload.targetFilter = cen.targetFilter
-        if (cen.targetFilter !== 'any') {
-          payload.targetFilterMode = cen.targetFilterMode
-        }
-      }
-      return payload
-    } else if (this.state.mode === 'identity') {
-      return {
-        version: 2,
-        kind: 'identity',
-        subject: this.state.identity.subject,
-        target: this.state.identity.target
-      }
-    } else {
-      const rel = this.state.relational
-      const payload = {
-        version: 2,
-        kind: 'relational',
-        subject: rel.left.subject,
-        subjectFilter: rel.left.filter,
-        operator: this.translateTargetsOperator(rel.left.subject, rel.right.subject, rel.operator),
-        target: rel.right.subject,
-        targetFilter: rel.right.filter
-      }
-
-      if (rel.left.filter !== 'any') {
-        payload.subjectFilterMode = rel.left.filterMode
-      }
-
-      if (rel.right.filter !== 'any') {
-        payload.targetFilterMode = rel.right.filterMode
-      }
-
-      if (rel.ui.leftComparisonOpen && rel.left.comparisonMetric) {
-        payload.subjectComparisonMetric = rel.left.comparisonMetric
-        payload.subjectComparator = rel.left.comparator
-        payload.subjectComparisonSource = rel.left.comparisonSource
-        if (rel.left.comparisonSource === 'exact_number') {
-          payload.subjectComparisonSourceTotal = rel.left.comparisonSourceTotal
-        }
-      }
-
-      if (rel.ui.rightComparisonOpen && rel.right.comparisonMetric) {
-        payload.targetComparisonMetric = rel.right.comparisonMetric
-        payload.targetComparator = rel.right.comparator
-        payload.targetComparisonSource = rel.right.comparisonSource
-        if (rel.right.comparisonSource === 'exact_number') {
-          payload.targetComparisonSourceTotal = rel.right.comparisonSourceTotal
-        }
-      }
-
-      return payload
-    }
-  }
-
-  translateTargetsOperator(leftSubject, rightSubject, operator) {
-    if (operator !== 'targets') { return operator }
-    const leftTeam = this.teamGroupForSubject(leftSubject)
-    const rightTeam = this.teamGroupForSubject(rightSubject)
-    return leftTeam === rightTeam ? 'defend' : 'attack'
-  }
-
-
-  // -------------------------------- GRAMMAR RULES ----------------------------------
-
-  applyIdentityCompatibilityRules() {
-    const id = this.state.identity
-    const allowedSubjects = Object.keys(this.grammarRules.samePieceTargets)
-    if (!allowedSubjects.includes(id.subject)) {
-      id.subject = allowedSubjects[0]
-    }
-    const allowedTargets = this.samePieceTargetsFor(id.subject)
-    if (!allowedTargets.includes(id.target)) {
-      id.target = allowedTargets[0]
-    }
-  }
-
-  clearRelationalComparator(side) {
-    const sideState = this.state.relational[side]
-    sideState.comparisonMetric = ''
-    sideState.comparator = 'equal_to'
-    sideState.comparisonSource = 'exact_number'
-    sideState.comparisonSourceTotal = 1
-  }
-
-  applyRelationalCompatibilityRules() {
-    const rel = this.state.relational
-
-    if (rel.right.subject === 'captured_piece') {
-      rel.right.subject = 'enemy'
-    }
-    const allowedLeft = this.regularRelationalSubjects()
-    if (!allowedLeft.includes(rel.left.subject)) {
-      rel.left.subject = 'allied'
-    }
-
-    const allowedRight = this.regularRelationalTargets()
-    if (!allowedRight.includes(rel.right.subject)) {
-      rel.right.subject = allowedRight[0]
-    }
-
-    if (this.leftUsesPriorBoardState()) {
-      this.clearRelationalComparator('right')
-      rel.ui.rightComparisonOpen = false
-    }
-
-    if (this.rightUsesPriorBoardState()) {
-      this.clearRelationalComparator('left')
-      rel.ui.leftComparisonOpen = false
-    }
-
-    if (this.leftUsesAggregateValue() && rel.right.comparisonMetric === 'aggregate_value') {
-      rel.right.comparisonMetric = 'count'
-    }
-
-    this.applyRelationalComparisonSourceCompatibility('left')
-    this.applyRelationalComparisonSourceCompatibility('right')
-    this.applyFilterModeCompatibilityRules()
-  }
-
-  applyRelationalComparisonSourceCompatibility(side) {
-    const sideState = this.state.relational[side]
-    const allowedSources = this.allowedRelationalComparisonSourcesForMetric(sideState.comparisonMetric)
-    if (!allowedSources.includes(sideState.comparisonSource)) {
-      sideState.comparisonSource = 'exact_number'
-      sideState.comparisonSourceTotal ||= 1
-    }
-  }
-
-  leftUsesPriorBoardState() {
-    const rel = this.state.relational
-    return this.state.mode === 'relational' && rel.ui.leftComparisonOpen && rel.left.comparisonSource === 'prior_board_state'
-  }
-
-  rightUsesPriorBoardState() {
-    const rel = this.state.relational
-    return this.state.mode === 'relational' && rel.ui.rightComparisonOpen && rel.right.comparisonSource === 'prior_board_state'
-  }
-
-  leftUsesAggregateValue() {
-    const rel = this.state.relational
-    return this.state.mode === 'relational' && rel.ui.leftComparisonOpen && rel.left.comparisonMetric === 'aggregate_value'
-  }
-
-  rightUsesAggregateValue() {
-    const rel = this.state.relational
-    return this.state.mode === 'relational' && rel.ui.rightComparisonOpen && rel.right.comparisonMetric === 'aggregate_value'
-  }
-
-  comparisonLocked(side) {
-    if (this.state.mode !== 'relational') { return false }
-    return side === 'left' ? this.rightUsesPriorBoardState() : this.leftUsesPriorBoardState()
-  }
-
-  comparisonUnavailableText(side) {
-    if (side === 'left' && this.rightUsesPriorBoardState()) {
-      return '+ comparison unavailable while target uses prior'
-    }
-    if (side === 'right' && this.leftUsesPriorBoardState()) {
-      return '+ comparison unavailable while subject uses prior'
-    }
-    return '+ comparison unavailable'
-  }
-
-  regularRelationalSubjects() {
-    return this.grammarRules.regularRelationalSubjects
-  }
-
-  regularRelationalTargets() {
-    const operator = this.state.relational.operator
-    if (operator === 'targets') { return this.grammarRules.regularRelationalTargets }
-    const targetRule = this.grammarRules.relationalOperatorTargetRules[operator] || 'any_regular'
-    if (targetRule === 'opposing_team') {
-      return this.opposingTeamTargetsFor(this.state.relational.left.subject)
-    } else if (targetRule === 'same_team') {
-      return this.sameTeamTargetsFor(this.state.relational.left.subject)
-    } else {
-      return this.grammarRules.regularRelationalTargets
-    }
-  }
-
-  samePieceTargetsFor(subject) {
-    return this.grammarRules.samePieceTargets[subject] || []
-  }
-
-  sameTeamTargetsFor(subject) {
-    const team = this.teamGroupForSubject(subject)
-    return team ? this.grammarRules.teamSubjectGroups[team] : []
-  }
-
-  opposingTeamTargetsFor(subject) {
-    const team = this.teamGroupForSubject(subject)
-    const opposingTeam = this.grammarRules.opposingTeamGroups[team]
-    return opposingTeam ? this.grammarRules.teamSubjectGroups[opposingTeam] : []
-  }
-
-  teamGroupForSubject(subject) {
-    return Object.keys(this.grammarRules.teamSubjectGroups).find(team => {
-      return this.grammarRules.teamSubjectGroups[team].includes(subject)
-    })
-  }
-
-  allowedCensusOperatorsForSubject(subject) {
-    if (['captured_piece', 'enemy_captured_piece'].includes(subject)) {
-      return ['count', 'value']
-    } else {
-      return ['count', 'mobility', 'value']
-    }
-  }
-
-  censusSubjectsForScope() {
-    const census = this.grammarRules.census || {}
-    if (this.state.census.scope === 'region') {
-      return census.regionSubjects || this.grammarRules.positionSubjects || ['allied', 'enemy', 'moved_piece', 'enemy_moved_piece']
-    }
-    return census.wholeBoardSubjects || this.editorSubjects()
-  }
-
-  censusTargetUsesActor() {
-    const cen = this.state.census
-    return cen.advanced && !['exact_number', 'prior_board_state'].includes(cen.target)
-  }
-
-  allowedCensusTargetsForOperator(operator) {
-    return [
-      'exact_number',
-      ...this.editorSubjects().filter(subject => this.allowedCensusOperatorsForSubject(subject).includes(operator)),
-      'prior_board_state'
-    ]
-  }
-
-  applyCensusCompatibilityRules() {
-    const cen = this.state.census
-    const allowedSubjects = this.censusSubjectsForScope()
-    if (!allowedSubjects.includes(cen.left.subject)) {
-      cen.left.subject = 'allied'
-    }
-    const allowedOperators = this.allowedCensusOperatorsForSubject(cen.left.subject)
-    if (!allowedOperators.includes(cen.operator)) {
-      cen.operator = 'count'
-    }
-    if (cen.scope === 'region' && cen.positionAxis === 'square') {
-      cen.positionComparator = 'equal_to'
-    }
-    if (!cen.advanced) {
-      cen.target = 'exact_number'
-      cen.targetFilter = 'any'
-      cen.targetFilterMode = 'include'
-    } else {
-      const allowedTargets = this.allowedCensusTargetsForOperator(cen.operator)
-      if (!allowedTargets.includes(cen.target)) {
-        cen.target = 'exact_number'
-        cen.targetFilter = 'any'
-        cen.targetFilterMode = 'include'
-      }
-    }
-    this.applyFilterModeCompatibilityRules()
-  }
-
-  resolvedPositionTarget(pos) {
-    if (pos.positionAxis === 'rank') { return pos.positionRankTarget }
-    if (pos.positionAxis === 'file') { return pos.positionFileTarget }
-    return (pos.positionSquareRank - 1) * 8 + (pos.positionSquareFile - 1)
-  }
-
-  disableCensusSubjectOptions(fields) {
-    const allowed = this.censusSubjectsForScope()
-    this.disableOptions(fields.censusSubject, this.editorSubjects().filter(v => !allowed.includes(v)))
-  }
-
-  disableCensusOperatorOptions(fields) {
-    const allowed = this.allowedCensusOperatorsForSubject(this.state.census.left.subject)
-    const all = Array.from(fields.censusOperator?.options || []).map(o => o.value)
-    this.disableOptions(fields.censusOperator, all.filter(v => !allowed.includes(v)))
-  }
-
-  disableCensusTargetOptions(fields) {
-    if (!fields.censusTarget) { return }
-    const all = Array.from(fields.censusTarget.options).map(o => o.value)
-    const allowed = this.allowedCensusTargetsForOperator(this.state.census.operator)
-    this.disableOptions(fields.censusTarget, all.filter(v => !allowed.includes(v)))
-  }
-
-  applyFilterModeCompatibilityRules() {
-    if (this.state.mode === 'relational') {
-      if (this.state.relational.left.filter === 'any') {
-        this.state.relational.left.filterMode = 'include'
-      }
-      if (this.state.relational.right.filter === 'any') {
-        this.state.relational.right.filterMode = 'include'
-      }
-    } else {
-      if (this.state.census.left.filter === 'any') {
-        this.state.census.left.filterMode = 'include'
-      }
-      if (this.state.census.targetFilter === 'any') {
-        this.state.census.targetFilterMode = 'include'
-      }
-    }
-  }
-
-  disableOptions(select, disallowedValues) {
-    Array.from(select.options).forEach(option => {
-      option.disabled = disallowedValues.includes(option.value)
-    })
-  }
-
-  enableAllOptions(select) {
-    Array.from(select.options).forEach(option => {
-      option.disabled = false
-    })
-  }
-
-  setComparisonInputsDisabled(side, fields, disabled) {
-    const metricKey = side === 'left' ? 'leftComparisonMetric' : 'rightComparisonMetric'
-    const comparatorKey = side === 'left' ? 'leftComparator' : 'rightComparator'
-    const comparatorInputsKey = side === 'left' ? 'leftComparatorInputs' : 'rightComparatorInputs'
-    const sourceKey = side === 'left' ? 'leftComparisonSource' : 'rightComparisonSource'
-    const sourceTotalKey = side === 'left' ? 'leftComparisonSourceTotal' : 'rightComparisonSourceTotal'
-
-    fields[metricKey].disabled = disabled
-    fields[sourceKey].disabled = disabled
-    fields[sourceTotalKey].disabled = disabled
-    fields[comparatorInputsKey]?.forEach(input => { input.disabled = disabled })
-    fields[comparatorKey]?.classList.toggle('condition-form-radio-row--disabled', disabled)
-  }
-
-  allowedRelationalComparisonSourcesForMetric(metric) {
-    if (metric === 'individual_value' || metric === 'aggregate_value') {
-      return ['exact_number', 'prior_board_state', 'moved_piece', 'captured_piece', 'enemy_moved_piece', 'enemy_captured_piece']
-    }
-    return ['exact_number', 'prior_board_state']
-  }
-
-  disableRelationalComparisonSourceOptions(fields) {
-    this.disableRelationalComparisonSourceOptionsForSide('left', fields.leftComparisonSource)
-    this.disableRelationalComparisonSourceOptionsForSide('right', fields.rightComparisonSource)
-  }
-
-  disableRelationalComparisonSourceOptionsForSide(side, select) {
-    const allowedSources = this.allowedRelationalComparisonSourcesForMetric(this.state.relational[side].comparisonMetric || 'count')
-    const allSources = Array.from(select.options).map(option => option.value)
-    this.disableOptions(select, allSources.filter(value => !allowedSources.includes(value)))
-  }
-
-  disableRelationalComparisonMetricOptions(fields) {
-    this.disableRelationalComparisonMetricOptionsForSide('left', fields.leftComparisonMetric)
-    this.disableRelationalComparisonMetricOptionsForSide('right', fields.rightComparisonMetric)
-  }
-
-  disableRelationalComparisonMetricOptionsForSide(side, select) {
-    const otherUsesAggregate = side === 'left' ? this.rightUsesAggregateValue() : this.leftUsesAggregateValue()
-    this.disableOptions(select, otherUsesAggregate ? ['aggregate_value'] : [])
-  }
-
-  disableRelationalSubjectOptions(fields) {
-    this.enableAllOptions(fields.leftSubject)
-    this.enableAllOptions(fields.rightSubject)
-
-    this.disableOptions(fields.leftSubject, this.editorSubjects().filter(v => !this.regularRelationalSubjects().includes(v)))
-    this.disableOptions(fields.rightSubject, this.editorSubjects().filter(v => !this.regularRelationalTargets().includes(v)))
-  }
-
-  showAllOptions(select) {
-    Array.from(select.options).forEach(option => {
-      option.hidden = false
-      option.disabled = false
-    })
-  }
-
-  editorSubjects() {
-    return this.grammarRules.editorSubjects
+    return this.modes[this.state.mode].buildPayload(this.state[this.state.mode])
   }
 
 }

--- a/app/javascript/editorV2/panels/condition_form/census_mode.js
+++ b/app/javascript/editorV2/panels/condition_form/census_mode.js
@@ -1,0 +1,276 @@
+import {
+  disableOptions, showAllOptions, pillValue, setPillChecked
+} from 'editorV2/panels/condition_form/dom_helpers'
+
+const DEFAULT_CENSUS_STATE = {
+  left: {
+    subject: 'allied',
+    filter: 'any',
+    filterMode: 'include'
+  },
+  scope: 'region',
+  regionAxis: 'rank',
+  regionComparator: 'equal_to',
+  regionRankTarget: 1,
+  regionFileTarget: 1,
+  regionSquareFile: 1,
+  regionSquareRank: 1,
+  advanced: false,
+  operator: 'count',
+  comparator: 'greater_than',
+  target: 'exact_number',
+  targetFilter: 'any',
+  targetFilterMode: 'include',
+  targetTotal: 0
+}
+
+// Census condition mode. Internal state uses region* names; the wire/payload
+// keeps positionAxis/positionComparator/positionTarget — fromNodeData and
+// buildPayload are the only translation points (wire rename deferred).
+export default class CensusMode {
+  constructor(grammarRules) {
+    this.grammarRules = grammarRules
+  }
+
+  defaultState() {
+    return structuredClone(DEFAULT_CENSUS_STATE)
+  }
+
+  fromNodeData(nodeData) {
+    const hasRegion = nodeData.positionAxis != null
+    const isSquare = nodeData.positionAxis === 'square'
+    const squareFile = isSquare ? ((nodeData.positionTarget % 8) + 1) : 1
+    const squareRank = isSquare ? (Math.floor(nodeData.positionTarget / 8) + 1) : 1
+    return {
+      left: {
+        subject: nodeData.subject || 'allied',
+        filter: nodeData.subjectFilter || 'any',
+        filterMode: nodeData.subjectFilterMode || 'include'
+      },
+      scope: hasRegion ? 'region' : 'whole',
+      regionAxis: nodeData.positionAxis || 'rank',
+      regionComparator: nodeData.positionComparator || 'equal_to',
+      regionRankTarget: nodeData.positionAxis === 'rank' ? (nodeData.positionTarget || 1) : 1,
+      regionFileTarget: nodeData.positionAxis === 'file' ? (nodeData.positionTarget || 1) : 1,
+      regionSquareFile: squareFile,
+      regionSquareRank: squareRank,
+      advanced: Boolean(nodeData.target) && nodeData.target !== 'exact_number',
+      operator: nodeData.operator || 'count',
+      comparator: nodeData.comparator || 'greater_than',
+      target: nodeData.target || 'exact_number',
+      targetFilter: nodeData.targetFilter || 'any',
+      targetFilterMode: nodeData.targetFilterMode || 'include',
+      targetTotal: typeof nodeData.targetTotal === 'number' ? nodeData.targetTotal : 0
+    }
+  }
+
+  readFields(cen, fields) {
+    cen.left.subject = fields.censusSubject?.value || 'allied'
+    cen.left.filterMode = fields.censusFilterMode?.checked ? 'exclude' : 'include'
+    cen.left.filter = fields.censusFilter?.value || 'any'
+    if (fields.censusScopeWhole?.checked) {
+      cen.scope = 'whole'
+    } else if (fields.censusAxisFile?.checked) {
+      cen.scope = 'region'
+      cen.regionAxis = 'file'
+    } else if (fields.censusAxisSquare?.checked) {
+      cen.scope = 'region'
+      cen.regionAxis = 'square'
+    } else {
+      cen.scope = 'region'
+      cen.regionAxis = 'rank'
+    }
+    cen.regionComparator = pillValue(fields.censusRegionComparatorInputs) || 'equal_to'
+    cen.regionRankTarget = Number(pillValue(fields.censusRankInputs) || 1)
+    cen.regionFileTarget = Number(pillValue(fields.censusFileInputs) || 1)
+    cen.regionSquareFile = Number(pillValue(fields.censusSquareFileInputs) || 1)
+    cen.regionSquareRank = Number(pillValue(fields.censusSquareRankInputs) || 1)
+    cen.operator = fields.censusOperator?.value || 'count'
+    cen.comparator = pillValue(fields.censusComparatorInputs) || 'greater_than'
+    cen.target = fields.censusTarget?.value || 'exact_number'
+    cen.targetFilter = fields.censusTargetFilter?.value || 'any'
+    cen.targetFilterMode = fields.censusTargetFilterMode?.checked ? 'exclude' : 'include'
+    cen.targetTotal = Number(fields.censusTargetTotal?.value || 0)
+  }
+
+  buildPayload(cen) {
+    const payload = {
+      version: 2,
+      kind: 'census',
+      subject: cen.left.subject,
+      subjectFilter: cen.left.filter,
+      operator: cen.operator,
+      comparator: cen.comparator
+    }
+    if (cen.left.filter !== 'any') {
+      payload.subjectFilterMode = cen.left.filterMode
+    }
+    if (cen.scope === 'region') {
+      payload.positionAxis = cen.regionAxis
+      payload.positionComparator = cen.regionAxis === 'square' ? 'equal_to' : cen.regionComparator
+      payload.positionTarget = this.resolvedRegionTarget(cen)
+    }
+    payload.target = cen.target
+    if (cen.target === 'exact_number') {
+      payload.targetTotal = cen.targetTotal
+    } else if (this.targetUsesActor(cen)) {
+      payload.targetFilter = cen.targetFilter
+      if (cen.targetFilter !== 'any') {
+        payload.targetFilterMode = cen.targetFilterMode
+      }
+    }
+    return payload
+  }
+
+  toggleAdvanced(cen) {
+    cen.advanced = !cen.advanced
+  }
+
+  render(cen, fields) {
+    const region = cen.scope === 'region'
+    const isSquare = region && cen.regionAxis === 'square'
+    const filterModeAvailable = cen.left.filter !== 'any'
+    const targetUsesActor = this.targetUsesActor(cen)
+    const targetFilterModeAvailable = targetUsesActor && cen.targetFilter !== 'any'
+
+    if (fields.censusSubject) fields.censusSubject.value = cen.left.subject
+    if (fields.censusFilterMode) fields.censusFilterMode.checked = filterModeAvailable && cen.left.filterMode === 'exclude'
+    if (fields.censusFilter) fields.censusFilter.value = cen.left.filter
+    if (fields.censusScopeWhole) fields.censusScopeWhole.checked = !region
+    if (fields.censusAxisRank) fields.censusAxisRank.checked = region && cen.regionAxis === 'rank'
+    if (fields.censusAxisFile) fields.censusAxisFile.checked = region && cen.regionAxis === 'file'
+    if (fields.censusAxisSquare) fields.censusAxisSquare.checked = region && cen.regionAxis === 'square'
+    fields.censusRegionComparatorInputs?.forEach(input => {
+      input.checked = input.value === cen.regionComparator
+      input.disabled = isSquare && input.value !== 'equal_to'
+    })
+    setPillChecked(fields.censusRankInputs, cen.regionRankTarget, true)
+    setPillChecked(fields.censusFileInputs, cen.regionFileTarget, true)
+    setPillChecked(fields.censusSquareFileInputs, cen.regionSquareFile, true)
+    setPillChecked(fields.censusSquareRankInputs, cen.regionSquareRank, true)
+    if (fields.censusOperator) fields.censusOperator.value = cen.operator
+    setPillChecked(fields.censusComparatorInputs, cen.comparator)
+    if (fields.censusTarget) fields.censusTarget.value = cen.target
+    if (fields.censusTargetTotal) fields.censusTargetTotal.value = cen.targetTotal
+    if (fields.censusTargetFilter) fields.censusTargetFilter.value = cen.targetFilter
+    if (fields.censusTargetFilterMode) fields.censusTargetFilterMode.checked = targetFilterModeAvailable && cen.targetFilterMode === 'exclude'
+
+    fields.censusRegionComparator?.classList.toggle('hidden', !region)
+    fields.censusRegionComparator?.classList.toggle('condition-form-comparator-toggle--locked', isSquare)
+    fields.censusRegionTarget?.classList.toggle('hidden', false)
+    fields.censusRankInput?.classList.toggle('hidden', !region || isSquare || cen.regionAxis === 'file')
+    fields.censusFileInput?.classList.toggle('hidden', !region || isSquare || cen.regionAxis === 'rank')
+    fields.censusSquareInputs?.classList.toggle('hidden', region && !isSquare)
+    fields.censusSquareInputs?.classList.toggle('condition-form-radio-list--disabled', !region)
+    const squareTargetInputs = [...(fields.censusSquareFileInputs || []), ...(fields.censusSquareRankInputs || [])]
+    squareTargetInputs.forEach(input => { input.disabled = !region })
+
+    fields.censusTarget?.classList.toggle('hidden', !cen.advanced)
+    fields.censusTargetTotal?.classList.toggle('hidden', cen.target !== 'exact_number')
+    fields.censusTargetFilterRow?.classList.toggle('hidden', !targetUsesActor)
+    fields.censusTargetStack?.classList.toggle('condition-form-comparison-source-stack--inline-number', cen.target === 'exact_number')
+
+    fields.censusComparisonBody?.classList.toggle('hidden', false)
+    fields.censusComparisonToggle?.classList.toggle('hidden', false)
+    if (fields.censusComparisonToggle) {
+      fields.censusComparisonToggle.textContent = cen.advanced ? 'Simplify' : '+ Advanced options'
+    }
+
+    fields.censusFilterModeControl?.classList.toggle('condition-form-checkbox--unavailable', !filterModeAvailable)
+    fields.censusTargetFilterModeControl?.classList.toggle('condition-form-checkbox--unavailable', !targetFilterModeAvailable)
+
+    showAllOptions(fields.censusSubject)
+    showAllOptions(fields.censusTarget)
+    this.disableSubjectOptions(cen, fields)
+    this.disableOperatorOptions(cen, fields)
+    this.disableTargetOptions(cen, fields)
+  }
+
+  applyCompatibilityRules(cen) {
+    const allowedSubjects = this.subjectsForScope(cen)
+    if (!allowedSubjects.includes(cen.left.subject)) {
+      cen.left.subject = 'allied'
+    }
+    const allowedOperators = this.allowedOperatorsForSubject(cen.left.subject)
+    if (!allowedOperators.includes(cen.operator)) {
+      cen.operator = 'count'
+    }
+    if (cen.scope === 'region' && cen.regionAxis === 'square') {
+      cen.regionComparator = 'equal_to'
+    }
+    if (!cen.advanced) {
+      cen.target = 'exact_number'
+      cen.targetFilter = 'any'
+      cen.targetFilterMode = 'include'
+    } else {
+      const allowedTargets = this.allowedTargetsForOperator(cen.operator)
+      if (!allowedTargets.includes(cen.target)) {
+        cen.target = 'exact_number'
+        cen.targetFilter = 'any'
+        cen.targetFilterMode = 'include'
+      }
+    }
+    this.applyFilterModeCompatibilityRules(cen)
+  }
+
+  applyFilterModeCompatibilityRules(cen) {
+    if (cen.left.filter === 'any') { cen.left.filterMode = 'include' }
+    if (cen.targetFilter === 'any') { cen.targetFilterMode = 'include' }
+  }
+
+  resolvedRegionTarget(cen) {
+    if (cen.regionAxis === 'rank') { return cen.regionRankTarget }
+    if (cen.regionAxis === 'file') { return cen.regionFileTarget }
+    return (cen.regionSquareRank - 1) * 8 + (cen.regionSquareFile - 1)
+  }
+
+  allowedOperatorsForSubject(subject) {
+    if (['captured_piece', 'enemy_captured_piece'].includes(subject)) {
+      return ['count', 'value']
+    } else {
+      return ['count', 'mobility', 'value']
+    }
+  }
+
+  subjectsForScope(cen) {
+    const census = this.grammarRules.census || {}
+    if (cen.scope === 'region') {
+      return census.regionSubjects || this.grammarRules.positionSubjects || ['allied', 'enemy', 'moved_piece', 'enemy_moved_piece']
+    }
+    return census.wholeBoardSubjects || this.editorSubjects()
+  }
+
+  targetUsesActor(cen) {
+    return cen.advanced && !['exact_number', 'prior_board_state'].includes(cen.target)
+  }
+
+  allowedTargetsForOperator(operator) {
+    return [
+      'exact_number',
+      ...this.editorSubjects().filter(subject => this.allowedOperatorsForSubject(subject).includes(operator)),
+      'prior_board_state'
+    ]
+  }
+
+  disableSubjectOptions(cen, fields) {
+    const allowed = this.subjectsForScope(cen)
+    disableOptions(fields.censusSubject, this.editorSubjects().filter(v => !allowed.includes(v)))
+  }
+
+  disableOperatorOptions(cen, fields) {
+    const allowed = this.allowedOperatorsForSubject(cen.left.subject)
+    const all = Array.from(fields.censusOperator?.options || []).map(o => o.value)
+    disableOptions(fields.censusOperator, all.filter(v => !allowed.includes(v)))
+  }
+
+  disableTargetOptions(cen, fields) {
+    if (!fields.censusTarget) { return }
+    const all = Array.from(fields.censusTarget.options).map(o => o.value)
+    const allowed = this.allowedTargetsForOperator(cen.operator)
+    disableOptions(fields.censusTarget, all.filter(v => !allowed.includes(v)))
+  }
+
+  editorSubjects() {
+    return this.grammarRules.editorSubjects
+  }
+}

--- a/app/javascript/editorV2/panels/condition_form/dom_helpers.js
+++ b/app/javascript/editorV2/panels/condition_form/dom_helpers.js
@@ -1,0 +1,43 @@
+// Shared, mode-agnostic DOM helpers used by every condition-form mode
+// strategy. Pure DOM mutation — no form state.
+
+const PILL_INPUT_CACHE = new WeakMap()
+
+export function pillInputs(container) {
+  if (!container) { return [] }
+  let inputs = PILL_INPUT_CACHE.get(container)
+  if (!inputs) {
+    inputs = Array.from(container.querySelectorAll('input[type="radio"]'))
+    PILL_INPUT_CACHE.set(container, inputs)
+  }
+  return inputs
+}
+
+export function pillValue(inputs) {
+  return inputs?.find(input => input.checked)?.value
+}
+
+export function setPillChecked(inputs, value, numeric = false) {
+  inputs?.forEach(input => {
+    input.checked = (numeric ? Number(input.value) : input.value) === value
+  })
+}
+
+export function disableOptions(select, disallowedValues) {
+  Array.from(select.options).forEach(option => {
+    option.disabled = disallowedValues.includes(option.value)
+  })
+}
+
+export function enableAllOptions(select) {
+  Array.from(select.options).forEach(option => {
+    option.disabled = false
+  })
+}
+
+export function showAllOptions(select) {
+  Array.from(select.options).forEach(option => {
+    option.hidden = false
+    option.disabled = false
+  })
+}

--- a/app/javascript/editorV2/panels/condition_form/identity_mode.js
+++ b/app/javascript/editorV2/panels/condition_form/identity_mode.js
@@ -1,0 +1,66 @@
+import { disableOptions, showAllOptions } from 'editorV2/panels/condition_form/dom_helpers'
+
+const DEFAULT_IDENTITY_STATE = {
+  subject: 'enemy_moved_piece',
+  target: 'captured_piece'
+}
+
+// Identity condition mode: a same-piece pairing of subject and target.
+export default class IdentityMode {
+  constructor(grammarRules) {
+    this.grammarRules = grammarRules
+  }
+
+  defaultState() {
+    return structuredClone(DEFAULT_IDENTITY_STATE)
+  }
+
+  fromNodeData(nodeData) {
+    return {
+      subject: nodeData.subject || DEFAULT_IDENTITY_STATE.subject,
+      target: nodeData.target || DEFAULT_IDENTITY_STATE.target
+    }
+  }
+
+  readFields(id, fields) {
+    id.subject = fields.identitySubject?.value || DEFAULT_IDENTITY_STATE.subject
+    id.target = fields.identityTarget?.value || DEFAULT_IDENTITY_STATE.target
+  }
+
+  applyCompatibilityRules(id) {
+    const allowedSubjects = Object.keys(this.grammarRules.samePieceTargets)
+    if (!allowedSubjects.includes(id.subject)) {
+      id.subject = allowedSubjects[0]
+    }
+    const allowedTargets = this.samePieceTargetsFor(id.subject)
+    if (!allowedTargets.includes(id.target)) {
+      id.target = allowedTargets[0]
+    }
+  }
+
+  buildPayload(id) {
+    return {
+      version: 2,
+      kind: 'identity',
+      subject: id.subject,
+      target: id.target
+    }
+  }
+
+  render(id, fields) {
+    if (fields.identitySubject) fields.identitySubject.value = id.subject
+    if (fields.identityTarget) {
+      fields.identityTarget.value = id.target
+      const allowed = this.samePieceTargetsFor(id.subject)
+      showAllOptions(fields.identityTarget)
+      disableOptions(
+        fields.identityTarget,
+        Array.from(fields.identityTarget.options).map(o => o.value).filter(v => !allowed.includes(v))
+      )
+    }
+  }
+
+  samePieceTargetsFor(subject) {
+    return this.grammarRules.samePieceTargets[subject] || []
+  }
+}

--- a/app/javascript/editorV2/panels/condition_form/relational_mode.js
+++ b/app/javascript/editorV2/panels/condition_form/relational_mode.js
@@ -1,0 +1,399 @@
+import {
+  disableOptions, enableAllOptions, showAllOptions, pillValue, setPillChecked
+} from 'editorV2/panels/condition_form/dom_helpers'
+
+const DEFAULT_RELATIONAL_STATE = {
+  left: {
+    subject: 'allied',
+    filter: 'any',
+    filterMode: 'include',
+    comparisonMetric: '',
+    comparator: 'equal_to',
+    comparisonSource: 'exact_number',
+    comparisonSourceTotal: 1
+  },
+  operator: 'targets',
+  right: {
+    subject: 'enemy',
+    filter: 'any',
+    filterMode: 'include',
+    comparisonMetric: '',
+    comparator: 'equal_to',
+    comparisonSource: 'exact_number',
+    comparisonSourceTotal: 1
+  },
+  ui: {
+    leftComparisonOpen: false,
+    rightComparisonOpen: false
+  }
+}
+
+// Relational condition mode. State-only: the orchestrator owns DOM events and
+// render scheduling; every method takes the relational state slice.
+export default class RelationalMode {
+  constructor(grammarRules) {
+    this.grammarRules = grammarRules
+  }
+
+  defaultState() {
+    return structuredClone(DEFAULT_RELATIONAL_STATE)
+  }
+
+  fromNodeData(nodeData) {
+    return {
+      left: this.sideState({
+        subject: nodeData.subject,
+        filter: nodeData.subjectFilter,
+        filterMode: nodeData.subjectFilterMode,
+        comparisonMetric: nodeData.subjectComparisonMetric,
+        comparator: nodeData.subjectComparator,
+        comparisonSource: nodeData.subjectComparisonSource,
+        comparisonSourceTotal: nodeData.subjectComparisonSourceTotal
+      }),
+      operator: this.uiOperatorFromPayload(nodeData.operator),
+      right: this.sideState({
+        subject: nodeData.target,
+        filter: nodeData.targetFilter,
+        filterMode: nodeData.targetFilterMode,
+        comparisonMetric: nodeData.targetComparisonMetric,
+        comparator: nodeData.targetComparator,
+        comparisonSource: nodeData.targetComparisonSource,
+        comparisonSourceTotal: nodeData.targetComparisonSourceTotal
+      }),
+      ui: {
+        leftComparisonOpen: Boolean(nodeData.subjectComparisonMetric),
+        rightComparisonOpen: Boolean(nodeData.targetComparisonMetric)
+      }
+    }
+  }
+
+  uiOperatorFromPayload(operator) {
+    if (operator === 'attack' || operator === 'defend') { return 'targets' }
+    if (operator === 'cover') { return 'shield' }
+    return operator || 'targets'
+  }
+
+  sideState({ subject, filter, filterMode, comparisonMetric, comparator, comparisonSource, comparisonSourceTotal }) {
+    const source = comparisonSource || 'exact_number'
+    return {
+      subject: subject || 'allied',
+      filter: filter || 'any',
+      filterMode: filterMode || 'include',
+      comparisonMetric: comparisonMetric || '',
+      comparator: comparator || 'equal_to',
+      comparisonSource: source,
+      comparisonSourceTotal: source === 'exact_number' && typeof comparisonSourceTotal === 'number' ? comparisonSourceTotal : 1
+    }
+  }
+
+  readFields(rel, fields) {
+    rel.left.subject = fields.leftSubject?.value || 'allied'
+    rel.left.filterMode = fields.leftFilterMode?.checked ? 'exclude' : 'include'
+    rel.left.filter = fields.leftFilter?.value || 'any'
+    rel.left.comparisonMetric = fields.leftComparisonMetric?.value || ''
+    rel.left.comparator = pillValue(fields.leftComparatorInputs) || 'equal_to'
+    rel.left.comparisonSource = fields.leftComparisonSource?.value || 'exact_number'
+    rel.left.comparisonSourceTotal = Number(fields.leftComparisonSourceTotal?.value || 1)
+    rel.operator = fields.relationalOperatorSelect?.value || 'targets'
+    rel.right.subject = fields.rightSubject?.value || 'enemy'
+    rel.right.filterMode = fields.rightFilterMode?.checked ? 'exclude' : 'include'
+    rel.right.filter = fields.rightFilter?.value || 'any'
+    rel.right.comparisonMetric = fields.rightComparisonMetric?.value || ''
+    rel.right.comparator = pillValue(fields.rightComparatorInputs) || 'equal_to'
+    rel.right.comparisonSource = fields.rightComparisonSource?.value || 'exact_number'
+    rel.right.comparisonSourceTotal = Number(fields.rightComparisonSourceTotal?.value || 1)
+  }
+
+  buildPayload(rel) {
+    const payload = {
+      version: 2,
+      kind: 'relational',
+      subject: rel.left.subject,
+      subjectFilter: rel.left.filter,
+      operator: this.translateTargetsOperator(rel.left.subject, rel.right.subject, rel.operator),
+      target: rel.right.subject,
+      targetFilter: rel.right.filter
+    }
+
+    if (rel.left.filter !== 'any') {
+      payload.subjectFilterMode = rel.left.filterMode
+    }
+
+    if (rel.right.filter !== 'any') {
+      payload.targetFilterMode = rel.right.filterMode
+    }
+
+    if (rel.ui.leftComparisonOpen && rel.left.comparisonMetric) {
+      payload.subjectComparisonMetric = rel.left.comparisonMetric
+      payload.subjectComparator = rel.left.comparator
+      payload.subjectComparisonSource = rel.left.comparisonSource
+      if (rel.left.comparisonSource === 'exact_number') {
+        payload.subjectComparisonSourceTotal = rel.left.comparisonSourceTotal
+      }
+    }
+
+    if (rel.ui.rightComparisonOpen && rel.right.comparisonMetric) {
+      payload.targetComparisonMetric = rel.right.comparisonMetric
+      payload.targetComparator = rel.right.comparator
+      payload.targetComparisonSource = rel.right.comparisonSource
+      if (rel.right.comparisonSource === 'exact_number') {
+        payload.targetComparisonSourceTotal = rel.right.comparisonSourceTotal
+      }
+    }
+
+    return payload
+  }
+
+  toggleComparison(side, rel) {
+    if (this.comparisonLocked(rel, side)) { return false }
+    const sideState = rel[side]
+    const uiKey = side === 'left' ? 'leftComparisonOpen' : 'rightComparisonOpen'
+
+    if (!rel.ui[uiKey] && !sideState.comparisonMetric) {
+      sideState.comparisonMetric = 'count'
+      sideState.comparator = 'equal_to'
+      sideState.comparisonSource = 'exact_number'
+      sideState.comparisonSourceTotal ||= 1
+    }
+
+    rel.ui[uiKey] = !rel.ui[uiKey]
+    return true
+  }
+
+  render(rel, fields) {
+    const leftComparisonActive = rel.ui.leftComparisonOpen
+    const rightComparisonActive = rel.ui.rightComparisonOpen
+    const leftFilterModeAvailable = rel.left.filter !== 'any'
+    const rightFilterModeAvailable = rel.right.filter !== 'any'
+
+    if (fields.relationalOperatorSelect) fields.relationalOperatorSelect.value = rel.operator
+    if (fields.leftSubject) fields.leftSubject.value = rel.left.subject
+    if (fields.leftFilterMode) fields.leftFilterMode.checked = leftFilterModeAvailable && rel.left.filterMode === 'exclude'
+    if (fields.leftFilter) fields.leftFilter.value = rel.left.filter
+    if (fields.leftComparisonMetric) fields.leftComparisonMetric.value = rel.left.comparisonMetric || 'count'
+    setPillChecked(fields.leftComparatorInputs, rel.left.comparator)
+    if (fields.leftComparisonSource) fields.leftComparisonSource.value = rel.left.comparisonSource
+    if (fields.leftComparisonSourceTotal) fields.leftComparisonSourceTotal.value = rel.left.comparisonSourceTotal
+
+    if (fields.rightSubject) fields.rightSubject.value = rel.right.subject
+    if (fields.rightFilterMode) fields.rightFilterMode.checked = rightFilterModeAvailable && rel.right.filterMode === 'exclude'
+    if (fields.rightFilter) fields.rightFilter.value = rel.right.filter
+    if (fields.rightComparisonMetric) fields.rightComparisonMetric.value = rel.right.comparisonMetric || 'count'
+    setPillChecked(fields.rightComparatorInputs, rel.right.comparator)
+    if (fields.rightComparisonSource) fields.rightComparisonSource.value = rel.right.comparisonSource
+    if (fields.rightComparisonSourceTotal) fields.rightComparisonSourceTotal.value = rel.right.comparisonSourceTotal
+
+    fields.leftComparisonBody.classList.toggle('hidden', !rel.ui.leftComparisonOpen)
+    fields.rightComparisonBody.classList.toggle('hidden', !rel.ui.rightComparisonOpen)
+    fields.leftComparisonSourceTotal?.classList.toggle('hidden', rel.left.comparisonSource !== 'exact_number')
+    fields.rightComparisonSourceTotal?.classList.toggle('hidden', rel.right.comparisonSource !== 'exact_number')
+    fields.leftComparisonSourceStack?.classList.toggle('condition-form-comparison-source-stack--inline-number', rel.left.comparisonSource === 'exact_number')
+    fields.rightComparisonSourceStack?.classList.toggle('condition-form-comparison-source-stack--inline-number', rel.right.comparisonSource === 'exact_number')
+
+    fields.leftFilterRow.classList.toggle('hidden', false)
+    fields.rightFilterRow.classList.toggle('hidden', false)
+    fields.leftFilterModeControl?.classList.toggle('condition-form-checkbox--unavailable', !leftFilterModeAvailable)
+    fields.rightFilterModeControl?.classList.toggle('condition-form-checkbox--unavailable', !rightFilterModeAvailable)
+    fields.rightComparisonToggle.closest('.condition-form-comparison').classList.toggle('hidden', false)
+
+    const leftLocked = this.comparisonLocked(rel, 'left')
+    const rightLocked = this.comparisonLocked(rel, 'right')
+    fields.leftComparisonToggle.disabled = leftLocked
+    fields.rightComparisonToggle.disabled = rightLocked
+    fields.leftComparisonToggle.textContent = leftLocked ? this.comparisonUnavailableText(rel, 'left') : (rel.ui.leftComparisonOpen ? 'Hide comparison' : '+ comparison (advanced)')
+    fields.rightComparisonToggle.textContent = rightLocked ? this.comparisonUnavailableText(rel, 'right') : (rel.ui.rightComparisonOpen ? 'Hide comparison' : '+ comparison (advanced)')
+
+    this.setComparisonInputsDisabled('left', fields, !leftComparisonActive)
+    this.setComparisonInputsDisabled('right', fields, !rightComparisonActive)
+
+    showAllOptions(fields.leftSubject)
+    showAllOptions(fields.rightSubject)
+    this.disableSubjectOptions(rel, fields)
+    this.disableComparisonSourceOptions(rel, fields)
+    this.disableComparisonMetricOptions(rel, fields)
+
+    fields.relationalTargetNote?.classList.toggle('hidden', rel.operator !== 'shield')
+    fields.rightAggregateNote?.classList.toggle('hidden', !this.leftUsesAggregateValue(rel))
+    fields.leftAggregateNote?.classList.toggle('hidden', !this.rightUsesAggregateValue(rel))
+  }
+
+  applyCompatibilityRules(rel) {
+    if (rel.right.subject === 'captured_piece') {
+      rel.right.subject = 'enemy'
+    }
+    const allowedLeft = this.regularSubjects()
+    if (!allowedLeft.includes(rel.left.subject)) {
+      rel.left.subject = 'allied'
+    }
+
+    const allowedRight = this.regularTargets(rel)
+    if (!allowedRight.includes(rel.right.subject)) {
+      rel.right.subject = allowedRight[0]
+    }
+
+    if (this.leftUsesPriorBoardState(rel)) {
+      this.clearComparator(rel, 'right')
+      rel.ui.rightComparisonOpen = false
+    }
+
+    if (this.rightUsesPriorBoardState(rel)) {
+      this.clearComparator(rel, 'left')
+      rel.ui.leftComparisonOpen = false
+    }
+
+    if (this.leftUsesAggregateValue(rel) && rel.right.comparisonMetric === 'aggregate_value') {
+      rel.right.comparisonMetric = 'count'
+    }
+
+    this.applyComparisonSourceCompatibility(rel, 'left')
+    this.applyComparisonSourceCompatibility(rel, 'right')
+    this.applyFilterModeCompatibilityRules(rel)
+  }
+
+  applyComparisonSourceCompatibility(rel, side) {
+    const sideState = rel[side]
+    const allowedSources = this.allowedComparisonSourcesForMetric(sideState.comparisonMetric)
+    if (!allowedSources.includes(sideState.comparisonSource)) {
+      sideState.comparisonSource = 'exact_number'
+      sideState.comparisonSourceTotal ||= 1
+    }
+  }
+
+  applyFilterModeCompatibilityRules(rel) {
+    if (rel.left.filter === 'any') { rel.left.filterMode = 'include' }
+    if (rel.right.filter === 'any') { rel.right.filterMode = 'include' }
+  }
+
+  clearComparator(rel, side) {
+    const sideState = rel[side]
+    sideState.comparisonMetric = ''
+    sideState.comparator = 'equal_to'
+    sideState.comparisonSource = 'exact_number'
+    sideState.comparisonSourceTotal = 1
+  }
+
+  leftUsesPriorBoardState(rel) {
+    return rel.ui.leftComparisonOpen && rel.left.comparisonSource === 'prior_board_state'
+  }
+
+  rightUsesPriorBoardState(rel) {
+    return rel.ui.rightComparisonOpen && rel.right.comparisonSource === 'prior_board_state'
+  }
+
+  leftUsesAggregateValue(rel) {
+    return rel.ui.leftComparisonOpen && rel.left.comparisonMetric === 'aggregate_value'
+  }
+
+  rightUsesAggregateValue(rel) {
+    return rel.ui.rightComparisonOpen && rel.right.comparisonMetric === 'aggregate_value'
+  }
+
+  comparisonLocked(rel, side) {
+    return side === 'left' ? this.rightUsesPriorBoardState(rel) : this.leftUsesPriorBoardState(rel)
+  }
+
+  comparisonUnavailableText(rel, side) {
+    if (side === 'left' && this.rightUsesPriorBoardState(rel)) {
+      return '+ comparison unavailable while target uses prior'
+    }
+    if (side === 'right' && this.leftUsesPriorBoardState(rel)) {
+      return '+ comparison unavailable while subject uses prior'
+    }
+    return '+ comparison unavailable'
+  }
+
+  regularSubjects() {
+    return this.grammarRules.regularRelationalSubjects
+  }
+
+  regularTargets(rel) {
+    const operator = rel.operator
+    if (operator === 'targets') { return this.grammarRules.regularRelationalTargets }
+    const targetRule = this.grammarRules.relationalOperatorTargetRules[operator] || 'any_regular'
+    if (targetRule === 'opposing_team') {
+      return this.opposingTeamTargetsFor(rel.left.subject)
+    } else if (targetRule === 'same_team') {
+      return this.sameTeamTargetsFor(rel.left.subject)
+    } else {
+      return this.grammarRules.regularRelationalTargets
+    }
+  }
+
+  sameTeamTargetsFor(subject) {
+    const team = this.teamGroupForSubject(subject)
+    return team ? this.grammarRules.teamSubjectGroups[team] : []
+  }
+
+  opposingTeamTargetsFor(subject) {
+    const team = this.teamGroupForSubject(subject)
+    const opposingTeam = this.grammarRules.opposingTeamGroups[team]
+    return opposingTeam ? this.grammarRules.teamSubjectGroups[opposingTeam] : []
+  }
+
+  teamGroupForSubject(subject) {
+    return Object.keys(this.grammarRules.teamSubjectGroups).find(team => {
+      return this.grammarRules.teamSubjectGroups[team].includes(subject)
+    })
+  }
+
+  translateTargetsOperator(leftSubject, rightSubject, operator) {
+    if (operator !== 'targets') { return operator }
+    const leftTeam = this.teamGroupForSubject(leftSubject)
+    const rightTeam = this.teamGroupForSubject(rightSubject)
+    return leftTeam === rightTeam ? 'defend' : 'attack'
+  }
+
+  allowedComparisonSourcesForMetric(metric) {
+    if (metric === 'individual_value' || metric === 'aggregate_value') {
+      return ['exact_number', 'prior_board_state', 'moved_piece', 'captured_piece', 'enemy_moved_piece', 'enemy_captured_piece']
+    }
+    return ['exact_number', 'prior_board_state']
+  }
+
+  setComparisonInputsDisabled(side, fields, disabled) {
+    const metricKey = side === 'left' ? 'leftComparisonMetric' : 'rightComparisonMetric'
+    const comparatorKey = side === 'left' ? 'leftComparator' : 'rightComparator'
+    const comparatorInputsKey = side === 'left' ? 'leftComparatorInputs' : 'rightComparatorInputs'
+    const sourceKey = side === 'left' ? 'leftComparisonSource' : 'rightComparisonSource'
+    const sourceTotalKey = side === 'left' ? 'leftComparisonSourceTotal' : 'rightComparisonSourceTotal'
+
+    fields[metricKey].disabled = disabled
+    fields[sourceKey].disabled = disabled
+    fields[sourceTotalKey].disabled = disabled
+    fields[comparatorInputsKey]?.forEach(input => { input.disabled = disabled })
+    fields[comparatorKey]?.classList.toggle('condition-form-radio-row--disabled', disabled)
+  }
+
+  disableComparisonSourceOptions(rel, fields) {
+    this.disableComparisonSourceOptionsForSide(rel, 'left', fields.leftComparisonSource)
+    this.disableComparisonSourceOptionsForSide(rel, 'right', fields.rightComparisonSource)
+  }
+
+  disableComparisonSourceOptionsForSide(rel, side, select) {
+    const allowedSources = this.allowedComparisonSourcesForMetric(rel[side].comparisonMetric || 'count')
+    const allSources = Array.from(select.options).map(option => option.value)
+    disableOptions(select, allSources.filter(value => !allowedSources.includes(value)))
+  }
+
+  disableComparisonMetricOptions(rel, fields) {
+    this.disableComparisonMetricOptionsForSide(rel, 'left', fields.leftComparisonMetric)
+    this.disableComparisonMetricOptionsForSide(rel, 'right', fields.rightComparisonMetric)
+  }
+
+  disableComparisonMetricOptionsForSide(rel, side, select) {
+    const otherUsesAggregate = side === 'left' ? this.rightUsesAggregateValue(rel) : this.leftUsesAggregateValue(rel)
+    disableOptions(select, otherUsesAggregate ? ['aggregate_value'] : [])
+  }
+
+  disableSubjectOptions(rel, fields) {
+    enableAllOptions(fields.leftSubject)
+    enableAllOptions(fields.rightSubject)
+
+    disableOptions(fields.leftSubject, this.editorSubjects().filter(v => !this.regularSubjects().includes(v)))
+    disableOptions(fields.rightSubject, this.editorSubjects().filter(v => !this.regularTargets(rel).includes(v)))
+  }
+
+  editorSubjects() {
+    return this.grammarRules.editorSubjects
+  }
+}

--- a/app/javascript/editorV2/panels/condition_preview/RULES.md
+++ b/app/javascript/editorV2/panels/condition_preview/RULES.md
@@ -1,5 +1,21 @@
 # condition_preview rules
 
+## Condition kinds
+
+Condition `kind` is `relational | census | identity` only. **`unary` and
+`position` are retired** — no `plan.kind`/`data.kind`/`source` will ever be
+those again; do not reason from or reintroduce them.
+
+- Region vs whole-board is detected by **`positionAxis` presence, not by
+  kind**: census with no spatial keys ≡ the old unary (whole-board; the
+  evaluator delegates to `evaluateUnary`); census with `positionAxis` ≡ the
+  old position (region-restricted).
+- A cross-frame `entry.source` **is `plan.kind`** — so it's `'census'`,
+  never `'unary'`.
+- `forward_resolver/`, `forward_pattern/`, and `reverse_relational/` are
+  **sunset**: not census-ified, gated off the live path. Don't rebaseline,
+  extend, or census-transform their specs — skip/retire instead.
+
 ## Goals
 
 Generate a wide variety of legal chess positions + moves in which the condition(s) are satisfied. Variety means:

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/_diagnostic_ep.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/_diagnostic_ep.test.js
@@ -24,7 +24,7 @@ function makeAdder() {
 describe('DIAGNOSTIC: standard outputs board summary (delete after analysis)', () => {
   it('counts pieces per example', () => {
     const combinedPlan = buildCombinedPlan([{
-      version: 2, kind: 'unary',
+      version: 2, kind: 'census',
       subject: 'moved_piece', subjectFilter: 'any',
       operator: 'count', comparator: 'equal_to',
       target: 'exact_number', targetTotal: 1

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/build_engine.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/build_engine.test.js
@@ -5,14 +5,14 @@ import { buildCombinedPlan } from 'editorV2/panels/condition_preview/plans/plan'
 import { buildAttempt } from 'editorV2/panels/condition_preview/forward_proposition/build_engine'
 
 const KNIGHT_MOVER_PAYLOAD = {
-  version: 2, kind: 'unary',
+  version: 2, kind: 'census',
   subject: 'moved_piece', subjectFilter: 'knight',
   operator: 'count', comparator: 'greater_than',
   target: 'exact_number', targetTotal: 0
 }
 
 const ROOK_MOBILITY_PAYLOAD = {
-  version: 2, kind: 'unary',
+  version: 2, kind: 'census',
   subject: 'allied', subjectFilter: 'rook',
   operator: 'mobility', comparator: 'less_than',
   target: 'exact_number', targetTotal: 5
@@ -106,7 +106,7 @@ const PIN_CHAIN_PAYLOADS = [
     target: 'enemy', targetFilter: 'king'
   },
   {
-    version: 2, kind: 'unary',
+    version: 2, kind: 'census',
     subject: 'enemy_moved_piece', subjectFilter: 'any',
     operator: 'mobility', comparator: 'equal_to',
     target: 'exact_number', targetTotal: 0
@@ -138,7 +138,7 @@ const MATE_CHAIN_PAYLOADS = [
     target: 'enemy', targetFilter: 'king'
   },
   {
-    version: 2, kind: 'unary',
+    version: 2, kind: 'census',
     subject: 'enemy', subjectFilter: 'any',
     operator: 'mobility', comparator: 'equal_to',
     target: 'exact_number', targetTotal: 0
@@ -163,7 +163,7 @@ const STALEMATE_CHAIN_PAYLOADS = [
     target: 'enemy', targetFilter: 'king'
   },
   {
-    version: 2, kind: 'unary',
+    version: 2, kind: 'census',
     subject: 'enemy', subjectFilter: 'any',
     operator: 'mobility', comparator: 'equal_to',
     target: 'exact_number', targetTotal: 0

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/census_region_propositions.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/census_region_propositions.test.js
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+import { buildCombinedPlan } from 'editorV2/panels/condition_preview/plans/plan'
+import { emitConstraintsFromPlan } from 'editorV2/panels/condition_preview/forward_proposition/propositions'
+
+// NEW-TDD-RED: the census kind is not yet a supported plan, and
+// regionFromPlan is still gated on plan.kind === 'position'. A census plan
+// carrying spatial keys must reach the proposition layer as a set-region;
+// a census against prior_board_state must emit BOTH frames region-restricted
+// (this is the foundation of generating region-specific PBS census examples).
+
+function censusPlan(payload) {
+  const combined = buildCombinedPlan([{ version: 2, kind: 'census', ...payload }])
+  return combined.plans[0]
+}
+
+describe('census region reaches the proposition layer (NEW-TDD-RED)', () => {
+  it('emits a board-wide region for a census with no spatial keys', () => {
+    const plan = censusPlan({
+      subject: 'allied', subjectFilter: 'pawn',
+      operator: 'count', comparator: 'greater_than_or_equal_to',
+      target: 'exact_number', targetTotal: 2
+    })
+
+    const { propositions } = emitConstraintsFromPlan(plan)
+
+    expect(propositions).toHaveLength(1)
+    expect(propositions[0].region).toEqual({ kind: 'all' })
+  })
+
+  it('emits a set-region proposition for a census carrying spatial keys', () => {
+    const plan = censusPlan({
+      subject: 'allied', subjectFilter: 'major',
+      positionAxis: 'file', positionComparator: 'equal_to', positionTarget: 4,
+      operator: 'count', comparator: 'equal_to', target: 'exact_number', targetTotal: 2
+    })
+
+    const { propositions } = emitConstraintsFromPlan(plan)
+
+    expect(propositions).toHaveLength(1)
+    expect(propositions[0].region.kind).toBe('set')
+    expect(propositions[0].region.squares.size).toBeGreaterThan(0)
+  })
+
+  it('emits both prior and current propositions region-restricted for a region census against prior_board_state', () => {
+    const plan = censusPlan({
+      subject: 'allied', subjectFilter: 'major',
+      positionAxis: 'rank', positionComparator: 'greater_than_or_equal_to', positionTarget: 5,
+      operator: 'count', comparator: 'greater_than',
+      target: 'prior_board_state'
+    })
+
+    const { propositions, crossFrame } = emitConstraintsFromPlan(plan)
+
+    const prior = propositions.find(p => p.frame === 'prior')
+    const current = propositions.find(p => p.frame === 'current')
+    expect(prior).toBeDefined()
+    expect(current).toBeDefined()
+    expect(prior.region.kind).toBe('set')
+    expect(current.region.kind).toBe('set')
+    expect(crossFrame).toHaveLength(1)
+    expect(crossFrame[0].source).toBe('census')
+  })
+})

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/chain_ctx.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/chain_ctx.test.js
@@ -5,7 +5,7 @@ import { buildChainCtx } from 'editorV2/panels/condition_preview/forward_proposi
 import { defaultStructuralPropositions } from 'editorV2/panels/condition_preview/forward_proposition/structural_invariants'
 
 const TRIVIAL_PAYLOAD = {
-  version: 2, kind: 'unary',
+  version: 2, kind: 'census',
   subject: 'allied', subjectFilter: 'pawn',
   operator: 'count', comparator: 'greater_than_or_equal_to',
   target: 'exact_number', targetTotal: 2

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/collect.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/collect.test.js
@@ -27,7 +27,7 @@ function makeAdder() {
 describe('collectForwardPropositionExamples', () => {
   it('produces verified examples for a simple knight-mover chain', () => {
     const combinedPlan = buildCombinedPlan([{
-      version: 2, kind: 'unary',
+      version: 2, kind: 'census',
       subject: 'moved_piece', subjectFilter: 'knight',
       operator: 'count', comparator: 'greater_than',
       target: 'exact_number', targetTotal: 0
@@ -51,7 +51,7 @@ describe('collectForwardPropositionExamples', () => {
 
   it('produces castle examples for a castle-compatible chain', () => {
     const combinedPlan = buildCombinedPlan([{
-      version: 2, kind: 'unary',
+      version: 2, kind: 'census',
       subject: 'allied', subjectFilter: 'pawn',
       operator: 'count', comparator: 'greater_than_or_equal_to',
       target: 'exact_number', targetTotal: 0
@@ -129,7 +129,7 @@ describe('collectForwardPropositionExamples', () => {
 
   it('generates examples for moved_piece value less_than captured_piece', () => {
     const combinedPlan = buildCombinedPlan([{
-      version: 2, kind: 'unary',
+      version: 2, kind: 'census',
       subject: 'moved_piece', subjectFilter: 'any',
       operator: 'value', comparator: 'less_than',
       target: 'captured_piece', targetFilter: 'any'

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/collect.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/collect.test.js
@@ -101,10 +101,9 @@ describe('collectForwardPropositionExamples', () => {
 
   it('generates examples for enemy_moved_piece same_piece captured_piece, including en passant', () => {
     const combinedPlan = buildCombinedPlan([{
-      version: 2, kind: 'relational',
-      subject: 'enemy_moved_piece', subjectFilter: 'any',
-      operator: 'same_piece',
-      target: 'captured_piece', targetFilter: 'any'
+      version: 2, kind: 'identity',
+      subject: 'enemy_moved_piece',
+      target: 'captured_piece'
     }])
     const standardExamples = []
     const produced = { 'forward-proposition': 0 }

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/commit_singulars.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/commit_singulars.test.js
@@ -6,7 +6,7 @@ import { commitSingularsSpecies } from 'editorV2/panels/condition_preview/forwar
 import { commitSingularsPosition } from 'editorV2/panels/condition_preview/forward_proposition/commit_singulars_position'
 
 const TRIVIAL_PLAN = {
-  version: 2, kind: 'unary',
+  version: 2, kind: 'census',
   subject: 'allied', subjectFilter: 'pawn',
   operator: 'count', comparator: 'greater_than_or_equal_to',
   target: 'exact_number', targetTotal: 1

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/cross_frame/moved_piece_captures_relation_participant.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/cross_frame/moved_piece_captures_relation_participant.test.js
@@ -57,8 +57,8 @@ describe('movedPieceCapturesRelationParticipant — appliesTo', () => {
     expect(movedPieceCapturesRelationParticipant.appliesTo(entry(), ctxWithSingulars(), new Map())).toBe(true)
   })
 
-  it('returns false for unary entries', () => {
-    expect(movedPieceCapturesRelationParticipant.appliesTo(entry({ source: 'unary' }), ctxWithSingulars(), new Map())).toBe(false)
+  it('returns false for census entries', () => {
+    expect(movedPieceCapturesRelationParticipant.appliesTo(entry({ source: 'census' }), ctxWithSingulars(), new Map())).toBe(false)
   })
 
   it('returns false for direction "+"', () => {

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/cross_frame/moved_piece_participates_in_attack_or_defend.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/cross_frame/moved_piece_participates_in_attack_or_defend.test.js
@@ -52,7 +52,7 @@ describe('movedPieceParticipatesInAttackOrDefend — appliesTo', () => {
   it('returns false for non-relational entries', () => {
     const ctx = defaultTestCtx({ singulars: { moved_piece: movedPieceSingular() } })
 
-    expect(movedPieceParticipatesInAttackOrDefend.appliesTo(entry({ source: 'unary' }), ctx, new Map())).toBe(false)
+    expect(movedPieceParticipatesInAttackOrDefend.appliesTo(entry({ source: 'census' }), ctx, new Map())).toBe(false)
   })
 
   it('returns false for shield or adjacent operators', () => {

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/cross_frame/moved_piece_shifts_allied_mobility.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/cross_frame/moved_piece_shifts_allied_mobility.test.js
@@ -21,7 +21,7 @@ function movedPieceSingular(species = Board.NIGHT) {
 
 function entry({
   direction = '-', team = Board.WHITE, species = Board.QUEEN,
-  boundSingularActor = null, source = 'unary'
+  boundSingularActor = null, source = 'census'
 } = {}) {
   const currentProposition = {
     team, frame: 'current',
@@ -42,7 +42,7 @@ function entry({
 }
 
 describe('movedPieceShiftsAlliedMobility — appliesTo', () => {
-  it('returns true for unary mobility on allied team not bound to moved_piece', () => {
+  it('returns true for census mobility on allied team not bound to moved_piece', () => {
     const ctx = defaultTestCtx({ singulars: { moved_piece: movedPieceSingular() } })
     expect(movedPieceShiftsAlliedMobility.appliesTo(entry(), ctx, new Map())).toBe(true)
   })

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/cross_frame/moved_piece_shifts_enemy_king_mobility.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/cross_frame/moved_piece_shifts_enemy_king_mobility.test.js
@@ -29,7 +29,7 @@ function entry({ direction = '-', team = Board.BLACK, speciesSet = new Set([Boar
     aggregate_mobility_range: { min: 0, max: Infinity }
   }
   return {
-    source: 'unary', operator: 'mobility', metric: 'aggregate_mobility', direction,
+    source: 'census', operator: 'mobility', metric: 'aggregate_mobility', direction,
     priorProposition: { ...currentProposition, frame: 'prior' },
     currentProposition,
     subjectProposition: null,

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/cross_frame/moved_piece_shifts_enemy_mobility.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/cross_frame/moved_piece_shifts_enemy_mobility.test.js
@@ -29,7 +29,7 @@ function entry({ direction = '-', team = Board.BLACK, speciesSet = new Set([Boar
     aggregate_mobility_range: { min: 0, max: Infinity }
   }
   return {
-    source: 'unary', operator: 'mobility', metric: 'aggregate_mobility', direction,
+    source: 'census', operator: 'mobility', metric: 'aggregate_mobility', direction,
     priorProposition: { ...currentProposition, frame: 'prior' },
     currentProposition,
     subjectProposition: null,

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/cross_frame/moved_piece_shifts_own_mobility.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/cross_frame/moved_piece_shifts_own_mobility.test.js
@@ -29,7 +29,7 @@ function entry({ direction = '+', boundSingularActor = 'moved_piece', species = 
     aggregate_mobility_range: { min: 0, max: Infinity }
   }
   return {
-    source: 'unary', operator: 'mobility', metric: 'aggregate_mobility', direction,
+    source: 'census', operator: 'mobility', metric: 'aggregate_mobility', direction,
     priorProposition: { ...currentProposition, frame: 'prior' },
     currentProposition,
     subjectProposition: null,
@@ -38,17 +38,17 @@ function entry({ direction = '+', boundSingularActor = 'moved_piece', species = 
 }
 
 describe('movedPieceShiftsOwnMobility — appliesTo', () => {
-  it('returns true for unary mobility entry bound to moved_piece', () => {
+  it('returns true for census mobility entry bound to moved_piece', () => {
     const ctx = defaultTestCtx({ singulars: { moved_piece: movedPieceSingular() } })
     expect(movedPieceShiftsOwnMobility.appliesTo(entry(), ctx, new Map())).toBe(true)
   })
 
-  it('returns false for unary mobility entries bound to other singulars', () => {
+  it('returns false for census mobility entries bound to other singulars', () => {
     const ctx = defaultTestCtx({ singulars: { moved_piece: movedPieceSingular() } })
     expect(movedPieceShiftsOwnMobility.appliesTo(entry({ boundSingularActor: 'enemy_moved_piece' }), ctx, new Map())).toBe(false)
   })
 
-  it('returns false for unary mobility entries not bound to a singular (team-wide)', () => {
+  it('returns false for census mobility entries not bound to a singular (team-wide)', () => {
     const ctx = defaultTestCtx({ singulars: { moved_piece: movedPieceSingular() } })
     expect(movedPieceShiftsOwnMobility.appliesTo(entry({ boundSingularActor: null }), ctx, new Map())).toBe(false)
   })

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/cross_frame/satisfy_cross_frame.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/cross_frame/satisfy_cross_frame.test.js
@@ -17,7 +17,7 @@ describe('satisfyCrossFrame — gate', () => {
   it('returns the input pieces map unchanged when no mechanisms apply', () => {
     const ctx = defaultTestCtx({
       crossFrame: [{
-        source: 'unary', operator: 'mobility', metric: 'aggregate_mobility',
+        source: 'census', operator: 'mobility', metric: 'aggregate_mobility',
         direction: '+',
         priorProposition: { team: 'w', frame: 'prior', species_set: new Set() },
         currentProposition: { team: 'w', frame: 'current', species_set: new Set() }

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/narrow_for_crossframe.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/narrow_for_crossframe.test.js
@@ -3,6 +3,14 @@ import Board from 'gameplay/board'
 import { narrowForCrossFrame } from 'editorV2/panels/condition_preview/forward_proposition/narrow_for_crossframe'
 import { defaultTestCtx } from './_helpers'
 
+// Kind retirement: crossFrame entry `source` is now 'census' (it is plan.kind).
+// The positive census narrowing path (drops null / intersects species_set, and
+// the formerly-dormant aggregate_value variant — now live under census value
+// PBS) lives in narrow_for_crossframe_census.test.js; that redundant describe
+// block was deleted from here to avoid duplication. Retained here: the
+// non-matching guard cases, re-based on source:'census' so each fails the
+// narrowing for the field under test — not vacuously because the source is dead.
+
 const CAPTURABLE = [Board.PAWN, Board.NIGHT, Board.BISHOP, Board.ROOK, Board.QUEEN]
 
 function capturedPieceSingular() {
@@ -14,50 +22,11 @@ function capturedPieceSingular() {
   }
 }
 
-function unaryEnemyCountDownEntry(speciesSet = new Set(CAPTURABLE)) {
+function censusEnemyCountDownEntry(speciesSet = new Set(CAPTURABLE)) {
   const currentProposition = { team: Board.BLACK, frame: 'current', species_set: speciesSet }
   const priorProposition   = { team: Board.BLACK, frame: 'prior',   species_set: speciesSet }
-  return { source: 'unary', metric: 'count', direction: '-', priorProposition, currentProposition }
+  return { source: 'census', metric: 'count', direction: '-', priorProposition, currentProposition }
 }
-
-describe('narrowForCrossFrame — narrows captured_piece for unary enemy count/value down', () => {
-  it('drops null from captured_piece.species_set when source is unary, direction is "-", metric is count, team is enemy', () => {
-    const ctx = defaultTestCtx({
-      singulars: { captured_piece: capturedPieceSingular() },
-      crossFrame: [unaryEnemyCountDownEntry()]
-    })
-
-    narrowForCrossFrame(ctx)
-
-    expect(ctx.singulars.captured_piece.species_set.has(null)).toBe(false)
-  })
-
-  it('intersects captured_piece.species_set with the crossFrame entry species_set', () => {
-    const ctx = defaultTestCtx({
-      singulars: { captured_piece: capturedPieceSingular() },
-      crossFrame: [unaryEnemyCountDownEntry(new Set([Board.QUEEN]))]
-    })
-
-    narrowForCrossFrame(ctx)
-
-    expect(ctx.singulars.captured_piece.species_set).toEqual(new Set([Board.QUEEN]))
-  })
-
-  // Dormant: relational aggregate_value is grammar-gated. Engine retained.
-  it.skip('handles aggregate_value metric the same as count', () => {
-    const ctx = defaultTestCtx({
-      singulars: { captured_piece: capturedPieceSingular() },
-      crossFrame: [{
-        ...unaryEnemyCountDownEntry(new Set([Board.ROOK, Board.QUEEN])),
-        metric: 'aggregate_value'
-      }]
-    })
-
-    narrowForCrossFrame(ctx)
-
-    expect(ctx.singulars.captured_piece.species_set).toEqual(new Set([Board.ROOK, Board.QUEEN]))
-  })
-})
 
 describe('narrowForCrossFrame — non-matching cases leave captured_piece unchanged', () => {
   it('leaves captured_piece alone when crossFrame is empty', () => {
@@ -75,7 +44,7 @@ describe('narrowForCrossFrame — non-matching cases leave captured_piece unchan
   it('leaves captured_piece alone when source is relational', () => {
     const ctx = defaultTestCtx({
       singulars: { captured_piece: capturedPieceSingular() },
-      crossFrame: [{ ...unaryEnemyCountDownEntry(), source: 'relational' }]
+      crossFrame: [{ ...censusEnemyCountDownEntry(), source: 'relational' }]
     })
 
     const before = new Set(ctx.singulars.captured_piece.species_set)
@@ -87,7 +56,7 @@ describe('narrowForCrossFrame — non-matching cases leave captured_piece unchan
   it('leaves captured_piece alone when direction is "+"', () => {
     const ctx = defaultTestCtx({
       singulars: { captured_piece: capturedPieceSingular() },
-      crossFrame: [{ ...unaryEnemyCountDownEntry(), direction: '+' }]
+      crossFrame: [{ ...censusEnemyCountDownEntry(), direction: '+' }]
     })
 
     const before = new Set(ctx.singulars.captured_piece.species_set)
@@ -99,7 +68,7 @@ describe('narrowForCrossFrame — non-matching cases leave captured_piece unchan
   it('leaves captured_piece alone when metric is aggregate_mobility', () => {
     const ctx = defaultTestCtx({
       singulars: { captured_piece: capturedPieceSingular() },
-      crossFrame: [{ ...unaryEnemyCountDownEntry(), metric: 'aggregate_mobility' }]
+      crossFrame: [{ ...censusEnemyCountDownEntry(), metric: 'aggregate_mobility' }]
     })
 
     const before = new Set(ctx.singulars.captured_piece.species_set)
@@ -109,7 +78,7 @@ describe('narrowForCrossFrame — non-matching cases leave captured_piece unchan
   })
 
   it('leaves captured_piece alone when team is the moving team (unreachable in practice but defensive)', () => {
-    const movingTeamEntry = unaryEnemyCountDownEntry()
+    const movingTeamEntry = censusEnemyCountDownEntry()
     movingTeamEntry.currentProposition = { ...movingTeamEntry.currentProposition, team: Board.WHITE }
     const ctx = defaultTestCtx({
       singulars: { captured_piece: capturedPieceSingular() },

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/narrow_for_crossframe_census.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/narrow_for_crossframe_census.test.js
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+import Board from 'gameplay/board'
+import { narrowForCrossFrame } from 'editorV2/panels/condition_preview/forward_proposition/narrow_for_crossframe'
+import { defaultTestCtx } from './_helpers'
+
+// NEW-TDD-RED: post-merge the crossFrame entry `source` becomes 'census'
+// (it is plan.kind). `forcesCapture` currently hard-requires
+// source === 'unary', so the captured_piece narrowing silently stops for
+// every census PBS. These pin the decided behavior: census conditions
+// involving captured_piece force the capture EXCEPT when the assertion is
+// count = 0 (which asserts that no capture happened).
+
+const CAPTURABLE = [Board.PAWN, Board.NIGHT, Board.BISHOP, Board.ROOK, Board.QUEEN]
+
+function capturedPieceSingular() {
+  return {
+    team: Board.BLACK,
+    species_set: new Set([null, ...CAPTURABLE]),
+    region: { kind: 'all' },
+    relationsToAnchors: []
+  }
+}
+
+function censusEnemyCountDownEntry(speciesSet = new Set(CAPTURABLE)) {
+  const currentProposition = { team: Board.BLACK, frame: 'current', species_set: speciesSet }
+  const priorProposition = { team: Board.BLACK, frame: 'prior', species_set: speciesSet }
+  return { source: 'census', metric: 'count', direction: '-', priorProposition, currentProposition }
+}
+
+describe('narrowForCrossFrame — census PBS still narrows captured_piece (NEW-TDD-RED)', () => {
+  it('drops null from captured_piece.species_set for a decreasing enemy count census', () => {
+    const ctx = defaultTestCtx({
+      singulars: { captured_piece: capturedPieceSingular() },
+      crossFrame: [censusEnemyCountDownEntry()]
+    })
+
+    narrowForCrossFrame(ctx)
+
+    expect(ctx.singulars.captured_piece.species_set.has(null)).toBe(false)
+  })
+
+  it('intersects captured_piece.species_set with the census crossFrame entry species_set', () => {
+    const ctx = defaultTestCtx({
+      singulars: { captured_piece: capturedPieceSingular() },
+      crossFrame: [censusEnemyCountDownEntry(new Set([Board.QUEEN]))]
+    })
+
+    narrowForCrossFrame(ctx)
+
+    expect(ctx.singulars.captured_piece.species_set).toEqual(new Set([Board.QUEEN]))
+  })
+
+  // Live under census: a decreasing-enemy census *value* PBS emits
+  // {source:'census', metric:'aggregate_value', direction:'-'}
+  // (propositions.js metricForOperator('value', collection) -> aggregate_value),
+  // so forcesCapture fires the same as for count.
+  it('handles aggregate_value metric the same as count', () => {
+    const ctx = defaultTestCtx({
+      singulars: { captured_piece: capturedPieceSingular() },
+      crossFrame: [{
+        ...censusEnemyCountDownEntry(new Set([Board.ROOK, Board.QUEEN])),
+        metric: 'aggregate_value'
+      }]
+    })
+
+    narrowForCrossFrame(ctx)
+
+    expect(ctx.singulars.captured_piece.species_set).toEqual(new Set([Board.ROOK, Board.QUEEN]))
+  })
+
+  it('leaves captured_piece untouched when the census asserts an enemy count of zero', () => {
+    // count = 0 asserts NO capture occurred, so it must not force one.
+    const zeroCountEntry = {
+      ...censusEnemyCountDownEntry(),
+      metric: 'count',
+      direction: '=',
+      currentProposition: { team: Board.BLACK, frame: 'current', species_set: new Set(CAPTURABLE), countIsZero: true }
+    }
+    const ctx = defaultTestCtx({
+      singulars: { captured_piece: capturedPieceSingular() },
+      crossFrame: [zeroCountEntry]
+    })
+
+    const before = new Set(ctx.singulars.captured_piece.species_set)
+    narrowForCrossFrame(ctx)
+
+    expect(ctx.singulars.captured_piece.species_set).toEqual(before)
+  })
+})

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/propositions.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/propositions.test.js
@@ -7,7 +7,7 @@ import { emitConstraintsFromPlan } from 'editorV2/panels/condition_preview/forwa
 describe('emitConstraintsFromPlan — unary group count', () => {
   it('emits one proposition with team, frame, species_set, region, and count_range', () => {
     const combinedPlan = buildCombinedPlan([{
-      version: 2, kind: 'unary',
+      version: 2, kind: 'census',
       subject: 'allied', subjectFilter: 'pawn',
       operator: 'count', comparator: 'greater_than_or_equal_to',
       target: 'exact_number', targetTotal: 2
@@ -27,7 +27,7 @@ describe('emitConstraintsFromPlan — unary group count', () => {
 
   it('emits count_range with equal min and max for comparator equal_to', () => {
     const combinedPlan = buildCombinedPlan([{
-      version: 2, kind: 'unary',
+      version: 2, kind: 'census',
       subject: 'allied', subjectFilter: 'pawn',
       operator: 'count', comparator: 'equal_to',
       target: 'exact_number', targetTotal: 3
@@ -42,7 +42,7 @@ describe('emitConstraintsFromPlan — unary group count', () => {
 
   it('emits count_range capped at total - 1 for comparator less_than', () => {
     const combinedPlan = buildCombinedPlan([{
-      version: 2, kind: 'unary',
+      version: 2, kind: 'census',
       subject: 'allied', subjectFilter: 'pawn',
       operator: 'count', comparator: 'less_than',
       target: 'exact_number', targetTotal: 4
@@ -57,7 +57,7 @@ describe('emitConstraintsFromPlan — unary group count', () => {
 
   it('emits species_set as the complement when subjectFilterMode is exclude', () => {
     const combinedPlan = buildCombinedPlan([{
-      version: 2, kind: 'unary',
+      version: 2, kind: 'census',
       subject: 'allied', subjectFilter: 'pawn', subjectFilterMode: 'exclude',
       operator: 'count', comparator: 'greater_than_or_equal_to',
       target: 'exact_number', targetTotal: 1
@@ -72,7 +72,7 @@ describe('emitConstraintsFromPlan — unary group count', () => {
 
   it('emits aggregate_value_range for unary value plans, with permissive default count_range', () => {
     const combinedPlan = buildCombinedPlan([{
-      version: 2, kind: 'unary',
+      version: 2, kind: 'census',
       subject: 'allied', subjectFilter: 'any',
       operator: 'value', comparator: 'greater_than',
       target: 'exact_number', targetTotal: 20
@@ -90,7 +90,7 @@ describe('emitConstraintsFromPlan — unary group count', () => {
 describe('emitConstraintsFromPlan — unary on a singular subject', () => {
   it('tags the proposition with boundSingularActor', () => {
     const combinedPlan = buildCombinedPlan([{
-      version: 2, kind: 'unary',
+      version: 2, kind: 'census',
       subject: 'enemy_moved_piece', subjectFilter: 'any',
       operator: 'mobility', comparator: 'equal_to',
       target: 'exact_number', targetTotal: 0
@@ -103,7 +103,7 @@ describe('emitConstraintsFromPlan — unary on a singular subject', () => {
 
   it('leaves boundSingularActor null on non-singular unary subjects', () => {
     const combinedPlan = buildCombinedPlan([{
-      version: 2, kind: 'unary',
+      version: 2, kind: 'census',
       subject: 'allied', subjectFilter: 'any',
       operator: 'count', comparator: 'greater_than_or_equal_to',
       target: 'exact_number', targetTotal: 1
@@ -118,7 +118,7 @@ describe('emitConstraintsFromPlan — unary on a singular subject', () => {
 describe('emitConstraintsFromPlan — position group', () => {
   it('emits region of qualifying squares for position group count plans', () => {
     const combinedPlan = buildCombinedPlan([{
-      version: 2, kind: 'position',
+      version: 2, kind: 'census',
       subject: 'allied', subjectFilter: 'pawn',
       positionAxis: 'rank', positionComparator: 'greater_than', positionTarget: 4,
       operator: 'count', comparator: 'greater_than_or_equal_to',
@@ -139,7 +139,7 @@ describe('emitConstraintsFromPlan — position group', () => {
 
   it('emits both region and aggregate_value_range for position group value plans', () => {
     const combinedPlan = buildCombinedPlan([{
-      version: 2, kind: 'position',
+      version: 2, kind: 'census',
       subject: 'allied', subjectFilter: 'major',
       positionAxis: 'rank', positionComparator: 'greater_than', positionTarget: 4,
       operator: 'value', comparator: 'greater_than_or_equal_to',
@@ -375,10 +375,10 @@ describe('emitConstraintsFromPlan — relational with both group sides', () => {
   })
 })
 
-describe('emitConstraintsFromPlan — PBS unary', () => {
-  it('emits prior+current propositions and a crossFrame entry for unary count plans against prior_board_state', () => {
+describe('emitConstraintsFromPlan — PBS census', () => {
+  it('emits prior+current propositions and a crossFrame entry for census count plans against prior_board_state', () => {
     const combinedPlan = buildCombinedPlan([{
-      version: 2, kind: 'unary',
+      version: 2, kind: 'census',
       subject: 'allied', subjectFilter: 'pawn',
       operator: 'count', comparator: 'greater_than',
       target: 'prior_board_state'
@@ -401,7 +401,7 @@ describe('emitConstraintsFromPlan — PBS unary', () => {
 
     expect(crossFrame).toHaveLength(1)
     expect(crossFrame[0]).toEqual({
-      source: 'unary',
+      source: 'census',
       operator: 'count',
       metric: 'count',
       direction: '+',
@@ -412,7 +412,7 @@ describe('emitConstraintsFromPlan — PBS unary', () => {
 
   it('uses metric aggregate_value for unary value plans against prior_board_state', () => {
     const combinedPlan = buildCombinedPlan([{
-      version: 2, kind: 'unary',
+      version: 2, kind: 'census',
       subject: 'allied', subjectFilter: 'any',
       operator: 'value', comparator: 'less_than',
       target: 'prior_board_state'
@@ -427,7 +427,7 @@ describe('emitConstraintsFromPlan — PBS unary', () => {
 
   it('uses metric individual_value for singular-subject unary value plans against prior_board_state', () => {
     const combinedPlan = buildCombinedPlan([{
-      version: 2, kind: 'unary',
+      version: 2, kind: 'census',
       subject: 'moved_piece', subjectFilter: 'any',
       operator: 'value', comparator: 'greater_than',
       target: 'prior_board_state'
@@ -441,7 +441,7 @@ describe('emitConstraintsFromPlan — PBS unary', () => {
 
   it('uses metric aggregate_mobility for unary mobility plans against prior_board_state', () => {
     const combinedPlan = buildCombinedPlan([{
-      version: 2, kind: 'unary',
+      version: 2, kind: 'census',
       subject: 'allied', subjectFilter: 'bishop',
       operator: 'mobility', comparator: 'greater_than',
       target: 'prior_board_state'
@@ -516,23 +516,23 @@ describe('emitConstraintsFromPlan — PBS-direction relational descriptor', () =
 })
 
 describe('emitConstraintsFromPlan — crossFrame source field', () => {
-  it('tags crossFrame entries from unary PBS plans with source "unary"', () => {
+  it('tags crossFrame entries from census PBS plans with source "census"', () => {
     const combinedPlan = buildCombinedPlan([{
-      version: 2, kind: 'unary',
+      version: 2, kind: 'census',
       subject: 'enemy', subjectFilter: 'any',
       operator: 'count', comparator: 'less_than',
       target: 'prior_board_state'
     }])
 
     const { crossFrame } = emitConstraintsFromPlan(combinedPlan.plans[0])
-    expect(crossFrame[0].source).toBe('unary')
+    expect(crossFrame[0].source).toBe('census')
   })
 })
 
 describe('emitConstraintsFromPlan — crossFrame operator field', () => {
-  it('stores the unary operator on crossFrame entries for unary PBS plans', () => {
+  it('stores the census operator on crossFrame entries for census PBS plans', () => {
     const combinedPlan = buildCombinedPlan([{
-      version: 2, kind: 'unary',
+      version: 2, kind: 'census',
       subject: 'allied', subjectFilter: 'any',
       operator: 'value', comparator: 'less_than',
       target: 'prior_board_state'

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/scenarios/eligibility.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/scenarios/eligibility.test.js
@@ -5,14 +5,14 @@ import { kingsideCastleScenario } from 'editorV2/panels/condition_preview/forwar
 import { queensideCastleScenario } from 'editorV2/panels/condition_preview/forward_proposition/scenarios/queenside_castle'
 
 const TRIVIAL_PAYLOAD = {
-  version: 2, kind: 'unary',
+  version: 2, kind: 'census',
   subject: 'allied', subjectFilter: 'pawn',
   operator: 'count', comparator: 'greater_than_or_equal_to',
   target: 'exact_number', targetTotal: 0
 }
 
 const KNIGHT_MOVER_PAYLOAD = {
-  version: 2, kind: 'unary',
+  version: 2, kind: 'census',
   subject: 'moved_piece', subjectFilter: 'knight',
   operator: 'count', comparator: 'greater_than',
   target: 'exact_number', targetTotal: 0
@@ -33,7 +33,7 @@ describe('eligibleScenariosFor', () => {
 
   it('filters out a castle scenario when chain demands enough queens on the home rank to force overlap with the castle emptiness', () => {
     const plan = buildCombinedPlan([{
-      version: 2, kind: 'position',
+      version: 2, kind: 'census',
       subject: 'allied', subjectFilter: 'queen',
       positionAxis: 'rank', positionComparator: 'equal_to', positionTarget: 1,
       operator: 'count', comparator: 'greater_than_or_equal_to',

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/scenarios/en_passant_left.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/scenarios/en_passant_left.test.js
@@ -5,7 +5,7 @@ import { buildAttempt } from 'editorV2/panels/condition_preview/forward_proposit
 import { enPassantLeftScenario } from 'editorV2/panels/condition_preview/forward_proposition/scenarios/en_passant_left'
 
 const TRIVIAL_PAYLOAD = {
-  version: 2, kind: 'unary',
+  version: 2, kind: 'census',
   subject: 'allied', subjectFilter: 'pawn',
   operator: 'count', comparator: 'greater_than_or_equal_to',
   target: 'exact_number', targetTotal: 0

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/scenarios/en_passant_right.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/scenarios/en_passant_right.test.js
@@ -5,7 +5,7 @@ import { buildAttempt } from 'editorV2/panels/condition_preview/forward_proposit
 import { enPassantRightScenario } from 'editorV2/panels/condition_preview/forward_proposition/scenarios/en_passant_right'
 
 const TRIVIAL_PAYLOAD = {
-  version: 2, kind: 'unary',
+  version: 2, kind: 'census',
   subject: 'allied', subjectFilter: 'pawn',
   operator: 'count', comparator: 'greater_than_or_equal_to',
   target: 'exact_number', targetTotal: 0

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/scenarios/kingside_castle.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/scenarios/kingside_castle.test.js
@@ -10,7 +10,7 @@ const G1 = 6
 const H1 = 7
 
 const TRIVIAL_PAYLOAD = {
-  version: 2, kind: 'unary',
+  version: 2, kind: 'census',
   subject: 'allied', subjectFilter: 'pawn',
   operator: 'count', comparator: 'greater_than_or_equal_to',
   target: 'exact_number', targetTotal: 0

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/scenarios/promotion_capture_left.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/scenarios/promotion_capture_left.test.js
@@ -8,7 +8,7 @@ const PROMOTION_SPECIES = new Set([Board.QUEEN, Board.ROOK, Board.BISHOP, Board.
 const CAPTURABLE_NON_PAWN = new Set([Board.NIGHT, Board.BISHOP, Board.ROOK, Board.QUEEN])
 
 const TRIVIAL_PAYLOAD = {
-  version: 2, kind: 'unary',
+  version: 2, kind: 'census',
   subject: 'allied', subjectFilter: 'pawn',
   operator: 'count', comparator: 'greater_than_or_equal_to',
   target: 'exact_number', targetTotal: 0

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/scenarios/promotion_capture_right.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/scenarios/promotion_capture_right.test.js
@@ -8,7 +8,7 @@ const PROMOTION_SPECIES = new Set([Board.QUEEN, Board.ROOK, Board.BISHOP, Board.
 const CAPTURABLE_NON_PAWN = new Set([Board.NIGHT, Board.BISHOP, Board.ROOK, Board.QUEEN])
 
 const TRIVIAL_PAYLOAD = {
-  version: 2, kind: 'unary',
+  version: 2, kind: 'census',
   subject: 'allied', subjectFilter: 'pawn',
   operator: 'count', comparator: 'greater_than_or_equal_to',
   target: 'exact_number', targetTotal: 0

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/scenarios/promotion_push.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/scenarios/promotion_push.test.js
@@ -8,7 +8,7 @@ const PROMOTION_SPECIES = new Set([Board.QUEEN, Board.ROOK, Board.BISHOP, Board.
 const WHITE_LAST_RANK_SQUARES = new Set([56, 57, 58, 59, 60, 61, 62, 63])
 
 const TRIVIAL_PAYLOAD = {
-  version: 2, kind: 'unary',
+  version: 2, kind: 'census',
   subject: 'allied', subjectFilter: 'pawn',
   operator: 'count', comparator: 'greater_than_or_equal_to',
   target: 'exact_number', targetTotal: 0

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/scenarios/queenside_castle.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/scenarios/queenside_castle.test.js
@@ -10,7 +10,7 @@ const D1 = 3
 const E1 = 4
 
 const TRIVIAL_PAYLOAD = {
-  version: 2, kind: 'unary',
+  version: 2, kind: 'census',
   subject: 'allied', subjectFilter: 'pawn',
   operator: 'count', comparator: 'greater_than_or_equal_to',
   target: 'exact_number', targetTotal: 0

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/singulars.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/__tests__/singulars.test.js
@@ -5,7 +5,7 @@ import { qualifyingSquares } from 'editorV2/panels/condition_preview/shared/unar
 import { buildSingulars } from 'editorV2/panels/condition_preview/forward_proposition/singulars'
 
 const TRIVIAL_PLAN = {
-  version: 2, kind: 'unary',
+  version: 2, kind: 'census',
   subject: 'allied', subjectFilter: 'pawn',
   operator: 'count', comparator: 'greater_than_or_equal_to',
   target: 'exact_number', targetTotal: 1
@@ -65,7 +65,7 @@ describe('buildSingulars — initialization', () => {
 describe('buildSingulars — position plan narrowing', () => {
   it('narrows singular region to qualifying squares when count > 0 on a position plan', () => {
     const combinedPlan = buildCombinedPlan([{
-      version: 2, kind: 'position',
+      version: 2, kind: 'census',
       subject: 'moved_piece', subjectFilter: 'any',
       positionAxis: 'rank', positionComparator: 'greater_than', positionTarget: 4,
       operator: 'count', comparator: 'greater_than',
@@ -81,7 +81,7 @@ describe('buildSingulars — position plan narrowing', () => {
 
   it('also narrows species_set to subjectSpeciesPool when count > 0 on a position plan with a filter', () => {
     const combinedPlan = buildCombinedPlan([{
-      version: 2, kind: 'position',
+      version: 2, kind: 'census',
       subject: 'moved_piece', subjectFilter: 'major',
       positionAxis: 'rank', positionComparator: 'greater_than', positionTarget: 4,
       operator: 'count', comparator: 'greater_than',
@@ -94,7 +94,7 @@ describe('buildSingulars — position plan narrowing', () => {
 
   it('subtracts qualifying squares from singular region when count = 0 on a position plan', () => {
     const combinedPlan = buildCombinedPlan([{
-      version: 2, kind: 'position',
+      version: 2, kind: 'census',
       subject: 'moved_piece', subjectFilter: 'any',
       positionAxis: 'rank', positionComparator: 'greater_than', positionTarget: 4,
       operator: 'count', comparator: 'equal_to',
@@ -114,7 +114,7 @@ describe('buildSingulars — position plan narrowing', () => {
 describe('buildSingulars — unary plan narrowing', () => {
   it('intersects species_set with subjectSpeciesPool when count > 0 on a unary plan', () => {
     const combinedPlan = buildCombinedPlan([{
-      version: 2, kind: 'unary',
+      version: 2, kind: 'census',
       subject: 'moved_piece', subjectFilter: 'major',
       operator: 'count', comparator: 'greater_than',
       target: 'exact_number', targetTotal: 0
@@ -126,7 +126,7 @@ describe('buildSingulars — unary plan narrowing', () => {
 
   it('subtracts subjectSpeciesPool from species_set when count = 0 on a unary plan, preserving null for optional actors', () => {
     const combinedPlan = buildCombinedPlan([{
-      version: 2, kind: 'unary',
+      version: 2, kind: 'census',
       subject: 'captured_piece', subjectFilter: 'major',
       operator: 'count', comparator: 'equal_to',
       target: 'exact_number', targetTotal: 0
@@ -140,7 +140,7 @@ describe('buildSingulars — unary plan narrowing', () => {
 describe('buildSingulars — unary value narrowing on singular subject', () => {
   it('narrows species_set to species whose materialValue satisfies value > target', () => {
     const combinedPlan = buildCombinedPlan([{
-      version: 2, kind: 'unary',
+      version: 2, kind: 'census',
       subject: 'moved_piece', subjectFilter: 'any',
       operator: 'value', comparator: 'greater_than',
       target: 'exact_number', targetTotal: 5
@@ -152,7 +152,7 @@ describe('buildSingulars — unary value narrowing on singular subject', () => {
 
   it('narrows species_set to species whose materialValue satisfies value = target (exact match)', () => {
     const combinedPlan = buildCombinedPlan([{
-      version: 2, kind: 'unary',
+      version: 2, kind: 'census',
       subject: 'moved_piece', subjectFilter: 'any',
       operator: 'value', comparator: 'equal_to',
       target: 'exact_number', targetTotal: 3
@@ -164,7 +164,7 @@ describe('buildSingulars — unary value narrowing on singular subject', () => {
 
   it('respects subjectFilter (major) intersected with value predicate', () => {
     const combinedPlan = buildCombinedPlan([{
-      version: 2, kind: 'unary',
+      version: 2, kind: 'census',
       subject: 'moved_piece', subjectFilter: 'major',
       operator: 'value', comparator: 'greater_than',
       target: 'exact_number', targetTotal: 5
@@ -287,13 +287,13 @@ describe('buildSingulars — multi-plan accumulation', () => {
   it('intersects narrowings across multiple plans on the same singular', () => {
     const combinedPlan = buildCombinedPlan([
       {
-        version: 2, kind: 'unary',
+        version: 2, kind: 'census',
         subject: 'moved_piece', subjectFilter: 'major',
         operator: 'count', comparator: 'greater_than',
         target: 'exact_number', targetTotal: 0
       },
       {
-        version: 2, kind: 'unary',
+        version: 2, kind: 'census',
         subject: 'moved_piece', subjectFilter: 'queen',
         operator: 'count', comparator: 'greater_than',
         target: 'exact_number', targetTotal: 0

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/build_engine.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/build_engine.js
@@ -5,6 +5,7 @@ import { commitSingularsPosition } from './commit_singulars_position'
 import { earlyPlaceConstraintTargets } from './early_placement/place_constraint_targets'
 import { isSatisfiable } from './is_satisfiable'
 import { narrowForCrossFrame } from './narrow_for_crossframe'
+import { narrowMovedPieceForRegion } from './narrow_moved_piece_for_region'
 import { placeSingulars } from './place_singulars'
 import { satisfyPropositions } from './satisfy_propositions'
 import { satisfyRelations } from './relations/satisfy_relations'
@@ -24,6 +25,7 @@ export function buildAttempt(combinedPlan, random, scenario = standardScenario) 
   mergeCtxDelta(ctx, scenario.buildCtxDelta(combinedPlan))
   relaxStabilityPbsRelations(ctx, random)
   narrowForCrossFrame(ctx)
+  narrowMovedPieceForRegion(ctx)
   if (!isSatisfiable(ctx)) { return null }
 
   commitSingularsSpecies(ctx, random)

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/cross_frame/mechanisms/moved_piece_shifts_region_membership.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/cross_frame/mechanisms/moved_piece_shifts_region_membership.js
@@ -1,0 +1,62 @@
+import { singularSquare, commitPriorRegion } from './participates_helpers'
+import { legalOriginCandidates } from './shifts_mobility_helpers'
+
+// Engineers a region-restricted PBS count delta by choosing moved_piece's
+// origin so its own region-membership differs prior-vs-after. moved_piece is
+// the only subject piece whose region-membership can change across a single
+// move, so for source census/unary the delta is manufactured here rather
+// than left to luck. Direction:
+//   '+'  destination in-region, origin out-of-region  (prior count is one less)
+//   '-'  destination out-of-region, origin in-region  (prior count is one more)
+//   '='  origin and destination on the same side of the region boundary
+// The capture-in-region path (enemy subject decreasing) is a separate
+// mechanism — moved_piece cannot be an enemy subject.
+export const movedPieceShiftsRegionMembership = {
+  name: 'moved-piece-shifts-region-membership',
+
+  appliesTo(entry, ctx) {
+    if (entry.source !== 'census') { return false }
+    if (entry.metric !== 'count') { return false }
+    if (entry.currentProposition?.region?.kind !== 'set') { return false }
+    return movedMatchesSubject(entry, ctx)
+  },
+
+  apply(entry, ctx, pieces) {
+    const moved = ctx.singulars.moved_piece
+    const destination = singularSquare(moved)
+    if (destination === null) { return null }
+    const movedSpecies = [...moved.species_set][0]
+    if (movedSpecies === null || movedSpecies === undefined) { return null }
+
+    const region = entry.currentProposition.region.squares
+    const destInRegion = region.has(destination)
+    const origins = legalOriginCandidates(pieces, destination, moved.team, movedSpecies)
+
+    let candidates
+    if (entry.direction === '+') {
+      if (!destInRegion) { return null }
+      candidates = origins.filter(o => !region.has(o))
+    } else if (entry.direction === '-') {
+      if (destInRegion) { return null }
+      candidates = origins.filter(o => region.has(o))
+    } else if (entry.direction === '=') {
+      candidates = origins.filter(o => region.has(o) === destInRegion)
+    } else {
+      return null
+    }
+
+    if (candidates.length === 0) { return null }
+    return commitPriorRegion(ctx, candidates, pieces)
+  }
+}
+
+function movedMatchesSubject(entry, ctx) {
+  const moved = ctx?.singulars?.moved_piece
+  const prop = entry.currentProposition
+  if (!moved || !prop) { return false }
+  if (moved.team !== prop.team) { return false }
+  for (const species of moved.species_set) {
+    if (species !== null && prop.species_set.has(species)) { return true }
+  }
+  return false
+}

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/cross_frame/satisfy_cross_frame.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/cross_frame/satisfy_cross_frame.js
@@ -4,6 +4,7 @@ import {
 } from 'editorV2/panels/condition_preview/shared/board_utils'
 import { buildPriorBoard } from 'editorV2/panels/condition_preview/shared/example_utils'
 import { pieceControlsSquare } from 'gameplay/board_query_utils'
+import { singularPosition } from '../relations/relation_helpers'
 import { movedPieceParticipatesInAttackOrDefend } from './mechanisms/moved_piece_participates_in_attack_or_defend'
 import { movedPieceParticipatesAdjacent } from './mechanisms/moved_piece_participates_adjacent'
 import { movedPieceParticipatesShield } from './mechanisms/moved_piece_participates_shield'
@@ -14,8 +15,10 @@ import { movedPieceShiftsAlliedMobility } from './mechanisms/moved_piece_shifts_
 import { movedPieceShiftsEnemyKingMobility } from './mechanisms/moved_piece_shifts_enemy_king_mobility'
 import { movedPieceShiftsEnemyMobility } from './mechanisms/moved_piece_shifts_enemy_mobility'
 import { movedPieceCapturesRelationParticipant } from './mechanisms/moved_piece_captures_relation_participant'
+import { movedPieceShiftsRegionMembership } from './mechanisms/moved_piece_shifts_region_membership'
 
 const MECHANISMS = Object.freeze([
+  movedPieceShiftsRegionMembership,
   movedPieceParticipatesInAttackOrDefend,
   movedPieceParticipatesAdjacent,
   movedPieceParticipatesShield,
@@ -62,6 +65,11 @@ export function satisfyCrossFrame(ctx, pieces, random) {
 // aggregate_*) return true unconditionally so the first non-null mechanism
 // wins.
 function entrySatisfied(entry, ctx, afterPieces) {
+  if (entry.source === 'census' &&
+      entry.metric === 'count' &&
+      entry.currentProposition?.region?.kind === 'set') {
+    return regionCountDeltaSatisfied(entry, ctx, afterPieces)
+  }
   if (entry.metric !== 'count') { return true }
   if (entry.operator !== 'attack' && entry.operator !== 'defend') { return true }
 
@@ -86,6 +94,39 @@ function entrySatisfied(entry, ctx, afterPieces) {
   })
 
   return compareWithDirection(afterCount, priorCount, entry.direction)
+}
+
+function regionCountDeltaSatisfied(entry, ctx, afterPieces) {
+  const moved = ctx.singulars.moved_piece
+  const destination = singularSquare(moved)
+  if (destination === null) { return true }
+  const origin = firstSquareOf(moved.priorRegion)
+  if (origin === null) { return true }
+
+  const priorPieces = buildPriorBoard({
+    pieces: afterPieces, singulars: ctx.singulars, origin, endPos: destination,
+    capturedPiecePosition: singularPosition(ctx, 'captured_piece') ?? undefined
+  })
+  if (priorPieces === null) { return false }
+
+  // census PBS builds both frames from one identical sideShape, so
+  // currentProposition's team/species/region also describe the prior frame.
+  const prop = entry.currentProposition
+  const region = prop.region.squares
+  const after = countInRegion(prop, afterPieces, region)
+  const prior = countInRegion(prop, priorPieces, region)
+  return compareWithDirection(after, prior, entry.direction)
+}
+
+function countInRegion(proposition, pieces, region) {
+  let count = 0
+  for (const [pos, piece] of pieces) {
+    if (!region.has(pos)) { continue }
+    if (piece.charAt(0) !== proposition.team) { continue }
+    if (!proposition.species_set.has(piece.slice(1))) { continue }
+    count += 1
+  }
+  return count
 }
 
 function countParticipants({ proposition, pieces, movedPieceSquare }) {

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/narrow_for_crossframe.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/narrow_for_crossframe.js
@@ -1,30 +1,21 @@
-// Narrows ctx.singulars based on crossFrame entries whose shape implies a
-// capture is forced. Today that's only unary PBS on the enemy team with the
-// direction going down (count or aggregate_value) — enemy pieces or aggregate
-// value can only decrease across frames via capture, since the enemy doesn't
-// move during the moving team's turn. Relational, position, mobility, and
-// upward-direction entries don't force capture and are ignored here.
+// Enemy count/value can only decrease across frames via capture (the enemy
+// doesn't move on the moving team's turn), so a decreasing-enemy PBS entry
+// forces the captured piece's species.
 export function narrowForCrossFrame(ctx) {
   for (const entry of ctx.crossFrame ?? []) {
     if (!forcesCapture(entry, ctx)) { continue }
-    narrowCapturedPiece(ctx.singulars.captured_piece, entry.currentProposition.species_set)
+    const captured = ctx.singulars.captured_piece
+    const forced = entry.currentProposition.species_set
+    captured.species_set = new Set(
+      [...captured.species_set].filter(s => s !== null && forced.has(s))
+    )
   }
 }
 
 function forcesCapture(entry, ctx) {
-  if (entry.source !== 'unary') { return false }
+  if (entry.source !== 'census') { return false }
   if (entry.direction !== '-') { return false }
   if (entry.metric !== 'count' && entry.metric !== 'aggregate_value') { return false }
   if (entry.currentProposition.team !== ctx.enemyTeam) { return false }
   return true
-}
-
-function narrowCapturedPiece(captured, crossFrameSpecies) {
-  const next = new Set()
-  for (const species of captured.species_set) {
-    if (species === null) { continue }
-    if (!crossFrameSpecies.has(species)) { continue }
-    next.add(species)
-  }
-  captured.species_set = next
 }

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/narrow_moved_piece_for_region.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/narrow_moved_piece_for_region.js
@@ -1,0 +1,52 @@
+import Board from 'gameplay/board'
+import { relativeRank } from 'gameplay/board_query_utils'
+import { intersectRegions } from './region'
+
+// Region census is only satisfiable via moved_piece: entering the region as a
+// subject (+), or capturing an in-region enemy (-).
+export function narrowMovedPieceForRegion(ctx) {
+  const moved = ctx.singulars?.moved_piece
+  if (!moved) { return }
+  const captured = ctx.singulars?.captured_piece
+  for (const entry of ctx.crossFrame ?? []) {
+    if (entry.source !== 'census') { continue }
+    if (entry.metric !== 'count') { continue }
+    const prop = entry.currentProposition
+    if (prop?.region?.kind !== 'set') { continue }
+
+    if (entry.direction === '+' && moved.team === prop.team) {
+      moved.species_set = intersectSpecies(moved.species_set, prop.species_set)
+      moved.region = intersectRegions(moved.region, prop.region)
+    } else if (entry.direction === '-' && moved.team !== prop.team) {
+      moved.region = intersectRegions(moved.region, captureRegion(prop.region, moved, captured))
+    }
+  }
+}
+
+function captureRegion(region, moved, captured) {
+  const squares = new Set(region.squares)
+  if (epEligible(moved, captured)) {
+    const forward = moved.team === Board.BLACK ? 8 : -8
+    for (const sq of region.squares) {
+      if (relativeRank(sq, moved.team) !== 5) { continue }
+      const landing = sq + forward
+      if (landing >= 0 && landing <= 63) { squares.add(landing) }
+    }
+  }
+  return { kind: 'set', squares }
+}
+
+function epEligible(moved, captured) {
+  return Boolean(captured) &&
+    moved.species_set.has(Board.PAWN) &&
+    captured.species_set.has(Board.PAWN)
+}
+
+function intersectSpecies(a, b) {
+  const next = new Set()
+  for (const species of a) {
+    if (species === null) { continue }
+    if (b.has(species)) { next.add(species) }
+  }
+  return next
+}

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/propositions.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/propositions.js
@@ -272,7 +272,7 @@ function freshRanges() {
 }
 
 function regionFromPlan(plan) {
-  if (plan.kind === 'position') {
+  if (plan.positionAxis !== undefined && plan.positionAxis !== null) {
     return {
       kind: 'set',
       squares: new Set(qualifyingSquares(plan.positionAxis, plan.positionComparator, plan.positionTarget, plan.movingTeam))

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/singulars.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/singulars.js
@@ -69,9 +69,10 @@ function narrowSingulars(plan, singulars) {
     return
   }
   if (!SINGULAR_ACTORS.has(plan.subject)) { return }
-  if (plan.kind === 'position') {
+  if (plan.kind !== 'census') { return }
+  if (plan.positionAxis != null) {
     narrowSingularByPositionPlan(plan, singulars[plan.subject])
-  } else if (plan.kind === 'unary') {
+  } else {
     narrowSingularByUnaryPlan(plan, singulars[plan.subject])
     if (plan.operator === 'value' && SINGULAR_ACTORS.has(plan.target)) {
       recordSingularValueComparison({

--- a/app/javascript/editorV2/panels/condition_preview/forward_resolver/__tests__/chain_constraints.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_resolver/__tests__/chain_constraints.test.js
@@ -9,7 +9,10 @@ import { buildChainConstraints } from 'editorV2/panels/condition_preview/forward
 // team bucket; these tests prevent regression by inspecting the inventory
 // state directly after buildChainConstraints.
 
-describe('buildChainConstraints inventory bumps for captured-type subjects', () => {
+// Skipped: sunset subsystem; forward_resolver/chain_constraints.js was not
+// census-ified (still gates plan.kind === 'unary'/'position'), so this spec is
+// retired with the kind rather than rebaselined.
+describe.skip('buildChainConstraints inventory bumps for captured-type subjects', () => {
   it('routes captured_piece singular contribution into the enemyTeam inventory bucket', () => {
     const combinedPlan = buildCombinedPlan([
       {

--- a/app/javascript/editorV2/panels/condition_preview/plans/__tests__/generation_plan.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/plans/__tests__/generation_plan.test.js
@@ -9,7 +9,7 @@ describe('buildPlan team assignment for captured-type actors', () => {
   it('assigns subjectTeam = enemyTeam for captured_piece subject', () => {
     const plan = buildPlan(
       {
-        version: 2, kind: 'unary',
+        version: 2, kind: 'census',
         subject: 'captured_piece', subjectFilter: 'any',
         operator: 'count', comparator: 'equal_to',
         target: 'exact_number', targetTotal: 1
@@ -23,7 +23,7 @@ describe('buildPlan team assignment for captured-type actors', () => {
   it('assigns subjectTeam = movingTeam for enemy_captured_piece subject', () => {
     const plan = buildPlan(
       {
-        version: 2, kind: 'unary',
+        version: 2, kind: 'census',
         subject: 'enemy_captured_piece', subjectFilter: 'any',
         operator: 'count', comparator: 'equal_to',
         target: 'exact_number', targetTotal: 1
@@ -37,7 +37,7 @@ describe('buildPlan team assignment for captured-type actors', () => {
   it('assigns targetTeam = enemyTeam for captured_piece target', () => {
     const plan = buildPlan(
       {
-        version: 2, kind: 'unary',
+        version: 2, kind: 'census',
         subject: 'allied', subjectFilter: 'any',
         operator: 'value', comparator: 'greater_than',
         target: 'captured_piece', targetFilter: 'any'
@@ -51,7 +51,7 @@ describe('buildPlan team assignment for captured-type actors', () => {
   it('assigns targetTeam = movingTeam for enemy_captured_piece target', () => {
     const plan = buildPlan(
       {
-        version: 2, kind: 'unary',
+        version: 2, kind: 'census',
         subject: 'enemy', subjectFilter: 'any',
         operator: 'value', comparator: 'greater_than',
         target: 'enemy_captured_piece', targetFilter: 'any'

--- a/app/javascript/editorV2/panels/condition_preview/plans/generation_plan.js
+++ b/app/javascript/editorV2/panels/condition_preview/plans/generation_plan.js
@@ -342,5 +342,14 @@ export function buildPlan(payload, options = {}) {
 
   if (payload.kind === 'relational') { return buildRelationalPlan(payload, options, teams) }
   if (payload.kind === 'census') { return buildCensusPlan(payload, options, teams) }
+  if (payload.kind === 'identity') {
+    // Verification still runs the identity payload — CandidateVerifier reads
+    // evaluationPayloads, not this plan.
+    return buildRelationalPlan(
+      { ...payload, kind: 'relational', operator: 'same_piece', subjectFilter: 'any', targetFilter: 'any' },
+      options,
+      teams
+    )
+  }
   return { status: 'unsupported', reason: `${payload.kind} previews are not supported yet.` }
 }

--- a/app/javascript/editorV2/panels/condition_preview/plans/generation_plan.js
+++ b/app/javascript/editorV2/panels/condition_preview/plans/generation_plan.js
@@ -275,15 +275,23 @@ function singularActorValuePool(pool, comparator, total) {
   }
 }
 
-function buildUnaryPlan(payload, options = {}, teams = {}) {
-  if (!SUPPORTED_UNARY_ACTORS.has(payload.subject)) {
-    return { status: 'unsupported', reason: `${payload.subject} unary previews are not supported yet.` }
+const SUPPORTED_POSITION_SUBJECTS = new Set(['allied', 'enemy', 'moved_piece', 'enemy_moved_piece'])
+const SUPPORTED_POSITION_AXES = new Set(['rank', 'file', 'square'])
+
+function buildCensusPlan(payload, options = {}, teams = {}) {
+  const hasRegion = payload.positionAxis !== undefined && payload.positionAxis !== null
+  const supportedSubjects = hasRegion ? SUPPORTED_POSITION_SUBJECTS : SUPPORTED_UNARY_ACTORS
+  if (!supportedSubjects.has(payload.subject)) {
+    return { status: 'unsupported', reason: `${payload.subject} census previews are not supported yet.` }
   }
   if (!SUPPORTED_UNARY_OPERATORS.has(payload.operator)) {
-    return { status: 'unsupported', reason: `${payload.operator} unary previews are not supported yet.` }
+    return { status: 'unsupported', reason: `${payload.operator} census previews are not supported yet.` }
   }
   if (!SUPPORTED_UNARY_TARGETS.has(payload.target)) {
-    return { status: 'unsupported', reason: `${payload.target} unary target previews are not supported yet.` }
+    return { status: 'unsupported', reason: `${payload.target} census target previews are not supported yet.` }
+  }
+  if (hasRegion && !SUPPORTED_POSITION_AXES.has(payload.positionAxis)) {
+    return { status: 'unsupported', reason: `${payload.positionAxis} census axis is not supported yet.` }
   }
 
   const { movingTeam, enemyTeam } = teams
@@ -299,7 +307,7 @@ function buildUnaryPlan(payload, options = {}, teams = {}) {
   return {
     status: 'supported',
     reason: null,
-    kind: 'unary',
+    kind: 'census',
     evaluationPayload: payload,
     subject: payload.subject,
     subjectFilter: payload.subjectFilter || 'any',
@@ -310,55 +318,13 @@ function buildUnaryPlan(payload, options = {}, teams = {}) {
     targetTotal: payload.target === EXACT_NUMBER_COMPARISON_SOURCE ? (payload.targetTotal ?? 0) : null,
     targetFilter: payload.targetFilter || 'any',
     targetFilterMode: payload.targetFilterMode || null,
+    positionAxis: hasRegion ? payload.positionAxis : null,
+    positionComparator: hasRegion ? payload.positionComparator : null,
+    positionTarget: hasRegion ? payload.positionTarget : null,
     subjectSpeciesPool,
     targetSpeciesPool: targetIsActor ? candidateSpecies(payload.targetFilter || 'any', payload.targetFilterMode || null) : [],
     subjectTeam,
     targetTeam,
-    movingTeam,
-    enemyTeam,
-    moveKinds: [MOVE_KIND_STANDARD, MOVE_KIND_CASTLE, MOVE_KIND_PROMOTION, MOVE_KIND_EN_PASSANT]
-  }
-}
-
-const SUPPORTED_POSITION_SUBJECTS = new Set(['allied', 'enemy', 'moved_piece', 'enemy_moved_piece'])
-const SUPPORTED_POSITION_OPERATORS = new Set(['count', 'value', 'mobility'])
-const SUPPORTED_POSITION_AXES = new Set(['rank', 'file', 'square'])
-
-function buildPositionPlan(payload, options = {}, teams = {}) {
-  if (!SUPPORTED_POSITION_SUBJECTS.has(payload.subject)) {
-    return { status: 'unsupported', reason: `${payload.subject} position previews are not supported yet.` }
-  }
-  if (!SUPPORTED_POSITION_OPERATORS.has(payload.operator)) {
-    return { status: 'unsupported', reason: `${payload.operator} position previews are not supported yet.` }
-  }
-  if (!SUPPORTED_POSITION_AXES.has(payload.positionAxis)) {
-    return { status: 'unsupported', reason: `${payload.positionAxis} position axis is not supported yet.` }
-  }
-
-  const { movingTeam, enemyTeam } = teams
-  const subjectTeam = actorTeam(payload.subject, movingTeam)
-
-  return {
-    status: 'supported',
-    reason: null,
-    kind: 'position',
-    evaluationPayload: payload,
-    subject: payload.subject,
-    subjectFilter: payload.subjectFilter || 'any',
-    subjectFilterMode: payload.subjectFilterMode || null,
-    // target is part of the polymorphic plan contract; position plans have no
-    // target actor concept, so it's null. Readers comparing plan.target to an
-    // actor name agnostically read false. Sub-fields (targetTeam, etc.) stay
-    // kind-specific — only access after confirming plan.target is a real actor.
-    target: null,
-    positionAxis: payload.positionAxis,
-    positionComparator: payload.positionComparator,
-    positionTarget: payload.positionTarget,
-    operator: payload.operator,
-    comparator: payload.comparator,
-    targetTotal: payload.targetTotal ?? 0,
-    subjectSpeciesPool: candidateSpecies(payload.subjectFilter || 'any', payload.subjectFilterMode || null),
-    subjectTeam,
     movingTeam,
     enemyTeam,
     moveKinds: [MOVE_KIND_STANDARD, MOVE_KIND_CASTLE, MOVE_KIND_PROMOTION, MOVE_KIND_EN_PASSANT]
@@ -374,8 +340,7 @@ export function buildPlan(payload, options = {}) {
   const enemyTeam = Board.opposingTeam(movingTeam)
   const teams = { movingTeam, enemyTeam }
 
-  if (payload.kind === 'unary') { return buildUnaryPlan(payload, options, teams) }
   if (payload.kind === 'relational') { return buildRelationalPlan(payload, options, teams) }
-  if (payload.kind === 'position') { return buildPositionPlan(payload, options, teams) }
+  if (payload.kind === 'census') { return buildCensusPlan(payload, options, teams) }
   return { status: 'unsupported', reason: `${payload.kind} previews are not supported yet.` }
 }

--- a/app/javascript/editorV2/panels/condition_preview/plans/plan.js
+++ b/app/javascript/editorV2/panels/condition_preview/plans/plan.js
@@ -132,7 +132,7 @@ function extractMovedPieceSpeciesPool(plans) {
 function positionRequirementsFromPlans(plans) {
   return plans
     .filter(plan => (
-      plan.kind === 'position' &&
+      plan.kind === 'census' &&
       plan.positionAxis === 'square' &&
       plan.positionComparator === 'equal_to' &&
       plan.subjectFilter !== 'any'
@@ -243,7 +243,7 @@ function rankSatisfiesComparator(rank, comparator, target) {
 
 function detectImpossiblePawnPosition({ plans }) {
   for (const plan of plans) {
-    if (plan.kind !== 'position') { continue }
+    if (plan.kind !== 'census') { continue }
     if (plan.subjectFilter !== 'pawn') { continue }
     if (plan.positionAxis !== 'rank') { continue }
     const matching = ALL_RELATIVE_RANKS.filter(r =>
@@ -278,7 +278,7 @@ function detectSingularActorWithAggregateValue({ plans }) {
 
 function detectSingularActorWithImpossibleUnaryCount({ plans }) {
   for (const plan of plans) {
-    if (plan.kind !== 'unary') { continue }
+    if (plan.kind !== 'census') { continue }
     if (!SINGULAR_ACTORS.has(plan.subject)) { continue }
     if (plan.operator !== 'count') { continue }
     if (plan.target !== 'exact_number') { continue }
@@ -296,9 +296,11 @@ function detectSingularActorWithImpossibleUnaryCount({ plans }) {
 
 function detectMovedPieceWithCountZero({ plans }) {
   for (const plan of plans) {
-    if (plan.kind !== 'unary') { continue }
+    if (plan.kind !== 'census') { continue }
     if (plan.subject !== 'moved_piece') { continue }
     if (plan.operator !== 'count') { continue }
+    // Region-restricted census moved_piece count = 0 is satisfiable (piece exists outside the region)
+    if (plan.positionAxis != null) { continue }
     if (plan.target !== 'exact_number') { continue }
     const total = Number(plan.targetTotal ?? 0)
     const requiresZero =

--- a/app/javascript/editorV2/utils/conditionPreviewFormatter.js
+++ b/app/javascript/editorV2/utils/conditionPreviewFormatter.js
@@ -195,12 +195,26 @@ function positionAxisPreview(axis, comparator, positionTarget) {
 }
 
 export function formatConditionPreview(nodeData = {}) {
-  if (nodeData.kind === 'position') {
-    const preview = {
-      left: subjectPreview(nodeData.subject, nodeData.subjectFilter || 'any', nodeData.subjectFilterMode || 'include'),
-      operator: positionAxisPreview(nodeData.positionAxis, nodeData.positionComparator, nodeData.positionTarget),
-      right: `${operatorLabel(nodeData.operator)} ${comparatorLabel(nodeData.comparator)} ${nodeData.targetTotal}`
-    }
+  if (nodeData.kind === 'census') {
+    const hasRegion = nodeData.positionAxis !== undefined && nodeData.positionAxis !== null
+    const left = subjectPreview(nodeData.subject, nodeData.subjectFilter || 'any', nodeData.subjectFilterMode || 'include')
+    const preview = hasRegion
+      ? {
+          left,
+          operator: positionAxisPreview(nodeData.positionAxis, nodeData.positionComparator, nodeData.positionTarget),
+          right: `${operatorLabel(nodeData.operator)} ${comparatorLabel(nodeData.comparator)} ${nodeData.targetTotal}`
+        }
+      : {
+          left,
+          operator: operatorLabel(nodeData.operator),
+          right: unaryTargetComparisonPreview({
+            comparator: nodeData.comparator,
+            target: nodeData.target,
+            targetFilter: nodeData.targetFilter,
+            targetFilterMode: nodeData.targetFilterMode,
+            targetTotal: nodeData.targetTotal
+          })
+        }
     preview.text = previewText(preview)
     return preview
   }

--- a/app/javascript/editorV2/utils/conditionPreviewFormatter.js
+++ b/app/javascript/editorV2/utils/conditionPreviewFormatter.js
@@ -219,6 +219,16 @@ export function formatConditionPreview(nodeData = {}) {
     return preview
   }
 
+  if (nodeData.kind === 'identity') {
+    const preview = {
+      left: subjectPreview(nodeData.subject, 'any', 'include'),
+      operator: operatorPreviewText('same_piece'),
+      right: subjectPreview(nodeData.target, 'any', 'include')
+    }
+    preview.text = previewText(preview)
+    return preview
+  }
+
   if (nodeData.kind === 'relational') {
     const preview = {
       left: sidePreview({

--- a/app/javascript/editorV2/utils/conditionPreviewFormatter.js
+++ b/app/javascript/editorV2/utils/conditionPreviewFormatter.js
@@ -172,6 +172,10 @@ function unaryTargetComparisonPreview({ comparator, target, targetFilter, target
   return `${comparatorLabel(comparator)} ${unaryTargetPreview({ target, targetFilter, targetFilterMode, targetTotal })}`
 }
 
+function metricPreview({ operator, comparator, targetTotal }) {
+  return `${operatorLabel(operator)} ${comparatorLabel(comparator)} ${targetTotal}`
+}
+
 function previewText({ left, operator, right }) {
   return `${left} : ${operator} : ${right}`
 }
@@ -194,78 +198,51 @@ function positionAxisPreview(axis, comparator, positionTarget) {
   return axis
 }
 
+let cachedSpecText
+let cachedSpec
+
+function sentenceSpec() {
+  const element = typeof document !== 'undefined' ? document.getElementById('condition-sentence-spec') : null
+  const text = element && element.textContent
+  if (!text || !text.trim()) {
+    throw new Error('#condition-sentence-spec not found — render the shared/condition_sentence_spec partial')
+  }
+  if (text !== cachedSpecText) {
+    cachedSpec = JSON.parse(text)
+    cachedSpecText = text
+  }
+  return cachedSpec
+}
+
+function snakeToCamel(key) {
+  return key.replace(/_([a-z])/g, (_, character) => character.toUpperCase())
+}
+
+function buildSentenceChunk(descriptor, payload) {
+  const chunk = { role: descriptor.role }
+  for (const [chunkKey, payloadKey] of Object.entries(descriptor.fields || {})) {
+    chunk[snakeToCamel(chunkKey)] = payload[payloadKey]
+  }
+  for (const [chunkKey, value] of Object.entries(descriptor.consts || {})) {
+    chunk[snakeToCamel(chunkKey)] = value
+  }
+  return chunk
+}
+
+function sentenceDescriptors(spec, payload) {
+  if (Array.isArray(spec)) { return spec }
+  // Mirrors NodePresenter: positionAxis presence picks region vs whole.
+  return payload.positionAxis != null ? spec.region : spec.whole
+}
+
 export function formatConditionPreview(nodeData = {}) {
-  if (nodeData.kind === 'census') {
-    const hasRegion = nodeData.positionAxis !== undefined && nodeData.positionAxis !== null
-    const left = subjectPreview(nodeData.subject, nodeData.subjectFilter || 'any', nodeData.subjectFilterMode || 'include')
-    const preview = hasRegion
-      ? {
-          left,
-          operator: positionAxisPreview(nodeData.positionAxis, nodeData.positionComparator, nodeData.positionTarget),
-          right: `${operatorLabel(nodeData.operator)} ${comparatorLabel(nodeData.comparator)} ${nodeData.targetTotal}`
-        }
-      : {
-          left,
-          operator: operatorLabel(nodeData.operator),
-          right: unaryTargetComparisonPreview({
-            comparator: nodeData.comparator,
-            target: nodeData.target,
-            targetFilter: nodeData.targetFilter,
-            targetFilterMode: nodeData.targetFilterMode,
-            targetTotal: nodeData.targetTotal
-          })
-        }
-    preview.text = previewText(preview)
-    return preview
+  const spec = sentenceSpec()[nodeData.kind]
+  if (!spec) {
+    return { left: '', operator: '', right: '', text: '[invalid condition]' }
   }
-
-  if (nodeData.kind === 'identity') {
-    const preview = {
-      left: subjectPreview(nodeData.subject, 'any', 'include'),
-      operator: operatorPreviewText('same_piece'),
-      right: subjectPreview(nodeData.target, 'any', 'include')
-    }
-    preview.text = previewText(preview)
-    return preview
-  }
-
-  if (nodeData.kind === 'relational') {
-    const preview = {
-      left: sidePreview({
-        subject: nodeData.subject,
-        filter: nodeData.subjectFilter || 'any',
-        filterMode: nodeData.subjectFilterMode || 'include',
-        comparisonMetric: nodeData.subjectComparisonMetric,
-        comparator: nodeData.subjectComparator,
-        comparisonSource: nodeData.subjectComparisonSource,
-        comparisonSourceTotal: nodeData.subjectComparisonSourceTotal
-      }),
-      operator: operatorPreviewText(nodeData.operator),
-      right: sidePreview({
-        subject: nodeData.target,
-        filter: nodeData.targetFilter || 'any',
-        filterMode: nodeData.targetFilterMode || 'include',
-        comparisonMetric: nodeData.targetComparisonMetric,
-        comparator: nodeData.targetComparator,
-        comparisonSource: nodeData.targetComparisonSource,
-        comparisonSourceTotal: nodeData.targetComparisonSourceTotal
-      })
-    }
-    preview.text = previewText(preview)
-    return preview
-  }
-
-  const preview = {
-    left: subjectPreview(nodeData.subject, nodeData.subjectFilter || 'any', nodeData.subjectFilterMode || 'include'),
-    operator: operatorLabel(nodeData.operator),
-    right: unaryTargetComparisonPreview({
-      comparator: nodeData.comparator,
-      target: nodeData.target,
-      targetFilter: nodeData.targetFilter,
-      targetFilterMode: nodeData.targetFilterMode,
-      targetTotal: nodeData.targetTotal
-    })
-  }
+  const [left, operator, right] = sentenceDescriptors(spec, nodeData)
+    .map(descriptor => formatConditionPreviewChunk(buildSentenceChunk(descriptor, nodeData)))
+  const preview = { left, operator, right }
   preview.text = previewText(preview)
   return preview
 }
@@ -273,11 +250,15 @@ export function formatConditionPreview(nodeData = {}) {
 export function formatConditionPreviewChunk(chunk) {
   switch (chunk.role) {
     case 'side':
-      return sidePreview(chunk)
+      return sidePreview({ ...chunk, filter: chunk.filter || 'any', filterMode: chunk.filterMode || 'include' })
     case 'operator':
       return operatorPreviewText(chunk.operator)
     case 'comparison':
       return unaryTargetComparisonPreview(chunk)
+    case 'region':
+      return positionAxisPreview(chunk.positionAxis, chunk.positionComparator, chunk.positionTarget)
+    case 'metric':
+      return metricPreview(chunk)
     default:
       return chunk.text || ''
   }
@@ -299,6 +280,11 @@ function parseChunkDataset(element) {
     targetFilterMode: dataset.conditionPreviewTargetFilterMode,
     targetTotal: dataset.conditionPreviewTargetTotal,
     operator: dataset.conditionPreviewOperator,
+    positionAxis: dataset.conditionPreviewPositionAxis,
+    positionComparator: dataset.conditionPreviewPositionComparator,
+    positionTarget: dataset.conditionPreviewPositionTarget === undefined
+      ? undefined
+      : Number(dataset.conditionPreviewPositionTarget),
     text: element.textContent
   }
 }

--- a/app/javascript/gameplay/benchmarks/forward_proposition_benchmark.js
+++ b/app/javascript/gameplay/benchmarks/forward_proposition_benchmark.js
@@ -109,9 +109,10 @@ const PAYLOADS = [
     }
   },
   {
+    // Baseline 2026-05-16 (post kind-retirement, now census): ~46% verified.
     name: "rook mobility < 5 (mobility-constrained)",
     payload: {
-      version: 2, kind: "unary",
+      version: 2, kind: "census",
       subject: "allied", subjectFilter: "rook",
       operator: "mobility", comparator: "less_than",
       target: "exact_number", targetTotal: 5
@@ -121,9 +122,10 @@ const PAYLOADS = [
     // Adversarial: allied bishop at h1 conflicts unconditionally with
     // kingside castle's rookStart empty constraint. Every castle attempt
     // should be detectable as wasted.
+    // Baseline 2026-05-16 (post kind-retirement, now census): ~77% verified.
     name: "allied bishop at h1 (conflicts with kingside castle)",
     payload: {
-      version: 2, kind: "position",
+      version: 2, kind: "census",
       subject: "allied", subjectFilter: "bishop",
       positionAxis: "square", positionComparator: "equal_to", positionTarget: 7,
       operator: "count", comparator: "greater_than",
@@ -134,13 +136,41 @@ const PAYLOADS = [
     // Adversarial: allied pawn at e5 conflicts with EP-left only when
     // moved_piece commits to d6 (diag-left-origin lands on e5). Other
     // EP destinations are fine. "Sometimes blocks."
+    // Baseline 2026-05-16 (post kind-retirement, now census): ~81% verified.
     name: "allied pawn at e5 (sometimes blocks en passant)",
     payload: {
-      version: 2, kind: "position",
+      version: 2, kind: "census",
       subject: "allied", subjectFilter: "pawn",
       positionAxis: "square", positionComparator: "equal_to", positionTarget: 36,
       operator: "count", comparator: "greater_than",
       target: "exact_number", targetTotal: 0
+    }
+  },
+  {
+    // Region-restricted PBS census, increasing. Rook chosen so the rank
+    // delta can't arise by luck (a rook may stay on its rank).
+    // Baseline 2026-05-16: 0.4% pre-mechanism (luck) -> 80.9% engineered
+    // (moved_piece species+region narrowing + swing mechanism).
+    name: "census rook count rank=5 > PBS (region, increasing)",
+    payload: {
+      version: 2, kind: "census",
+      subject: "allied", subjectFilter: "rook", subjectFilterMode: "include",
+      positionAxis: "rank", positionComparator: "equal_to", positionTarget: 5,
+      operator: "count", comparator: "greater_than",
+      target: "prior_board_state"
+    }
+  },
+  {
+    // Region-restricted PBS census, decreasing (capture-in-region path).
+    // Baseline 2026-05-16: 9.2% luck -> 76.5% engineered
+    // (moved_piece region narrowing to the capture region + en passant).
+    name: "census enemy count file=4 < PBS (region, decreasing)",
+    payload: {
+      version: 2, kind: "census",
+      subject: "enemy", subjectFilter: "any",
+      positionAxis: "file", positionComparator: "equal_to", positionTarget: 4,
+      operator: "count", comparator: "less_than",
+      target: "prior_board_state"
     }
   }
 ]

--- a/app/javascript/vitest.setup.js
+++ b/app/javascript/vitest.setup.js
@@ -1,0 +1,53 @@
+import { beforeEach } from 'vitest'
+
+// Test-scoped mirror of NodePresenter::SENTENCE_SPEC. In production the spec is
+// served by the shared/_condition_sentence_spec partial; tests inject it so the
+// real DOM-read path in conditionPreviewFormatter runs (B: no production
+// fallback). Keep in sync with NodePresenter::SENTENCE_SPEC — node_presenter_spec
+// independently locks the Ruby side; the chunk roles/fields are the contract.
+const SENTENCE_SPEC = {
+  relational: [
+    { role: 'side', fields: {
+      subject: 'subject', filter: 'subjectFilter', filter_mode: 'subjectFilterMode',
+      comparison_metric: 'subjectComparisonMetric', comparator: 'subjectComparator',
+      comparison_source: 'subjectComparisonSource', comparison_source_total: 'subjectComparisonSourceTotal' } },
+    { role: 'operator', fields: { operator: 'operator' } },
+    { role: 'side', fields: {
+      subject: 'target', filter: 'targetFilter', filter_mode: 'targetFilterMode',
+      comparison_metric: 'targetComparisonMetric', comparator: 'targetComparator',
+      comparison_source: 'targetComparisonSource', comparison_source_total: 'targetComparisonSourceTotal' } }
+  ],
+  identity: [
+    { role: 'side', fields: { subject: 'subject' }, consts: { filter: 'any' } },
+    { role: 'operator', consts: { operator: 'same_piece' } },
+    { role: 'side', fields: { subject: 'target' }, consts: { filter: 'any' } }
+  ],
+  census: {
+    variant_by: 'position_axis_present',
+    whole: [
+      { role: 'side', fields: { subject: 'subject', filter: 'subjectFilter', filter_mode: 'subjectFilterMode' } },
+      { role: 'operator', fields: { operator: 'operator' } },
+      { role: 'comparison', fields: {
+        comparator: 'comparator', target: 'target', target_filter: 'targetFilter',
+        target_filter_mode: 'targetFilterMode', target_total: 'targetTotal' } }
+    ],
+    region: [
+      { role: 'side', fields: { subject: 'subject', filter: 'subjectFilter', filter_mode: 'subjectFilterMode' } },
+      { role: 'region', fields: {
+        position_axis: 'positionAxis', position_comparator: 'positionComparator',
+        position_target: 'positionTarget' } },
+      { role: 'metric', fields: { operator: 'operator', comparator: 'comparator', target_total: 'targetTotal' } }
+    ]
+  }
+}
+
+beforeEach(() => {
+  let element = document.getElementById('condition-sentence-spec')
+  if (!element) {
+    element = document.createElement('script')
+    element.type = 'application/json'
+    element.id = 'condition-sentence-spec'
+    document.head.appendChild(element)
+  }
+  element.textContent = JSON.stringify(SENTENCE_SPEC)
+})

--- a/app/models/node_grammar_rules.rb
+++ b/app/models/node_grammar_rules.rb
@@ -54,6 +54,7 @@ class NodeGrammarRules
 
   COMPARISON_SOURCES_BY_METRIC = {
     'count' => %w[exact_number prior_board_state],
+    'value' => NodeGrammarV2::COMPARISON_SOURCES,
     'individual_value' => NodeGrammarV2::COMPARISON_SOURCES
   }.freeze
 
@@ -113,6 +114,10 @@ class NodeGrammarRules
       POSITION_OPERATORS_BY_SUBJECT.fetch(subject, []).include?(operator)
     end
 
+    def valid_identity_pair?(subject:, target:)
+      SAME_PIECE_TARGETS.fetch(subject, []).include?(target)
+    end
+
     def editor_config
       {
         'editorSubjects' => NodeGrammarV2::EDITOR_SUBJECTS,
@@ -122,7 +127,14 @@ class NodeGrammarRules
         'samePieceTargets' => SAME_PIECE_TARGETS,
         'teamSubjectGroups' => TEAM_SUBJECT_GROUPS,
         'opposingTeamGroups' => OPPOSING_TEAM_GROUPS,
-        'positionSubjects' => NodeGrammarV2::POSITION_SUBJECTS
+        'positionSubjects' => NodeGrammarV2::POSITION_SUBJECTS,
+        'census' => {
+          'regionSubjects' => NodeGrammarV2::POSITION_SUBJECTS,
+          'wholeBoardSubjects' => NodeGrammarV2::EDITOR_SUBJECTS,
+          'operators' => NodeGrammarV2::POSITION_OPERATORS,
+          'axes' => NodeGrammarV2::POSITION_AXES,
+          'wholeBoardTargets' => NodeGrammarV2::UNARY_TARGETS
+        }
       }
     end
 

--- a/app/models/node_grammar_rules.rb
+++ b/app/models/node_grammar_rules.rb
@@ -84,22 +84,14 @@ class NodeGrammarRules
       return false unless NodeGrammarV2.valid_subject?(subject)
       return false unless NodeGrammarV2.valid_relational_operator?(operator)
 
-      if operator == 'same_piece'
-        SAME_PIECE_TARGETS.key?(subject)
-      else
-        REGULAR_RELATIONAL_SUBJECTS.include?(subject)
-      end
+      REGULAR_RELATIONAL_SUBJECTS.include?(subject)
     end
 
     def valid_relational_target_for?(subject:, operator:, target:)
       return false unless NodeGrammarV2.valid_subject?(target)
       return false unless valid_relational_operator_for_subject?(subject:, operator:)
 
-      if operator == 'same_piece'
-        SAME_PIECE_TARGETS.fetch(subject, []).include?(target)
-      else
-        regular_relational_targets_for(subject:, operator:).include?(target)
-      end
+      regular_relational_targets_for(subject:, operator:).include?(target)
     end
 
     def regular_relational_targets_for(subject:, operator:)
@@ -136,10 +128,6 @@ class NodeGrammarRules
           'wholeBoardTargets' => NodeGrammarV2::UNARY_TARGETS
         }
       }
-    end
-
-    def comparison_allowed_for_relational_operator?(operator)
-      NodeGrammarV2::RELATIONAL_OPERATORS.include?(operator)
     end
 
     def comparison_sources_for_metric(metric)

--- a/app/models/node_grammar_v2.rb
+++ b/app/models/node_grammar_v2.rb
@@ -15,8 +15,6 @@
     FILTER_MODES = %w[include exclude].freeze
 
     RELATIONAL_OPERATORS = %w[attack defend cover shield adjacent].freeze
-    SPECIAL_TARGETED_OPERATORS = %w[same_piece].freeze
-    ALL_RELATIONAL_OPERATORS = (RELATIONAL_OPERATORS + SPECIAL_TARGETED_OPERATORS).freeze
 
     UNARY_OPERATORS = %w[count mobility value].freeze
     SPECIAL_UNARY_TARGETS = %w[exact_number prior_board_state].freeze
@@ -49,7 +47,7 @@
       end
 
       def valid_relational_operator?(operator)
-        ALL_RELATIONAL_OPERATORS.include?(operator)
+        RELATIONAL_OPERATORS.include?(operator)
       end
 
       def valid_comparison_metric?(value)

--- a/app/models/node_grammar_v2.rb
+++ b/app/models/node_grammar_v2.rb
@@ -25,6 +25,7 @@
     POSITION_SUBJECTS = %w[allied enemy moved_piece enemy_moved_piece].freeze
     POSITION_OPERATORS = %w[count mobility value].freeze
     POSITION_AXES = %w[rank file square].freeze
+    OFF_BOARD_SUBJECTS = %w[captured_piece enemy_captured_piece].freeze
     POSITION_MOBILITY_SUBJECTS = %w[allied enemy moved_piece enemy_moved_piece].freeze
 
     COMPARISON_METRICS = %w[count individual_value].freeze

--- a/app/models/nodes/data_normalizer.rb
+++ b/app/models/nodes/data_normalizer.rb
@@ -57,37 +57,22 @@ module Nodes
       if kind == 'relational'
         normalized.delete('comparator')
         normalized.delete('targetTotal')
-        unless NodeGrammarRules.comparison_allowed_for_relational_operator?(normalized['operator'])
+        unless normalized['subjectComparisonMetric'].present?
           normalized.delete('subjectComparisonMetric')
           normalized.delete('subjectComparator')
           normalized.delete('subjectComparisonSource')
           normalized.delete('subjectComparisonSourceTotal')
+        else
+          normalize_relational_comparison_source_shape!(normalized, 'subject')
+        end
+
+        unless normalized['targetComparisonMetric'].present?
           normalized.delete('targetComparisonMetric')
           normalized.delete('targetComparator')
           normalized.delete('targetComparisonSource')
           normalized.delete('targetComparisonSourceTotal')
-          normalized['subjectFilter'] = 'any'
-          normalized.delete('subjectFilterMode')
-          normalized['targetFilter'] = 'any'
-          normalized.delete('targetFilterMode')
         else
-          unless normalized['subjectComparisonMetric'].present?
-            normalized.delete('subjectComparisonMetric')
-            normalized.delete('subjectComparator')
-            normalized.delete('subjectComparisonSource')
-            normalized.delete('subjectComparisonSourceTotal')
-          else
-            normalize_relational_comparison_source_shape!(normalized, 'subject')
-          end
-
-          unless normalized['targetComparisonMetric'].present?
-            normalized.delete('targetComparisonMetric')
-            normalized.delete('targetComparator')
-            normalized.delete('targetComparisonSource')
-            normalized.delete('targetComparisonSourceTotal')
-          else
-            normalize_relational_comparison_source_shape!(normalized, 'target')
-          end
+          normalize_relational_comparison_source_shape!(normalized, 'target')
         end
       elsif kind == 'census'
         normalized['target'] = 'exact_number' if normalized['target'].blank?

--- a/app/models/nodes/data_normalizer.rb
+++ b/app/models/nodes/data_normalizer.rb
@@ -54,32 +54,7 @@ module Nodes
       if %w[any].include?(normalized['targetFilter'])
         normalized.delete('targetFilterMode')
       end
-      if kind == 'unary'
-        normalized.delete('subjectComparisonMetric')
-        normalized.delete('subjectComparator')
-        normalized.delete('subjectComparisonSource')
-        normalized.delete('subjectComparisonSourceTotal')
-        normalized.delete('targetComparisonMetric')
-        normalized.delete('targetComparator')
-        normalized.delete('targetComparisonSource')
-        normalized.delete('targetComparisonSourceTotal')
-        normalize_unary_target!(normalized)
-      elsif kind == 'position'
-        normalized.delete('target')
-        normalized.delete('targetFilter')
-        normalized.delete('targetFilterMode')
-        normalized.delete('subjectComparisonMetric')
-        normalized.delete('subjectComparator')
-        normalized.delete('subjectComparisonSource')
-        normalized.delete('subjectComparisonSourceTotal')
-        normalized.delete('targetComparisonMetric')
-        normalized.delete('targetComparator')
-        normalized.delete('targetComparisonSource')
-        normalized.delete('targetComparisonSourceTotal')
-        if normalized['positionAxis'] == 'square'
-          normalized['positionComparator'] = 'equal_to'
-        end
-      elsif kind == 'relational'
+      if kind == 'relational'
         normalized.delete('comparator')
         normalized.delete('targetTotal')
         unless NodeGrammarRules.comparison_allowed_for_relational_operator?(normalized['operator'])
@@ -114,6 +89,28 @@ module Nodes
             normalize_relational_comparison_source_shape!(normalized, 'target')
           end
         end
+      elsif kind == 'census'
+        normalized['target'] = 'exact_number' if normalized['target'].blank?
+        normalized.delete('subjectComparisonMetric')
+        normalized.delete('subjectComparator')
+        normalized.delete('subjectComparisonSource')
+        normalized.delete('subjectComparisonSourceTotal')
+        normalized.delete('targetComparisonMetric')
+        normalized.delete('targetComparator')
+        normalized.delete('targetComparisonSource')
+        normalized.delete('targetComparisonSourceTotal')
+        normalize_unary_target!(normalized)
+        if normalized['positionAxis'] == 'square'
+          normalized['positionComparator'] = 'equal_to'
+        end
+      elsif kind == 'identity'
+        %w[
+          subjectFilter subjectFilterMode targetFilter targetFilterMode
+          operator comparator targetTotal
+          positionAxis positionComparator positionTarget
+          subjectComparisonMetric subjectComparator subjectComparisonSource subjectComparisonSourceTotal
+          targetComparisonMetric targetComparator targetComparisonSource targetComparisonSourceTotal
+        ].each { |key| normalized.delete(key) }
       end
     end
 

--- a/app/models/nodes/data_normalizer.rb
+++ b/app/models/nodes/data_normalizer.rb
@@ -89,13 +89,7 @@ module Nodes
           normalized['positionComparator'] = 'equal_to'
         end
       elsif kind == 'identity'
-        %w[
-          subjectFilter subjectFilterMode targetFilter targetFilterMode
-          operator comparator targetTotal
-          positionAxis positionComparator positionTarget
-          subjectComparisonMetric subjectComparator subjectComparisonSource subjectComparisonSourceTotal
-          targetComparisonMetric targetComparator targetComparisonSource targetComparisonSourceTotal
-        ].each { |key| normalized.delete(key) }
+        normalized.slice!(*Nodes::DataValidator::CONDITION_V2_IDENTITY_KEYS)
       end
     end
 

--- a/app/models/nodes/data_validator.rb
+++ b/app/models/nodes/data_validator.rb
@@ -76,10 +76,6 @@ module Nodes
       record.errors.add(:data, 'has invalid subjectFilterMode') unless NodeGrammarRules.valid_filter_mode_for_filter?(filter: subject_filter, filter_mode: subject_filter_mode)
       record.errors.add(:data, 'has invalid targetFilter') unless NodeGrammarV2.valid_filter?(target_filter)
       record.errors.add(:data, 'has invalid targetFilterMode') unless NodeGrammarRules.valid_filter_mode_for_filter?(filter: target_filter, filter_mode: target_filter_mode)
-      unless NodeGrammarRules.comparison_allowed_for_relational_operator?(operator)
-        validate_v2_same_piece_relational!
-        return
-      end
       validate_v2_side_comparator!(
         metric_key: 'subjectComparisonMetric',
         comparator_key: 'subjectComparator',
@@ -100,21 +96,6 @@ module Nodes
       end
       if record.data['targetComparisonSource'] == 'prior_board_state' && side_condition_present?('subject')
         record.errors.add(:data, 'cannot use subject-side comparison when targetComparisonSource is prior_board_state')
-      end
-    end
-
-    def validate_v2_same_piece_relational!
-      if record.data['subjectFilter'] != 'any'
-        record.errors.add(:data, 'same_piece requires subjectFilter to be any')
-      end
-      if record.data['targetFilter'] != 'any'
-        record.errors.add(:data, 'same_piece requires targetFilter to be any')
-      end
-      if side_condition_present?('subject')
-        record.errors.add(:data, 'same_piece does not allow subject-side comparison')
-      end
-      if side_condition_present?('target')
-        record.errors.add(:data, 'same_piece does not allow target-side comparison')
       end
     end
 

--- a/app/models/nodes/data_validator.rb
+++ b/app/models/nodes/data_validator.rb
@@ -1,8 +1,8 @@
 module Nodes
   class DataValidator
-    CONDITION_V2_UNARY_KEYS = %w[ version kind subject subjectFilter subjectFilterMode operator comparator target targetFilter targetFilterMode targetTotal ].freeze
     CONDITION_V2_RELATION_KEYS = %w[ version kind subject subjectFilter subjectFilterMode subjectComparisonMetric subjectComparator subjectComparisonSource subjectComparisonSourceTotal operator target targetFilter targetFilterMode targetComparisonMetric targetComparator targetComparisonSource targetComparisonSourceTotal ].freeze
-    CONDITION_V2_POSITION_KEYS = %w[ version kind subject subjectFilter subjectFilterMode positionAxis positionComparator positionTarget operator comparator targetTotal ].freeze
+    CONDITION_V2_CENSUS_KEYS = %w[ version kind subject subjectFilter subjectFilterMode operator comparator target targetFilter targetFilterMode targetTotal positionAxis positionComparator positionTarget ].freeze
+    CONDITION_V2_IDENTITY_KEYS = %w[ version kind subject target ].freeze
     ACTION_TYPES = %w[add subtract set return].freeze
     ACTION_KEYS = %w[actionType value].freeze
     ORGANIZER_KEYS = %w[title notes].freeze
@@ -40,45 +40,15 @@ module Nodes
     def validate_condition_data_v2
       kind = record.data['kind'] || record.data[:kind]
       case kind
-      when 'unary'
-        validate_condition_data_v2_unary
       when 'relational'
         validate_condition_data_v2_relational
-      when 'position'
-        validate_condition_data_v2_position
+      when 'census'
+        validate_condition_data_v2_census
+      when 'identity'
+        validate_condition_data_v2_identity
       else
         record.errors.add(:data, "has invalid kind: #{kind}")
       end
-    end
-
-    def validate_condition_data_v2_unary
-      keys = record.data.keys.map(&:to_s)
-      extra_keys = keys - CONDITION_V2_UNARY_KEYS
-      missing_keys = %w[version kind subject subjectFilter operator comparator target] - keys
-      if extra_keys.any?
-        record.errors.add(:data, "contains invalid keys: #{extra_keys.join(', ')}")
-      end
-      if missing_keys.any?
-        record.errors.add(:data, "is missing required keys: #{missing_keys.join(', ')}")
-        return
-      end
-      subject = record.data['subject']
-      subject_filter = record.data['subjectFilter']
-      subject_filter_mode = record.data['subjectFilterMode']
-      operator = record.data['operator']
-      comparator = record.data['comparator']
-      target = record.data['target']
-      target_filter = record.data['targetFilter']
-      target_filter_mode = record.data['targetFilterMode']
-      target_total = record.data['targetTotal']
-
-      record.errors.add(:data, 'has invalid subject') unless NodeGrammarV2.valid_subject?(subject)
-      record.errors.add(:data, 'has invalid subjectFilter') unless NodeGrammarV2.valid_filter?(subject_filter)
-      record.errors.add(:data, 'has invalid subjectFilterMode') unless NodeGrammarRules.valid_filter_mode_for_filter?(filter: subject_filter, filter_mode: subject_filter_mode)
-      record.errors.add(:data, 'has invalid operator') unless NodeGrammarRules.valid_unary_operator_for_subject?(subject, operator)
-      record.errors.add(:data, 'has invalid comparator') unless NodeGrammarV2.valid_comparator?(comparator)
-      record.errors.add(:data, 'has invalid target') unless NodeGrammarRules.valid_unary_target_for_operator?(target:, operator:)
-      validate_unary_target_shape!(target:, target_filter:, target_filter_mode:, target_total:)
     end
 
     def validate_condition_data_v2_relational
@@ -148,10 +118,10 @@ module Nodes
       end
     end
 
-    def validate_condition_data_v2_position
+    def validate_condition_data_v2_census
       keys = record.data.keys.map(&:to_s)
-      extra_keys = keys - CONDITION_V2_POSITION_KEYS
-      missing_keys = %w[version kind subject subjectFilter positionAxis positionComparator positionTarget operator comparator targetTotal] - keys
+      extra_keys = keys - CONDITION_V2_CENSUS_KEYS
+      missing_keys = %w[version kind subject subjectFilter operator comparator target] - keys
       if extra_keys.any?
         record.errors.add(:data, "contains invalid keys: #{extra_keys.join(', ')}")
       end
@@ -162,16 +132,30 @@ module Nodes
       subject = record.data['subject']
       subject_filter = record.data['subjectFilter']
       subject_filter_mode = record.data['subjectFilterMode']
-      position_axis = record.data['positionAxis']
-      position_comparator = record.data['positionComparator']
-      position_target = record.data['positionTarget']
       operator = record.data['operator']
       comparator = record.data['comparator']
+      target = record.data['target']
+      target_filter = record.data['targetFilter']
+      target_filter_mode = record.data['targetFilterMode']
       target_total = record.data['targetTotal']
+      position_axis = record.data['positionAxis']
 
-      record.errors.add(:data, 'has invalid subject') unless NodeGrammarV2.valid_position_subject?(subject)
+      record.errors.add(:data, 'has invalid subject') unless NodeGrammarV2.valid_subject?(subject)
       record.errors.add(:data, 'has invalid subjectFilter') unless NodeGrammarV2.valid_filter?(subject_filter)
       record.errors.add(:data, 'has invalid subjectFilterMode') unless NodeGrammarRules.valid_filter_mode_for_filter?(filter: subject_filter, filter_mode: subject_filter_mode)
+      record.errors.add(:data, 'has invalid operator') unless NodeGrammarRules.valid_unary_operator_for_subject?(subject, operator)
+      record.errors.add(:data, 'has invalid comparator') unless NodeGrammarV2.valid_comparator?(comparator)
+      record.errors.add(:data, 'has invalid target') unless NodeGrammarRules.valid_unary_target_for_operator?(target:, operator:)
+      validate_unary_target_shape!(target:, target_filter:, target_filter_mode:, target_total:)
+      validate_census_region!(subject:, position_axis:) if position_axis.present?
+    end
+
+    def validate_census_region!(subject:, position_axis:)
+      if NodeGrammarV2::OFF_BOARD_SUBJECTS.include?(subject)
+        record.errors.add(:data, 'off-board subject does not allow spatial keys')
+      end
+      position_comparator = record.data['positionComparator']
+      position_target = record.data['positionTarget']
       record.errors.add(:data, 'has invalid positionAxis') unless NodeGrammarV2.valid_position_axis?(position_axis)
       if position_axis == 'square'
         record.errors.add(:data, 'positionComparator must be equal_to for square axis') unless position_comparator == 'equal_to'
@@ -180,9 +164,24 @@ module Nodes
       end
       valid_target_range = position_axis == 'square' ? (0..63) : (1..8)
       record.errors.add(:data, 'positionTarget is out of range') unless position_target.is_a?(Numeric) && valid_target_range.cover?(position_target)
-      record.errors.add(:data, 'has invalid operator') unless NodeGrammarRules.valid_position_operator_for_subject?(subject, operator)
-      record.errors.add(:data, 'has invalid comparator') unless NodeGrammarV2.valid_comparator?(comparator)
-      record.errors.add(:data, 'targetTotal must be numeric') unless target_total.is_a?(Numeric)
+    end
+
+    def validate_condition_data_v2_identity
+      keys = record.data.keys.map(&:to_s)
+      extra_keys = keys - CONDITION_V2_IDENTITY_KEYS
+      missing_keys = %w[version kind subject target] - keys
+      if extra_keys.any?
+        record.errors.add(:data, "contains invalid keys: #{extra_keys.join(', ')}")
+      end
+      if missing_keys.any?
+        record.errors.add(:data, "is missing required keys: #{missing_keys.join(', ')}")
+        return
+      end
+      subject = record.data['subject']
+      target = record.data['target']
+      unless NodeGrammarRules.valid_identity_pair?(subject:, target:)
+        record.errors.add(:data, 'has invalid identity subject/target pairing')
+      end
     end
 
     def validate_score_data

--- a/app/presenters/node_presenter.rb
+++ b/app/presenters/node_presenter.rb
@@ -1,4 +1,61 @@
 class NodePresenter
+  # Ordered content-chunk descriptors per condition kind: which payload field
+  # feeds each chunk field. Spacers are inserted by the interpreter, not here.
+  # Census is the one variant case (region vs whole), keyed off positionAxis
+  # presence in the interpreter — never branched in this data.
+  SENTENCE_SPEC = {
+    'relational' => [
+      { 'role' => 'side', 'fields' => {
+        'subject' => 'subject', 'filter' => 'subjectFilter', 'filter_mode' => 'subjectFilterMode',
+        'comparison_metric' => 'subjectComparisonMetric', 'comparator' => 'subjectComparator',
+        'comparison_source' => 'subjectComparisonSource', 'comparison_source_total' => 'subjectComparisonSourceTotal' } },
+      { 'role' => 'operator', 'fields' => { 'operator' => 'operator' } },
+      { 'role' => 'side', 'fields' => {
+        'subject' => 'target', 'filter' => 'targetFilter', 'filter_mode' => 'targetFilterMode',
+        'comparison_metric' => 'targetComparisonMetric', 'comparator' => 'targetComparator',
+        'comparison_source' => 'targetComparisonSource', 'comparison_source_total' => 'targetComparisonSourceTotal' } }
+    ],
+    'identity' => [
+      { 'role' => 'side', 'fields' => { 'subject' => 'subject' }, 'consts' => { 'filter' => 'any' } },
+      { 'role' => 'operator', 'consts' => { 'operator' => 'same_piece' } },
+      { 'role' => 'side', 'fields' => { 'subject' => 'target' }, 'consts' => { 'filter' => 'any' } }
+    ],
+    'census' => {
+      'variant_by' => 'position_axis_present',
+      'whole' => [
+        { 'role' => 'side', 'fields' => {
+          'subject' => 'subject', 'filter' => 'subjectFilter', 'filter_mode' => 'subjectFilterMode' } },
+        { 'role' => 'operator', 'fields' => { 'operator' => 'operator' } },
+        { 'role' => 'comparison', 'fields' => {
+          'comparator' => 'comparator', 'target' => 'target', 'target_filter' => 'targetFilter',
+          'target_filter_mode' => 'targetFilterMode', 'target_total' => 'targetTotal' } }
+      ],
+      'region' => [
+        { 'role' => 'side', 'fields' => {
+          'subject' => 'subject', 'filter' => 'subjectFilter', 'filter_mode' => 'subjectFilterMode' } },
+        { 'role' => 'region', 'fields' => {
+          'position_axis' => 'positionAxis', 'position_comparator' => 'positionComparator',
+          'position_target' => 'positionTarget' } },
+        { 'role' => 'metric', 'fields' => {
+          'operator' => 'operator', 'comparator' => 'comparator', 'target_total' => 'targetTotal' } }
+      ]
+    }
+  }.freeze
+
+  # Canonical chunk-field set per role; unmapped fields stay nil so output
+  # shape is stable regardless of which kind produced the chunk.
+  ROLE_KEYS = {
+    'side' => %w[subject filter filter_mode comparison_metric comparator comparison_source comparison_source_total],
+    'operator' => %w[operator],
+    'comparison' => %w[comparator target target_filter target_filter_mode target_total],
+    'region' => %w[position_axis position_comparator position_target],
+    'metric' => %w[operator comparator target_total]
+  }.freeze
+
+  def self.sentence_spec
+    SENTENCE_SPEC
+  end
+
   def initialize(node)
     @node = node
   end
@@ -30,88 +87,32 @@ class NodePresenter
   end
 
   def self.condition_preview_chunks_v2(data)
-    kind = data['kind'] || data[:kind]
-    case kind
-    when 'relational'
-      condition_preview_chunks_v2_relational(data)
-    when 'census'
-      # Whole-board census is unary-shaped; the region axis clause is Phase 2.
-      condition_preview_chunks_v2_unary(data)
-    when 'identity'
-      condition_preview_chunks_v2_identity(data)
-    else
-      ['[invalid condition]']
+    spec = SENTENCE_SPEC[data['kind'] || data[:kind]]
+    return ['[invalid condition]'] unless spec
+
+    descriptors = spec.is_a?(Array) ? spec : census_descriptors(spec, data)
+    descriptors.each_with_index.flat_map do |descriptor, index|
+      chunk = build_sentence_chunk(descriptor, data)
+      index.zero? ? [chunk] : [{ role: 'spacer' }, chunk]
     end
   end
 
-  def self.condition_preview_chunks_v2_identity(data)
-    [
-      v2_side_chunk(subject: data['subject'], filter: 'any', filter_mode: nil),
-      { role: 'spacer' },
-      { role: 'operator', operator: 'same_piece' },
-      { role: 'spacer' },
-      v2_side_chunk(subject: data['target'], filter: 'any', filter_mode: nil)
-    ]
+  # The one variant case: positionAxis presence selects region vs whole.
+  def self.census_descriptors(spec, data)
+    (data['positionAxis'] || data[:positionAxis]).present? ? spec['region'] : spec['whole']
   end
 
-  def self.condition_preview_chunks_v2_relational(data)
-    [
-      v2_side_chunk(
-        subject: data['subject'],
-        filter: data['subjectFilter'],
-        filter_mode: data['subjectFilterMode'],
-        comparison_metric: data['subjectComparisonMetric'],
-        comparator: data['subjectComparator'],
-        comparison_source: data['subjectComparisonSource'],
-        comparison_source_total: data['subjectComparisonSourceTotal']
-      ),
-      { role: 'spacer' },
-      { role: 'operator', operator: data['operator'] },
-      { role: 'spacer' },
-      v2_side_chunk(
-        subject: data['target'],
-        filter: data['targetFilter'],
-        filter_mode: data['targetFilterMode'],
-        comparison_metric: data['targetComparisonMetric'],
-        comparator: data['targetComparator'],
-        comparison_source: data['targetComparisonSource'],
-        comparison_source_total: data['targetComparisonSourceTotal']
-      )
-    ]
-  end
-
-  def self.condition_preview_chunks_v2_unary(data)
-    [
-      v2_side_chunk(
-        subject: data['subject'],
-        filter: data['subjectFilter'],
-        filter_mode: data['subjectFilterMode']
-      ),
-      { role: 'spacer' },
-      { role: 'operator', operator: data['operator'] },
-      { role: 'spacer' },
-      {
-        role: 'comparison',
-        comparator: data['comparator'],
-        target: data['target'],
-        target_filter: data['targetFilter'],
-        target_filter_mode: data['targetFilterMode'],
-        target_total: data['targetTotal']
-      }
-    ]
-  end
-
-  def self.v2_side_chunk(subject:, filter:, filter_mode:, comparison_metric: nil, comparator: nil, comparison_source: nil, comparison_source_total: nil)
-    {
-      role: 'side',
-      subject: subject,
-      filter: filter,
-      filter_mode: filter_mode,
-      comparison_metric: comparison_metric,
-      comparator: comparator,
-      comparison_source: comparison_source,
-      comparison_source_total: comparison_source_total
-    }
+  def self.build_sentence_chunk(descriptor, data)
+    fields = descriptor['fields'] || {}
+    consts = descriptor['consts'] || {}
+    chunk = { role: descriptor['role'] }
+    ROLE_KEYS.fetch(descriptor['role']).each do |key|
+      chunk[key.to_sym] =
+        if consts.key?(key) then consts[key]
+        elsif fields.key?(key) then data[fields[key]]
+        end
+    end
+    chunk
   end
 
   private

--- a/app/presenters/node_presenter.rb
+++ b/app/presenters/node_presenter.rb
@@ -34,11 +34,24 @@ class NodePresenter
     case kind
     when 'relational'
       condition_preview_chunks_v2_relational(data)
-    when 'unary'
+    when 'census'
+      # Whole-board census is unary-shaped; the region axis clause is Phase 2.
       condition_preview_chunks_v2_unary(data)
+    when 'identity'
+      condition_preview_chunks_v2_identity(data)
     else
       ['[invalid condition]']
     end
+  end
+
+  def self.condition_preview_chunks_v2_identity(data)
+    [
+      v2_side_chunk(subject: data['subject'], filter: 'any', filter_mode: nil),
+      { role: 'spacer' },
+      { role: 'operator', operator: 'same_piece' },
+      { role: 'spacer' },
+      v2_side_chunk(subject: data['target'], filter: 'any', filter_mode: nil)
+    ]
   end
 
   def self.condition_preview_chunks_v2_relational(data)

--- a/app/services/bot_compiler.rb
+++ b/app/services/bot_compiler.rb
@@ -93,20 +93,6 @@ class BotCompiler
       kind = raw['kind'] || raw[:kind]
 
       case kind
-      when 'unary'
-        {
-          version: 2,
-          kind: 'unary',
-          subject: raw['subject'] || raw[:subject],
-          subjectFilter: raw['subjectFilter'] || raw[:subjectFilter],
-          subjectFilterMode: raw['subjectFilterMode'] || raw[:subjectFilterMode],
-          operator: raw['operator'] || raw[:operator],
-          comparator: raw['comparator'] || raw[:comparator],
-          target: raw['target'] || raw[:target],
-          targetFilter: raw['targetFilter'] || raw[:targetFilter],
-          targetFilterMode: raw['targetFilterMode'] || raw[:targetFilterMode],
-          targetTotal: hash_value(raw, 'targetTotal')
-        }.compact
       when 'census'
         # Unary shape plus optional region keys; compact drops absent ones.
         {
@@ -124,6 +110,13 @@ class BotCompiler
           positionAxis: raw['positionAxis'] || raw[:positionAxis],
           positionComparator: raw['positionComparator'] || raw[:positionComparator],
           positionTarget: hash_value(raw, 'positionTarget')
+        }.compact
+      when 'identity'
+        {
+          version: 2,
+          kind: 'identity',
+          subject: raw['subject'] || raw[:subject],
+          target: raw['target'] || raw[:target]
         }.compact
       when 'relational'
         {

--- a/app/services/bot_compiler.rb
+++ b/app/services/bot_compiler.rb
@@ -107,6 +107,24 @@ class BotCompiler
           targetFilterMode: raw['targetFilterMode'] || raw[:targetFilterMode],
           targetTotal: hash_value(raw, 'targetTotal')
         }.compact
+      when 'census'
+        # Unary shape plus optional region keys; compact drops absent ones.
+        {
+          version: 2,
+          kind: 'census',
+          subject: raw['subject'] || raw[:subject],
+          subjectFilter: raw['subjectFilter'] || raw[:subjectFilter],
+          subjectFilterMode: raw['subjectFilterMode'] || raw[:subjectFilterMode],
+          operator: raw['operator'] || raw[:operator],
+          comparator: raw['comparator'] || raw[:comparator],
+          target: raw['target'] || raw[:target],
+          targetFilter: raw['targetFilter'] || raw[:targetFilter],
+          targetFilterMode: raw['targetFilterMode'] || raw[:targetFilterMode],
+          targetTotal: hash_value(raw, 'targetTotal'),
+          positionAxis: raw['positionAxis'] || raw[:positionAxis],
+          positionComparator: raw['positionComparator'] || raw[:positionComparator],
+          positionTarget: hash_value(raw, 'positionTarget')
+        }.compact
       when 'relational'
         {
           version: 2,

--- a/app/views/bots/nodes/_editor.html.erb
+++ b/app/views/bots/nodes/_editor.html.erb
@@ -7,8 +7,9 @@
   <div class="panel-content condition-form-panel__content">
     <div id="condition-form" class="node-form-section hidden">
       <div class="condition-form-mode-picker">
-        <button type="button" class="condition-form-mode-picker__option" id="cond-mode-relational">Relational</button>
         <button type="button" class="condition-form-mode-picker__option" id="cond-mode-census">Positions</button>
+        <button type="button" class="condition-form-mode-picker__option" id="cond-mode-relational">Attack/Defend</button>
+        <button type="button" class="condition-form-mode-picker__option" id="cond-mode-identity">Identity</button>
       </div>
 
       <div class="condition-form-layout">
@@ -80,8 +81,6 @@
             <option value="targets">Targets</option>
             <option value="shield">Shield</option>
             <option value="adjacent">Adjacent</option>
-            <option disabled>────────</option>
-            <option value="same_piece">Same-Piece</option>
           </select>
         </section>
 
@@ -319,6 +318,39 @@
         </section>
 
         <p class="condition-form-note condition-form-position-layout__note">Rank is relative to your side (rank 1 = your back rank).</p>
+      </div>
+
+      <div class="condition-form-layout condition-form-identity-layout hidden" id="cond-identity-layout">
+        <section class="condition-form-side">
+          <div class="condition-form-side__header">
+            <span class="condition-form-side__label">Subject</span>
+          </div>
+          <div class="condition-form-field">
+            <select id="cond-identity-subject">
+              <% NodeGrammarRules::SAME_PIECE_TARGETS.keys.each do |value| %>
+                <option value="<%= value %>"><%= NodeForm.subject_label(value) %></option>
+              <% end %>
+            </select>
+          </div>
+        </section>
+
+        <section class="condition-form-operator">
+          <label>Relation</label>
+          <p class="condition-form-identity-relation">is the same piece as</p>
+        </section>
+
+        <section class="condition-form-side">
+          <div class="condition-form-side__header">
+            <span class="condition-form-side__label">Target</span>
+          </div>
+          <div class="condition-form-field">
+            <select id="cond-identity-target">
+              <% NodeGrammarRules::SAME_PIECE_TARGETS.values.flatten.uniq.each do |value| %>
+                <option value="<%= value %>"><%= NodeForm.subject_label(value) %></option>
+              <% end %>
+            </select>
+          </div>
+        </section>
       </div>
 
       <div class="condition-form-formulation">

--- a/app/views/bots/nodes/_editor.html.erb
+++ b/app/views/bots/nodes/_editor.html.erb
@@ -8,8 +8,7 @@
     <div id="condition-form" class="node-form-section hidden">
       <div class="condition-form-mode-picker">
         <button type="button" class="condition-form-mode-picker__option" id="cond-mode-relational">Relational</button>
-        <button type="button" class="condition-form-mode-picker__option" id="cond-mode-measure">Measure</button>
-        <button type="button" class="condition-form-mode-picker__option" id="cond-mode-position">Position</button>
+        <button type="button" class="condition-form-mode-picker__option" id="cond-mode-census">Positions</button>
       </div>
 
       <div class="condition-form-layout">
@@ -40,8 +39,6 @@
             </div>
           </div>
 
-          <p class="condition-form-note hidden" id="cond-measure-subject-note">Mobility is unavailable for Captured Piece and Enemy Captured Piece.</p>
-
           <div class="condition-form-comparison" id="cond-left-comparison-section">
             <button type="button" class="condition-form-comparison__toggle" id="cond-left-comparison-toggle"></button>
 
@@ -53,13 +50,14 @@
                   <% end %>
                 </select>
 
-                <select id="cond-left-comparator">
-                  <option value="equal_to">=</option>
-                  <option value="greater_than">></option>
-                  <option value="less_than"><</option>
-                  <option value="greater_than_or_equal_to">≥</option>
-                  <option value="less_than_or_equal_to">≤</option>
-                </select>
+                <div class="condition-form-radio-row" id="cond-left-comparator">
+                  <% [['equal_to', '='], ['greater_than', '>'], ['less_than', '<'], ['greater_than_or_equal_to', '≥'], ['less_than_or_equal_to', '≤']].each_with_index do |(value, glyph), i| %>
+                    <label class="condition-form-checkbox">
+                      <input type="radio" name="cond-left-comparator" value="<%= value %>" <%= 'checked' if i.zero? %>>
+                      <span><%= glyph %></span>
+                    </label>
+                  <% end %>
+                </div>
 
                 <div class="condition-form-comparison-source-stack" id="cond-left-comparison-source-stack">
                   <select id="cond-left-comparison-source">
@@ -85,23 +83,6 @@
             <option disabled>────────</option>
             <option value="same_piece">Same-Piece</option>
           </select>
-          <select id="cond-measure-operator" class="hidden">
-            <% NodeForm.condition_form_measure_operator_options.each do |label, value| %>
-              <option value="<%= value %>"><%= label %></option>
-            <% end %>
-          </select>
-
-          <div class="condition-form-comparison hidden" id="cond-unary-comparison-section">
-            <div class="condition-form-field">
-              <select id="cond-unary-comparator">
-                <option value="equal_to">=</option>
-                <option value="greater_than">></option>
-                <option value="less_than"><</option>
-                <option value="greater_than_or_equal_to">≥</option>
-                <option value="less_than_or_equal_to">≤</option>
-              </select>
-            </div>
-          </div>
         </section>
 
         <section class="condition-form-side" id="cond-right-card">
@@ -145,13 +126,14 @@
                     <% end %>
                   </select>
 
-                  <select id="cond-right-comparator">
-                    <option value="equal_to">=</option>
-                    <option value="greater_than">></option>
-                    <option value="less_than"><</option>
-                    <option value="greater_than_or_equal_to">≥</option>
-                    <option value="less_than_or_equal_to">≤</option>
-                  </select>
+                  <div class="condition-form-radio-row" id="cond-right-comparator">
+                    <% [['equal_to', '='], ['greater_than', '>'], ['less_than', '<'], ['greater_than_or_equal_to', '≥'], ['less_than_or_equal_to', '≤']].each_with_index do |(value, glyph), i| %>
+                      <label class="condition-form-checkbox">
+                        <input type="radio" name="cond-right-comparator" value="<%= value %>" <%= 'checked' if i.zero? %>>
+                        <span><%= glyph %></span>
+                      </label>
+                    <% end %>
+                  </div>
 
                   <div class="condition-form-comparison-source-stack" id="cond-right-comparison-source-stack">
                     <select id="cond-right-comparison-source">
@@ -167,57 +149,30 @@
               </div>
             </div>
           </div>
-
-          <div class="condition-form-comparison hidden" id="cond-unary-target-section">
-            <div class="condition-form-field">
-              <label>Target</label>
-              <div class="condition-form-comparison-source-stack" id="cond-unary-target-stack">
-                <select id="cond-unary-target">
-                  <% NodeForm.unary_target_options.each do |label, value| %>
-                    <option value="<%= value %>"><%= label %></option>
-                  <% end %>
-                </select>
-
-                <div class="condition-form-inline-pair" id="cond-unary-target-filter-row">
-                  <label class="condition-form-checkbox">
-                    <input id="cond-unary-target-filter-mode" type="checkbox">
-                    <span>Non-</span>
-                  </label>
-                  <select id="cond-unary-target-filter">
-                    <% NodeForm.filter_options.each do |label, value| %>
-                      <option value="<%= value %>"><%= label %></option>
-                    <% end %>
-                  </select>
-                </div>
-
-                <input id="cond-unary-target-total" type="number" min="0" step="1">
-              </div>
-            </div>
-          </div>
         </section>
       </div>
 
-      <div class="condition-form-layout condition-form-position-layout hidden" id="cond-position-layout">
+      <div class="condition-form-layout condition-form-position-layout hidden" id="cond-census-layout">
         <section class="condition-form-side">
           <div class="condition-form-side__header">
             <span class="condition-form-side__label">Subject</span>
           </div>
 
           <div class="condition-form-field">
-            <select id="cond-position-subject">
-              <% NodeGrammarV2::POSITION_SUBJECTS.each do |value| %>
-                <option value="<%= value %>"><%= NodeForm.subject_label(value) %></option>
+            <select id="cond-census-subject">
+              <% NodeForm.editor_subject_options.each do |label, value| %>
+                <option value="<%= value %>"><%= label %></option>
               <% end %>
             </select>
           </div>
 
-          <div class="condition-form-field" id="cond-position-filter-row">
+          <div class="condition-form-field" id="cond-census-filter-row">
             <div class="condition-form-inline-pair">
               <label class="condition-form-checkbox">
-                <input id="cond-position-filter-mode" type="checkbox">
+                <input id="cond-census-filter-mode" type="checkbox">
                 <span>Non-</span>
               </label>
-              <select id="cond-position-filter">
+              <select id="cond-census-filter">
                 <% NodeForm.filter_options.each do |label, value| %>
                   <option value="<%= value %>"><%= label %></option>
                 <% end %>
@@ -225,97 +180,140 @@
             </div>
           </div>
 
-          <div class="condition-form-comparison" id="cond-position-comparison">
-            <button type="button" class="condition-form-comparison__toggle" id="cond-position-comparison-toggle"></button>
+          <div class="condition-form-comparison" id="cond-census-comparison">
+            <button type="button" class="condition-form-comparison__toggle" id="cond-census-comparison-toggle"></button>
 
-            <div class="condition-form-comparison__body hidden" id="cond-position-comparison-body">
-              <div class="condition-form-comparison-grid condition-form-comparison-grid--position">
-                <select id="cond-position-operator">
+            <div class="condition-form-comparison__body hidden" id="cond-census-comparison-body">
+              <div class="condition-form-comparison-grid condition-form-comparison-grid--relational">
+                <select id="cond-census-operator">
                   <% NodeForm.condition_form_position_operator_options.each do |label, value| %>
                     <option value="<%= value %>"><%= label %></option>
                   <% end %>
                 </select>
 
-                <select id="cond-position-metric-comparator">
-                  <option value="equal_to">=</option>
-                  <option value="greater_than">></option>
-                  <option value="less_than"><</option>
-                  <option value="greater_than_or_equal_to">≥</option>
-                  <option value="less_than_or_equal_to">≤</option>
-                </select>
+                <div class="condition-form-radio-row" id="cond-census-comparator">
+                  <% [['equal_to', '='], ['greater_than', '>'], ['less_than', '<'], ['greater_than_or_equal_to', '≥'], ['less_than_or_equal_to', '≤']].each_with_index do |(value, glyph), i| %>
+                    <label class="condition-form-checkbox">
+                      <input type="radio" name="cond-census-comparator" value="<%= value %>" <%= 'checked' if i.zero? %>>
+                      <span><%= glyph %></span>
+                    </label>
+                  <% end %>
+                </div>
 
-                <input id="cond-position-target-total" type="number" min="0" step="1" value="0">
+                <div class="condition-form-comparison-source-stack" id="cond-census-target-stack">
+                  <select id="cond-census-target">
+                    <% NodeForm.unary_target_options.each do |label, value| %>
+                      <option value="<%= value %>"><%= label %></option>
+                    <% end %>
+                  </select>
+
+                  <div class="condition-form-inline-pair" id="cond-census-target-filter-row">
+                    <label class="condition-form-checkbox">
+                      <input id="cond-census-target-filter-mode" type="checkbox">
+                      <span>Non-</span>
+                    </label>
+                    <select id="cond-census-target-filter">
+                      <% NodeForm.filter_options.each do |label, value| %>
+                        <option value="<%= value %>"><%= label %></option>
+                      <% end %>
+                    </select>
+                  </div>
+
+                  <input id="cond-census-target-total" type="number" min="0" step="1" value="0">
+                </div>
               </div>
             </div>
           </div>
         </section>
 
         <section class="condition-form-operator">
-          <label>Position</label>
-          <select id="cond-position-axis">
-            <option value="rank">Rank</option>
-            <option value="file">File</option>
-            <option value="square">Square</option>
-          </select>
+          <label>Positions</label>
+          <div class="condition-form-positions-row">
+          <div class="condition-form-scope-toggle" id="cond-census-scope">
+            <label class="condition-form-checkbox">
+              <input type="radio" name="cond-census-scope" id="cond-census-scope-whole" value="whole">
+              <span>Whole<br>board</span>
+            </label>
+            <label class="condition-form-checkbox">
+              <input type="radio" name="cond-census-scope" id="cond-census-axis-rank" value="rank" checked>
+              <span>Rank</span>
+            </label>
+            <label class="condition-form-checkbox">
+              <input type="radio" name="cond-census-scope" id="cond-census-axis-file" value="file">
+              <span>File</span>
+            </label>
+            <label class="condition-form-checkbox">
+              <input type="radio" name="cond-census-scope" id="cond-census-axis-square" value="square">
+              <span>Square</span>
+            </label>
+          </div>
 
-          <select id="cond-position-comparator">
-            <option value="equal_to">=</option>
-            <option value="greater_than">></option>
-            <option value="less_than"><</option>
-            <option value="greater_than_or_equal_to">≥</option>
-            <option value="less_than_or_equal_to">≤</option>
-          </select>
+          <div class="condition-form-comparator-toggle" id="cond-census-region-comparator">
+            <label class="condition-form-checkbox">
+              <input type="radio" name="cond-census-region-comparator" value="equal_to" checked>
+              <span>=</span>
+            </label>
+            <label class="condition-form-checkbox">
+              <input type="radio" name="cond-census-region-comparator" value="greater_than">
+              <span>></span>
+            </label>
+            <label class="condition-form-checkbox">
+              <input type="radio" name="cond-census-region-comparator" value="less_than">
+              <span><</span>
+            </label>
+            <label class="condition-form-checkbox">
+              <input type="radio" name="cond-census-region-comparator" value="greater_than_or_equal_to">
+              <span>≥</span>
+            </label>
+            <label class="condition-form-checkbox">
+              <input type="radio" name="cond-census-region-comparator" value="less_than_or_equal_to">
+              <span>≤</span>
+            </label>
+          </div>
+          </div>
         </section>
 
-        <section class="condition-form-side">
+        <section class="condition-form-side" id="cond-census-region-target">
           <div class="condition-form-side__header">
             <span class="condition-form-side__label">Target</span>
           </div>
 
           <div class="condition-form-field">
-            <select id="cond-position-rank-input">
-              <option value="1">1</option>
-              <option value="2">2</option>
-              <option value="3">3</option>
-              <option value="4">4</option>
-              <option value="5">5</option>
-              <option value="6">6</option>
-              <option value="7">7</option>
-              <option value="8">8</option>
-            </select>
+            <div id="cond-census-rank-input" class="condition-form-radio-list">
+              <% (1..8).each do |n| %>
+                <label class="condition-form-checkbox">
+                  <input type="radio" name="cond-census-rank-input" value="<%= n %>" <%= 'checked' if n == 1 %>>
+                  <span><%= n %></span>
+                </label>
+              <% end %>
+            </div>
 
-            <select id="cond-position-file-input" class="hidden">
-              <option value="1">a</option>
-              <option value="2">b</option>
-              <option value="3">c</option>
-              <option value="4">d</option>
-              <option value="5">e</option>
-              <option value="6">f</option>
-              <option value="7">g</option>
-              <option value="8">h</option>
-            </select>
+            <div id="cond-census-file-input" class="condition-form-radio-list hidden">
+              <% %w[a b c d e f g h].each_with_index do |letter, i| %>
+                <label class="condition-form-checkbox">
+                  <input type="radio" name="cond-census-file-input" value="<%= i + 1 %>" <%= 'checked' if i.zero? %>>
+                  <span><%= letter %></span>
+                </label>
+              <% end %>
+            </div>
 
-            <div id="cond-position-square-inputs" class="condition-form-inline-pair hidden">
-              <select id="cond-position-square-file">
-                <option value="1">a</option>
-                <option value="2">b</option>
-                <option value="3">c</option>
-                <option value="4">d</option>
-                <option value="5">e</option>
-                <option value="6">f</option>
-                <option value="7">g</option>
-                <option value="8">h</option>
-              </select>
-              <select id="cond-position-square-rank">
-                <option value="1">1</option>
-                <option value="2">2</option>
-                <option value="3">3</option>
-                <option value="4">4</option>
-                <option value="5">5</option>
-                <option value="6">6</option>
-                <option value="7">7</option>
-                <option value="8">8</option>
-              </select>
+            <div id="cond-census-square-inputs" class="condition-form-square-inputs hidden">
+              <div id="cond-census-square-file" class="condition-form-radio-list">
+                <% %w[a b c d e f g h].each_with_index do |letter, i| %>
+                  <label class="condition-form-checkbox">
+                    <input type="radio" name="cond-census-square-file" value="<%= i + 1 %>" <%= 'checked' if i.zero? %>>
+                    <span><%= letter %></span>
+                  </label>
+                <% end %>
+              </div>
+              <div id="cond-census-square-rank" class="condition-form-radio-list">
+                <% (1..8).each do |n| %>
+                  <label class="condition-form-checkbox">
+                    <input type="radio" name="cond-census-square-rank" value="<%= n %>" <%= 'checked' if n == 1 %>>
+                    <span><%= n %></span>
+                  </label>
+                <% end %>
+              </div>
             </div>
           </div>
         </section>

--- a/app/views/bots/nodes/_editor.html.erb
+++ b/app/views/bots/nodes/_editor.html.erb
@@ -4,6 +4,8 @@
     <%= raw json_escape(NodeGrammarRules.editor_config.to_json) %>
   </script>
 
+  <%= render 'shared/condition_sentence_spec' %>
+
   <div class="panel-content condition-form-panel__content">
     <div id="condition-form" class="node-form-section hidden">
       <div class="condition-form-mode-picker">

--- a/app/views/bots/nodes/types/_condition.html.erb
+++ b/app/views/bots/nodes/types/_condition.html.erb
@@ -24,6 +24,10 @@
           <% value = chunk.key?(:target_total) ? chunk[:target_total] : chunk['target_total'] %>
           <% unless value.nil? %>data-condition-preview-target-total="<%= value %>"<% end %>
           <% if (value = chunk[:operator] || chunk['operator']).present? %>data-condition-preview-operator="<%= value %>"<% end %>
+          <% if (value = chunk[:position_axis] || chunk['position_axis']).present? %>data-condition-preview-position-axis="<%= value %>"<% end %>
+          <% if (value = chunk[:position_comparator] || chunk['position_comparator']).present? %>data-condition-preview-position-comparator="<%= value %>"<% end %>
+          <% value = chunk.key?(:position_target) ? chunk[:position_target] : chunk['position_target'] %>
+          <% unless value.nil? %>data-condition-preview-position-target="<%= value %>"<% end %>
         ></div>
       <% end %>
     <% elsif chunk == "" %>

--- a/app/views/matches/show.html.erb
+++ b/app/views/matches/show.html.erb
@@ -1,4 +1,5 @@
 <div class="match-show-page">
+  <%= render 'shared/condition_sentence_spec' %>
   <% if @match.awaiting_generation? %>
     <meta http-equiv="refresh" content="2">
   <% end %>

--- a/app/views/shared/_condition_sentence_spec.html.erb
+++ b/app/views/shared/_condition_sentence_spec.html.erb
@@ -1,0 +1,3 @@
+<script type="application/json" id="condition-sentence-spec">
+  <%= raw json_escape(NodePresenter.sentence_spec.to_json) %>
+</script>

--- a/db/migrate/20260516120000_migrate_condition_kinds_to_census_and_identity.rb
+++ b/db/migrate/20260516120000_migrate_condition_kinds_to_census_and_identity.rb
@@ -1,0 +1,33 @@
+class MigrateConditionKindsToCensusAndIdentity < ActiveRecord::Migration[7.1]
+  def up
+    execute <<-SQL
+      UPDATE nodes
+      SET data = jsonb_set(
+        CASE WHEN jsonb_exists(data::jsonb, 'target')
+             THEN data::jsonb
+             ELSE jsonb_set(data::jsonb, '{target}', '"exact_number"') END,
+        '{kind}', '"census"'
+      )::json
+      WHERE node_type = 'condition'
+        AND data->>'kind' IN ('unary', 'position');
+
+      UPDATE nodes
+      SET data = jsonb_build_object(
+        'version', data::jsonb->'version',
+        'kind', '"identity"'::jsonb,
+        'subject', data::jsonb->'subject',
+        'target', data::jsonb->'target'
+      )::json
+      WHERE node_type = 'condition'
+        AND data->>'kind' = 'relational'
+        AND data->>'operator' = 'same_piece';
+    SQL
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration,
+          'kind unification is lossy (census loses its unary/position origin; ' \
+          'identity drops the relational payload). Restore from the ' \
+          'pre-migration DB snapshot / branch state instead.'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_05_15_120000) do
+ActiveRecord::Schema[7.1].define(version: 2026_05_16_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 

--- a/spec/factories/nodes.rb
+++ b/spec/factories/nodes.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
       when "condition"
         {
           version: 2,
-          kind: "unary",
+          kind: "census",
           subject: "moved_piece",
           subjectFilter: "any",
           subjectFilterMode: "include",
@@ -38,7 +38,7 @@ FactoryBot.define do
       data do
         {
           version: 2,
-          kind: "unary",
+          kind: "census",
           subject: "moved_piece",
           subjectFilter: "any",
           subjectFilterMode: "include",

--- a/spec/migrations/migrate_condition_kinds_to_census_and_identity_spec.rb
+++ b/spec/migrations/migrate_condition_kinds_to_census_and_identity_spec.rb
@@ -1,0 +1,108 @@
+require 'rails_helper'
+
+# NEW-TDD-RED: the kind-unification data migration.
+# Canonical target the implementation must create:
+#   db/migrate/20260516120000_migrate_condition_kinds_to_census_and_identity.rb
+#   class MigrateConditionKindsToCensusAndIdentity
+# Guarded so the absent migration fails these examples individually
+# (NEW-TDD-RED) rather than aborting the whole suite at load.
+begin
+  require Rails.root.join(
+    'db', 'migrate', '20260516120000_migrate_condition_kinds_to_census_and_identity'
+  )
+rescue LoadError
+  nil
+end
+
+RSpec.describe 'MigrateConditionKindsToCensusAndIdentity', type: :model do
+  let(:migration) { MigrateConditionKindsToCensusAndIdentity.new }
+
+  # Persist a row bypassing validation (the post-migration validator no longer
+  # accepts kind: unary/position/relational+same_piece).
+  def legacy_node(data)
+    node = create(:node, :condition)
+    node.update_column(:data, data)
+    node
+  end
+
+  it 'rewrites a unary node to census, preserving the rest of the payload byte-for-byte' do
+    node = legacy_node(
+      'version' => 2, 'kind' => 'unary', 'subject' => 'allied',
+      'subjectFilter' => 'pawn', 'subjectFilterMode' => 'include',
+      'operator' => 'value', 'comparator' => 'greater_than',
+      'target' => 'exact_number', 'targetTotal' => 6
+    )
+
+    migration.up
+
+    expect(node.reload.data).to eq(
+      'version' => 2, 'kind' => 'census', 'subject' => 'allied',
+      'subjectFilter' => 'pawn', 'subjectFilterMode' => 'include',
+      'operator' => 'value', 'comparator' => 'greater_than',
+      'target' => 'exact_number', 'targetTotal' => 6
+    )
+  end
+
+  it 'rewrites a position node to census, preserving the spatial keys' do
+    node = legacy_node(
+      'version' => 2, 'kind' => 'position', 'subject' => 'allied',
+      'subjectFilter' => 'major', 'subjectFilterMode' => 'include',
+      'operator' => 'count', 'comparator' => 'equal_to', 'targetTotal' => 2,
+      'positionAxis' => 'file', 'positionComparator' => 'equal_to', 'positionTarget' => 4
+    )
+
+    migration.up
+
+    expect(node.reload.data).to eq(
+      'version' => 2, 'kind' => 'census', 'subject' => 'allied',
+      'subjectFilter' => 'major', 'subjectFilterMode' => 'include',
+      'operator' => 'count', 'comparator' => 'equal_to', 'targetTotal' => 2,
+      'target' => 'exact_number',
+      'positionAxis' => 'file', 'positionComparator' => 'equal_to', 'positionTarget' => 4
+    )
+  end
+
+  it 'reduces a same_piece relational node to the minimal identity payload' do
+    node = legacy_node(
+      'version' => 2, 'kind' => 'relational', 'subject' => 'enemy_moved_piece',
+      'subjectFilter' => 'any', 'operator' => 'same_piece',
+      'target' => 'captured_piece', 'targetFilter' => 'any'
+    )
+
+    migration.up
+
+    expect(node.reload.data).to eq(
+      'version' => 2, 'kind' => 'identity',
+      'subject' => 'enemy_moved_piece', 'target' => 'captured_piece'
+    )
+  end
+
+  it 'leaves non-same_piece relational nodes untouched' do
+    node = legacy_node(
+      'version' => 2, 'kind' => 'relational', 'subject' => 'allied',
+      'subjectFilter' => 'any', 'operator' => 'attack',
+      'target' => 'enemy', 'targetFilter' => 'any'
+    )
+
+    migration.up
+
+    expect(node.reload.data['kind']).to eq('relational')
+    expect(node.reload.data['operator']).to eq('attack')
+  end
+
+  it 'is idempotent on re-run' do
+    node = legacy_node(
+      'version' => 2, 'kind' => 'position', 'subject' => 'allied',
+      'subjectFilter' => 'major', 'subjectFilterMode' => 'include',
+      'operator' => 'count', 'comparator' => 'equal_to', 'targetTotal' => 2,
+      'positionAxis' => 'file', 'positionComparator' => 'equal_to', 'positionTarget' => 4
+    )
+
+    migration.up
+    first = node.reload.data
+    migration.up
+
+    expect(node.reload.data).to eq(first)
+    expect(node.reload.data['kind']).to eq('census')
+  end
+end

--- a/spec/models/bot_spec.rb
+++ b/spec/models/bot_spec.rb
@@ -226,7 +226,7 @@ RSpec.describe Bot, type: :model do
 
       node.update!(data: {
         version: 2,
-        kind: 'unary',
+        kind: 'census',
         subject: 'moved_piece',
         subjectFilter: 'any',
         subjectFilterMode: 'include',

--- a/spec/models/node_form_spec.rb
+++ b/spec/models/node_form_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe NodeForm, type: :model do
     it 'offers count and value (individual_value) but never aggregate_value' do
       options = described_class.comparison_metric_options
 
-      expect(options).to include(['count', 'count'])
-      expect(options).to include(['value', 'individual_value'])
+      expect(options).to include(['Count', 'count'])
+      expect(options).to include(['Value', 'individual_value'])
       expect(options.map(&:last)).not_to include('aggregate_value')
     end
   end

--- a/spec/models/node_grammar_rules_spec.rb
+++ b/spec/models/node_grammar_rules_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe NodeGrammarRules, type: :model do
   end
 
   describe '.valid_relational_target_for?' do
-    it 'allows same_piece targets only for the paired subjects' do
-      expect(described_class.valid_relational_target_for?(subject: 'enemy_moved_piece', operator: 'same_piece', target: 'captured_piece')).to be(true)
-      expect(described_class.valid_relational_target_for?(subject: 'enemy_moved_piece', operator: 'same_piece', target: 'enemy')).to be(false)
+    it 'rejects same_piece as a relational operator (it is now the identity kind)' do
+      expect(described_class.valid_relational_target_for?(subject: 'enemy_moved_piece', operator: 'same_piece', target: 'captured_piece')).to be(false)
+      expect(NodeGrammarV2.valid_relational_operator?('same_piece')).to be(false)
     end
 
     it 'allows attack targets only across teams' do

--- a/spec/models/node_spec.rb
+++ b/spec/models/node_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Node, type: :model do
     it 'rejects condition data with invalid keys' do
       node = build(:node, :condition, data: {
         version: 2,
-        kind: 'unary',
+        kind: 'census',
         subject: 'moved_piece',
         subjectFilter: 'any',
         subjectFilterMode: 'include',
@@ -93,7 +93,7 @@ RSpec.describe Node, type: :model do
       it 'rejects V2 condition data with unexpected keys' do
         node = build(:node, :condition, data: {
           version: 2,
-          kind: 'unary',
+          kind: 'census',
           subject: 'moved_piece',
           subjectFilter: 'any',
           operator: 'value',
@@ -107,10 +107,10 @@ RSpec.describe Node, type: :model do
         expect(node.errors[:data]).to include('contains invalid keys: script')
       end
 
-      it 'rejects invalid subjectFilterMode for unary V2 conditions' do
+      it 'rejects invalid subjectFilterMode for census V2 conditions' do
         node = build(:node, :condition, data: {
           version: 2,
-          kind: 'unary',
+          kind: 'census',
           subject: 'moved_piece',
           subjectFilter: 'pawn',
           subjectFilterMode: 'banana',
@@ -124,10 +124,10 @@ RSpec.describe Node, type: :model do
         expect(node.errors[:data]).to include('has invalid subjectFilterMode')
       end
 
-      it 'rejects captured-piece unary targets for mobility' do
+      it 'rejects captured-piece census targets for mobility' do
         node = build(:node, :condition, data: {
           version: 2,
-          kind: 'unary',
+          kind: 'census',
           subject: 'allied',
           subjectFilter: 'any',
           operator: 'mobility',
@@ -159,7 +159,7 @@ RSpec.describe Node, type: :model do
       it 'delegates data normalization before validation' do
         input_data = {
           version: 2,
-          kind: 'unary',
+          kind: 'census',
           subject: 'moved_piece',
           subjectFilter: 'any',
           operator: 'value',
@@ -171,7 +171,7 @@ RSpec.describe Node, type: :model do
 
         expect(Nodes::DataNormalizer).to receive(:normalize).with(
           node_type: 'condition',
-          data: include('kind' => 'unary', 'subject' => 'moved_piece')
+          data: include('kind' => 'census', 'subject' => 'moved_piece')
         ).and_return(normalized_data)
 
         node = build(:node, :condition, data: input_data)

--- a/spec/models/nodes/census_validation_spec.rb
+++ b/spec/models/nodes/census_validation_spec.rb
@@ -1,0 +1,57 @@
+require 'rails_helper'
+
+# NEW-TDD-RED: DataValidator only knows kind ∈ {unary, relational, position}.
+# Until the validator/grammar accept census, every "is valid" expectation
+# below fails with "has invalid kind: census". The off-board-subject rule
+# additionally pins that spatial keys are rejected for actors that have no
+# board square.
+RSpec.describe 'census condition validation', type: :model do
+  def condition(data)
+    build(:node, :condition, data: data)
+  end
+
+  it 'accepts a board-wide census with no spatial keys' do
+    node = condition(
+      version: 2, kind: 'census', subject: 'allied',
+      subjectFilter: 'pawn', subjectFilterMode: 'include',
+      operator: 'value', comparator: 'greater_than',
+      target: 'exact_number', targetTotal: 6
+    )
+
+    expect(node).to be_valid
+  end
+
+  it 'accepts a region-restricted census carrying spatial keys' do
+    node = condition(
+      version: 2, kind: 'census', subject: 'allied',
+      subjectFilter: 'major', subjectFilterMode: 'include',
+      operator: 'count', comparator: 'equal_to', target: 'exact_number', targetTotal: 2,
+      positionAxis: 'file', positionComparator: 'equal_to', positionTarget: 4
+    )
+
+    expect(node).to be_valid
+  end
+
+  it 'accepts a region-restricted census compared against prior_board_state' do
+    node = condition(
+      version: 2, kind: 'census', subject: 'allied',
+      subjectFilter: 'major', subjectFilterMode: 'include',
+      operator: 'count', comparator: 'greater_than', target: 'prior_board_state',
+      positionAxis: 'rank', positionComparator: 'greater_than_or_equal_to', positionTarget: 5
+    )
+
+    expect(node).to be_valid
+  end
+
+  it 'rejects spatial keys on an off-board subject that has no board square' do
+    node = condition(
+      version: 2, kind: 'census', subject: 'captured_piece',
+      subjectFilter: 'any',
+      operator: 'count', comparator: 'equal_to', target: 'exact_number', targetTotal: 1,
+      positionAxis: 'rank', positionComparator: 'equal_to', positionTarget: 4
+    )
+
+    expect(node).not_to be_valid
+    expect(node.errors[:data]).to include(a_string_matching(/off-board|position|spatial/i))
+  end
+end

--- a/spec/models/nodes/data_normalizer_spec.rb
+++ b/spec/models/nodes/data_normalizer_spec.rb
@@ -140,40 +140,6 @@ RSpec.describe Nodes::DataNormalizer, type: :model do
       expect(normalized).not_to include('targetTotal', 'targetFilterMode')
     end
 
-    it 'resets relational same_piece filters and removes comparison fields' do
-      normalized = described_class.normalize(node_type: 'condition', data: {
-        version: 2,
-        kind: 'relational',
-        subject: 'enemy_moved_piece',
-        subjectFilter: 'pawn',
-        subjectFilterMode: 'exclude',
-        subjectComparisonMetric: 'count',
-        subjectComparator: 'greater_than',
-        subjectComparisonSource: 'exact_number',
-        subjectComparisonSourceTotal: 0,
-        operator: 'same_piece',
-        target: 'captured_piece',
-        targetFilter: 'pawn',
-        targetFilterMode: 'exclude',
-        targetComparisonMetric: 'count',
-        targetComparator: 'greater_than',
-        targetComparisonSource: 'exact_number',
-        targetComparisonSourceTotal: 0
-      })
-
-      expect(normalized).to eq(
-        {
-          'version' => 2,
-          'kind' => 'relational',
-          'subject' => 'enemy_moved_piece',
-          'subjectFilter' => 'any',
-          'operator' => 'same_piece',
-          'target' => 'captured_piece',
-          'targetFilter' => 'any'
-        }
-      )
-    end
-
     it 'removes blank subject comparison fields for relational conditions' do
       normalized = described_class.normalize(node_type: 'condition', data: {
         version: 2,

--- a/spec/models/nodes/data_normalizer_spec.rb
+++ b/spec/models/nodes/data_normalizer_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Nodes::DataNormalizer, type: :model do
     it 'stringifies condition keys' do
       input = {
         version: 2,
-        kind: 'unary',
+        kind: 'census',
         subject: 'moved_piece',
         subjectFilter: 'pawn',
         subjectFilterMode: 'include',
@@ -20,7 +20,7 @@ RSpec.describe Nodes::DataNormalizer, type: :model do
       expect(normalized).to eq(
         {
           'version' => 2,
-          'kind' => 'unary',
+          'kind' => 'census',
           'subject' => 'moved_piece',
           'subjectFilter' => 'pawn',
           'subjectFilterMode' => 'include',
@@ -32,7 +32,7 @@ RSpec.describe Nodes::DataNormalizer, type: :model do
       )
       expect(input).to eq(
         version: 2,
-        kind: 'unary',
+        kind: 'census',
         subject: 'moved_piece',
         subjectFilter: 'pawn',
         subjectFilterMode: 'include',
@@ -43,10 +43,10 @@ RSpec.describe Nodes::DataNormalizer, type: :model do
       )
     end
 
-    it 'removes unary relational-only fields' do
+    it 'removes census relational-only fields' do
       normalized = described_class.normalize(node_type: 'condition', data: {
         version: 2,
-        kind: 'unary',
+        kind: 'census',
         subject: 'moved_piece',
         subjectFilter: 'any',
         subjectFilterMode: 'include',
@@ -69,7 +69,7 @@ RSpec.describe Nodes::DataNormalizer, type: :model do
       expect(normalized).to eq(
         {
           'version' => 2,
-          'kind' => 'unary',
+          'kind' => 'census',
           'subject' => 'moved_piece',
           'subjectFilter' => 'any',
           'operator' => 'value',
@@ -80,10 +80,10 @@ RSpec.describe Nodes::DataNormalizer, type: :model do
       )
     end
 
-    it 'removes target actor fields from exact-number unary targets' do
+    it 'removes target actor fields from exact-number census targets' do
       normalized = described_class.normalize(node_type: 'condition', data: {
         version: 2,
-        kind: 'unary',
+        kind: 'census',
         subject: 'allied',
         subjectFilter: 'any',
         operator: 'value',
@@ -101,10 +101,10 @@ RSpec.describe Nodes::DataNormalizer, type: :model do
       expect(normalized).not_to include('targetFilter', 'targetFilterMode')
     end
 
-    it 'removes actor and numeric target fields from prior-board unary targets' do
+    it 'removes actor and numeric target fields from prior-board census targets' do
       normalized = described_class.normalize(node_type: 'condition', data: {
         version: 2,
-        kind: 'unary',
+        kind: 'census',
         subject: 'allied',
         subjectFilter: 'any',
         operator: 'mobility',
@@ -119,10 +119,10 @@ RSpec.describe Nodes::DataNormalizer, type: :model do
       expect(normalized).not_to include('targetTotal', 'targetFilter', 'targetFilterMode')
     end
 
-    it 'removes numeric and unnecessary filter-mode fields from actor unary targets' do
+    it 'removes numeric and unnecessary filter-mode fields from actor census targets' do
       normalized = described_class.normalize(node_type: 'condition', data: {
         version: 2,
-        kind: 'unary',
+        kind: 'census',
         subject: 'allied',
         subjectFilter: 'any',
         operator: 'value',
@@ -292,7 +292,7 @@ RSpec.describe Nodes::DataNormalizer, type: :model do
     it 'returns a copy and does not mutate the original hash' do
       input = {
         version: 2,
-        kind: 'unary',
+        kind: 'census',
         subject: 'moved_piece',
         subjectFilter: 'pawn',
         subjectFilterMode: 'include',
@@ -307,7 +307,7 @@ RSpec.describe Nodes::DataNormalizer, type: :model do
       expect(normalized).not_to be(input)
       expect(input).to eq(
         version: 2,
-        kind: 'unary',
+        kind: 'census',
         subject: 'moved_piece',
         subjectFilter: 'pawn',
         subjectFilterMode: 'include',

--- a/spec/models/nodes/identity_validation_spec.rb
+++ b/spec/models/nodes/identity_validation_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+
+# NEW-TDD-RED: DataValidator only knows kind ∈ {unary, relational, position}.
+# Until the validator/grammar accept identity, every "is valid" expectation
+# below fails with "has invalid kind: identity". The identity payload is
+# minimal — version, kind, subject, target only — mirroring today's
+# validate_v2_same_piece_relational! constraints.
+RSpec.describe 'identity condition validation', type: :model do
+  def condition(data)
+    build(:node, :condition, data: data)
+  end
+
+  it 'accepts the minimal identity payload' do
+    node = condition(
+      version: 2, kind: 'identity',
+      subject: 'enemy_moved_piece', target: 'captured_piece'
+    )
+
+    expect(node).to be_valid
+  end
+
+  it 'accepts the reversed minimal identity payload' do
+    node = condition(
+      version: 2, kind: 'identity',
+      subject: 'captured_piece', target: 'enemy_moved_piece'
+    )
+
+    expect(node).to be_valid
+  end
+
+  it 'normalizes filter/comparison keys away to the minimal identity payload' do
+    node = condition(
+      version: 2, kind: 'identity',
+      subject: 'enemy_moved_piece', target: 'captured_piece',
+      subjectFilter: 'queen', subjectFilterMode: 'include'
+    )
+
+    expect(node).to be_valid
+    expect(node.data.keys).to match_array(%w[version kind subject target])
+  end
+
+  it 'rejects an identity subject/target pair that is not a same_piece pairing' do
+    node = condition(
+      version: 2, kind: 'identity',
+      subject: 'allied', target: 'enemy'
+    )
+
+    expect(node).not_to be_valid
+  end
+end

--- a/spec/presenters/node_presenter_spec.rb
+++ b/spec/presenters/node_presenter_spec.rb
@@ -91,6 +91,42 @@ RSpec.describe NodePresenter do
       ])
     end
 
+    it 'renders a region census with the position-axis clause' do
+      node = build(:node, :condition, data: {
+        'version' => 2,
+        'kind' => 'census',
+        'subject' => 'allied',
+        'subjectFilter' => 'rook',
+        'subjectFilterMode' => 'include',
+        'positionAxis' => 'rank',
+        'positionComparator' => 'equal_to',
+        'positionTarget' => 5,
+        'operator' => 'count',
+        'comparator' => 'greater_than',
+        'target' => 'exact_number',
+        'targetTotal' => 0
+      })
+
+      chunks = described_class.new(node).condition_preview_chunks
+
+      expect(chunks).to eq([
+        {
+          role: 'side',
+          subject: 'allied',
+          filter: 'rook',
+          filter_mode: 'include',
+          comparison_metric: nil,
+          comparator: nil,
+          comparison_source: nil,
+          comparison_source_total: nil
+        },
+        { role: 'spacer' },
+        { role: 'region', position_axis: 'rank', position_comparator: 'equal_to', position_target: 5 },
+        { role: 'spacer' },
+        { role: 'metric', operator: 'count', comparator: 'greater_than', target_total: 0 }
+      ])
+    end
+
     it 'renders an identity condition as a same-piece sentence' do
       node = build(:node, :condition, data: {
         'version' => 2,

--- a/spec/presenters/node_presenter_spec.rb
+++ b/spec/presenters/node_presenter_spec.rb
@@ -51,10 +51,10 @@ RSpec.describe NodePresenter do
       ])
     end
 
-    it 'preserves unary chunk structure' do
+    it 'preserves whole-board census chunk structure (unary-shaped)' do
       node = build(:node, :condition, data: {
         'version' => 2,
-        'kind' => 'unary',
+        'kind' => 'census',
         'subject' => 'enemy_moved_piece',
         'subjectFilter' => 'pawn',
         'subjectFilterMode' => 'include',
@@ -87,6 +87,43 @@ RSpec.describe NodePresenter do
           target_filter: 'any',
           target_filter_mode: nil,
           target_total: nil
+        }
+      ])
+    end
+
+    it 'renders an identity condition as a same-piece sentence' do
+      node = build(:node, :condition, data: {
+        'version' => 2,
+        'kind' => 'identity',
+        'subject' => 'enemy_moved_piece',
+        'target' => 'captured_piece'
+      })
+
+      chunks = described_class.new(node).condition_preview_chunks
+
+      expect(chunks).to eq([
+        {
+          role: 'side',
+          subject: 'enemy_moved_piece',
+          filter: 'any',
+          filter_mode: nil,
+          comparison_metric: nil,
+          comparator: nil,
+          comparison_source: nil,
+          comparison_source_total: nil
+        },
+        { role: 'spacer' },
+        { role: 'operator', operator: 'same_piece' },
+        { role: 'spacer' },
+        {
+          role: 'side',
+          subject: 'captured_piece',
+          filter: 'any',
+          filter_mode: nil,
+          comparison_metric: nil,
+          comparator: nil,
+          comparison_source: nil,
+          comparison_source_total: nil
         }
       ])
     end

--- a/spec/requests/bot_nodes_controller_spec.rb
+++ b/spec/requests/bot_nodes_controller_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe BotNodesController, type: :request do
           position_y: 200,
           data: {
             version: 2,
-            kind: 'unary',
+            kind: 'census',
             subject: 'moved_piece',
             subjectFilter: 'any',
             subjectFilterMode: 'include',

--- a/spec/services/bot_compiler_spec.rb
+++ b/spec/services/bot_compiler_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe BotCompiler do
       let!(:condition) do
         create(:node, :condition, bot: bot, position_x: 100, position_y: 100, data: {
           version: 2,
-          kind: 'unary',
+          kind: 'census',
           subject: 'moved_piece',
           subjectFilter: 'any',
           subjectFilterMode: 'include',
@@ -51,7 +51,7 @@ RSpec.describe BotCompiler do
             type: 'condition',
             data: {
               version: 2,
-              kind: 'unary',
+              kind: 'census',
               subject: 'moved_piece',
               subjectFilter: 'any',
               operator: 'value',
@@ -86,7 +86,7 @@ RSpec.describe BotCompiler do
       let!(:unary_condition) do
         create(:node, :condition, bot: bot, position_x: 220, position_y: 100, data: {
           version: 2,
-          kind: 'unary',
+          kind: 'census',
           subject: 'enemy_moved_piece',
           subjectFilter: 'pawn',
           subjectFilterMode: 'include',
@@ -96,10 +96,27 @@ RSpec.describe BotCompiler do
           targetFilter: 'any'
         })
       end
+      let!(:region_census_condition) do
+        create(:node, :condition, bot: bot, position_x: 340, position_y: 100, data: {
+          version: 2,
+          kind: 'census',
+          subject: 'allied',
+          subjectFilter: 'rook',
+          subjectFilterMode: 'include',
+          positionAxis: 'rank',
+          positionComparator: 'equal_to',
+          positionTarget: 5,
+          operator: 'count',
+          comparator: 'greater_than',
+          target: 'exact_number',
+          targetTotal: 0
+        })
+      end
 
       before do
         connect_nodes(root, relational_condition)
         connect_nodes(root, unary_condition)
+        connect_nodes(root, region_census_condition)
       end
 
       it 'preserves v2 relational condition payloads in compiled output' do
@@ -123,13 +140,13 @@ RSpec.describe BotCompiler do
         )
       end
 
-      it 'preserves v2 unary condition payloads in compiled output' do
+      it 'preserves v2 census condition payloads in compiled output' do
         compiled = described_class.new(bot).compile
 
         expect(compiled[:nodes][unary_condition.id.to_s][:data]).to eq(
           {
             version: 2,
-            kind: 'unary',
+            kind: 'census',
             subject: 'enemy_moved_piece',
             subjectFilter: 'pawn',
             subjectFilterMode: 'include',
@@ -137,6 +154,27 @@ RSpec.describe BotCompiler do
             comparator: 'equal_to',
             target: 'captured_piece',
             targetFilter: 'any'
+          }
+        )
+      end
+
+      it 'preserves region census spatial keys in compiled output' do
+        compiled = described_class.new(bot).compile
+
+        expect(compiled[:nodes][region_census_condition.id.to_s][:data]).to eq(
+          {
+            version: 2,
+            kind: 'census',
+            subject: 'allied',
+            subjectFilter: 'rook',
+            subjectFilterMode: 'include',
+            operator: 'count',
+            comparator: 'greater_than',
+            target: 'exact_number',
+            targetTotal: 0,
+            positionAxis: 'rank',
+            positionComparator: 'equal_to',
+            positionTarget: 5
           }
         )
       end

--- a/spec/services/bot_compiler_spec.rb
+++ b/spec/services/bot_compiler_spec.rb
@@ -113,10 +113,20 @@ RSpec.describe BotCompiler do
         })
       end
 
+      let!(:identity_condition) do
+        create(:node, :condition, bot: bot, position_x: 460, position_y: 100, data: {
+          version: 2,
+          kind: 'identity',
+          subject: 'enemy_moved_piece',
+          target: 'captured_piece'
+        })
+      end
+
       before do
         connect_nodes(root, relational_condition)
         connect_nodes(root, unary_condition)
         connect_nodes(root, region_census_condition)
+        connect_nodes(root, identity_condition)
       end
 
       it 'preserves v2 relational condition payloads in compiled output' do
@@ -175,6 +185,19 @@ RSpec.describe BotCompiler do
             positionAxis: 'rank',
             positionComparator: 'equal_to',
             positionTarget: 5
+          }
+        )
+      end
+
+      it 'preserves v2 identity condition payloads in compiled output' do
+        compiled = described_class.new(bot).compile
+
+        expect(compiled[:nodes][identity_condition.id.to_s][:data]).to eq(
+          {
+            version: 2,
+            kind: 'identity',
+            subject: 'enemy_moved_piece',
+            target: 'captured_piece'
           }
         )
       end

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -7,6 +7,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+    setupFiles: ['./app/javascript/vitest.setup.js'],
     include: [
       'app/javascript/bot_execution/**/*.test.js',
       'app/javascript/editorV2/**/*.test.js',


### PR DESCRIPTION
Unify unary+position into census, extract same_piece into identity (data migration)

  - census replaces unary and position; region vs whole-board is detected
    by positionAxis presence, not kind. Census targets gain
    prior_board_state and distinct-actor modes alongside exact_number.
  - identity replaces relational same_piece, simplifying the relational
    validator/normalizer.
  - NodePresenter sentence structure single-sourced in SENTENCE_SPEC;
    editor split into per-mode strategies.
  - Irreversible migration rewrites existing rows; down raises
    IrreversibleMigration