### PR TITLE
Worktree condition sentences

### DIFF
--- a/app/javascript/editorV2/EditorActions.js
+++ b/app/javascript/editorV2/EditorActions.js
@@ -5,7 +5,7 @@ import Connection from 'editorV2/models/Connection'
 import generateConditionExamples from 'editorV2/panels/condition_preview/orchestrator'
 import { pipelineStats } from 'editorV2/panels/condition_preview/shared/pipeline_stats'
 import { buildSelectedConditionChain } from 'editorV2/panels/condition_preview/condition_chain_selection'
-import { formatConditionPreview } from 'editorV2/utils/conditionPreviewFormatter'
+import { formatConditionSentence } from 'editorV2/utils/conditionPreviewFormatter'
 import { exampleId } from 'editorV2/utils/example_id'
 
 const CLIPBOARD_STORAGE_KEY = 'editorV2.nodeClipboard'
@@ -157,7 +157,7 @@ class EditorActions {
       return
     }
 
-    const conditionLabels = chain.payloads.map(p => formatConditionPreview(p).text)
+    const conditionLabels = chain.payloads.map(p => formatConditionSentence(p))
     this._runChainGeneration({ chain, conditionLabels, previousExamples: [] })
   }
 

--- a/app/javascript/editorV2/RULES.md
+++ b/app/javascript/editorV2/RULES.md
@@ -21,3 +21,8 @@ branching in the formatter.
 - Wording lives only in the JS formatter (`subjectLabel`,
   `operatorLabel`, `positionAxisPreview`, …). Ruby chunks carry raw
   enum tokens, never display strings.
+- Sentence composition (terse or natural-language) dispatches on the
+  **chunk-role signature**, never on `kind`. `census` alone proves
+  kind ≠ structure — it has two role-shapes (`whole`, `region`) under
+  one kind. A new kind that reuses an existing role-shape must work
+  with no composer change.

--- a/app/javascript/editorV2/__tests__/BoardStatePreview.test.js
+++ b/app/javascript/editorV2/__tests__/BoardStatePreview.test.js
@@ -5,7 +5,11 @@ vi.mock('../panels/condition_preview/orchestrator', () => ({
   default: vi.fn()
 }))
 vi.mock('../utils/conditionPreviewFormatter', () => ({
-  formatConditionPreview: vi.fn()
+  formatConditionSentence: vi.fn(() => [{ text: 'label' }]),
+  renderSentenceSegments: (target, segments) => {
+    target.textContent = segments.map(s => s.text).join('')
+    return target
+  }
 }))
 vi.mock('gameplay/board', () => ({
   default: { squareColor: vi.fn(() => 'light') }
@@ -15,7 +19,7 @@ vi.mock('gameplay/sound', () => ({
 }))
 
 import generateConditionExamples from '../panels/condition_preview/orchestrator.js'
-import { formatConditionPreview } from '../utils/conditionPreviewFormatter.js'
+import { formatConditionSentence } from '../utils/conditionPreviewFormatter.js'
 
 function buildWrap() {
   const wrap = document.createElement('div')
@@ -138,7 +142,7 @@ describe('BoardStatePreview', () => {
     it('shows content and marks isEnabled true when toggling back on in form mode', () => {
       const form = buildConditionFormMock({})
       generateConditionExamples.mockReturnValue({ status: 'no_examples', reason: 'none', examples: [] })
-      formatConditionPreview.mockReturnValue({ text: 'label' })
+      formatConditionSentence.mockReturnValue([{ text: 'label' }])
 
       preview.activate(form)
       preview.toggle()  // off
@@ -153,7 +157,10 @@ describe('BoardStatePreview', () => {
 
   describe('_appendChain', () => {
     it('appends an ordered list with one item per condition label', () => {
-      preview.conditionLabels = ['White pawn advances', 'Black king is in check']
+      preview.conditionLabels = [
+        [{ text: 'White pawn advances' }],
+        [{ text: 'Black king is in check' }]
+      ]
       preview._appendChain()
 
       const chain = preview.content.querySelector('.board-state-preview__chain')
@@ -180,7 +187,7 @@ describe('BoardStatePreview', () => {
     it('calls generateConditionExamples with the payload after debounce and generation timers fire', () => {
       const payload = { subject: 'allied', operator: 'targets' }
       generateConditionExamples.mockReturnValue({ status: 'no_examples', reason: 'none', examples: [] })
-      formatConditionPreview.mockReturnValue({ text: 'label' })
+      formatConditionSentence.mockReturnValue([{ text: 'label' }])
 
       preview._update(payload)
       vi.runAllTimers()

--- a/app/javascript/editorV2/__tests__/conditionPreviewSentence.test.js
+++ b/app/javascript/editorV2/__tests__/conditionPreviewSentence.test.js
@@ -1,0 +1,246 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatConditionSentence } from 'editorV2/utils/conditionPreviewFormatter'
+
+// Render segments to a marked string: the emphasized segment wrapped in **…**.
+// Lets each assertion read exactly like the locked phrasing spec.
+function s(payload) {
+  return formatConditionSentence(payload)
+    .map(seg => (seg.emphasis ? `**${seg.text}**` : seg.text))
+    .join('')
+}
+
+const rel = (extra) => ({ version: 2, kind: 'relational', ...extra })
+const census = (extra) => ({ version: 2, kind: 'census', ...extra })
+const pbs = 'prior_board_state'
+
+describe('formatConditionSentence', () => {
+  describe('relational — bare (implicit count > 0)', () => {
+    it('allied any attack enemy king', () => {
+      expect(s(rel({ subject: 'allied', subjectFilter: 'any', operator: 'attack', target: 'enemy', targetFilter: 'king' })))
+        .toBe('**at least one** of my pieces attacks enemy king')
+    })
+    it('enemy non-pawn attack moved_piece', () => {
+      expect(s(rel({ subject: 'enemy', subjectFilter: 'pawn', subjectFilterMode: 'exclude', operator: 'attack', target: 'moved_piece', targetFilter: 'any' })))
+        .toBe('**at least one** enemy non-pawn attacks my moved piece')
+    })
+    it('allied any defend moved_piece', () => {
+      expect(s(rel({ subject: 'allied', subjectFilter: 'any', operator: 'defend', target: 'moved_piece', targetFilter: 'any' })))
+        .toBe('**at least one** of my pieces defends my moved piece')
+    })
+  })
+
+  describe('relational — count vs exact_number', () => {
+    const c = (n, cmp, extra) => rel({
+      subjectComparisonMetric: 'count', subjectComparator: cmp,
+      subjectComparisonSource: 'exact_number', subjectComparisonSourceTotal: n, ...extra
+    })
+    it('count = 0', () => {
+      expect(s(c(0, 'equal_to', { subject: 'allied', subjectFilter: 'any', operator: 'attack', target: 'enemy', targetFilter: 'king' })))
+        .toBe('**0** of my pieces attack enemy king')
+    })
+    it('enemy pawn count = 0', () => {
+      expect(s(c(0, 'equal_to', { subject: 'enemy', subjectFilter: 'pawn', operator: 'attack', target: 'moved_piece', targetFilter: 'any' })))
+        .toBe('**0** enemy pawns attack my moved piece')
+    })
+    it('count > 1', () => {
+      expect(s(c(1, 'greater_than', { subject: 'allied', subjectFilter: 'any', operator: 'defend', target: 'moved_piece', targetFilter: 'any' })))
+        .toBe('**more than 1** of my pieces defend my moved piece')
+    })
+    it('count = 2', () => {
+      expect(s(c(2, 'equal_to', { subject: 'allied', subjectFilter: 'any', operator: 'attack', target: 'enemy', targetFilter: 'king' })))
+        .toBe('**exactly 2** of my pieces attack enemy king')
+    })
+  })
+
+  describe('relational — count vs prior_board_state (delta)', () => {
+    const d = (cmp, extra) => rel({
+      subjectComparisonMetric: 'count', subjectComparator: cmp, subjectComparisonSource: pbs, ...extra
+    })
+    it('> PBS', () => {
+      expect(s(d('greater_than', { subject: 'allied', subjectFilter: 'knight', operator: 'attack', target: 'enemy', targetFilter: 'queen' })))
+        .toBe('**more** of my knights attack enemy queen than before')
+    })
+    it('< PBS', () => {
+      expect(s(d('less_than', { subject: 'allied', subjectFilter: 'knight', operator: 'defend', target: 'allied', targetFilter: 'king' })))
+        .toBe('**fewer** of my knights defend my king than before')
+    })
+    it('= PBS', () => {
+      expect(s(d('equal_to', { subject: 'enemy', subjectFilter: 'pawn', subjectFilterMode: 'exclude', operator: 'attack', target: 'moved_piece', targetFilter: 'any' })))
+        .toBe('the **same number** of enemy non-pawns attack my moved piece as before')
+    })
+    it('>= PBS', () => {
+      expect(s(d('greater_than_or_equal_to', { subject: 'allied', subjectFilter: 'knight', operator: 'attack', target: 'enemy', targetFilter: 'queen' })))
+        .toBe('**no fewer** of my knights attack enemy queen than before')
+    })
+    it('<= PBS', () => {
+      expect(s(d('less_than_or_equal_to', { subject: 'allied', subjectFilter: 'knight', operator: 'attack', target: 'enemy', targetFilter: 'queen' })))
+        .toBe('**no more** of my knights attack enemy queen than before')
+    })
+    it('adjacent > PBS', () => {
+      expect(s(d('greater_than', { subject: 'allied', subjectFilter: 'any', operator: 'adjacent', target: 'enemy', targetFilter: 'any' })))
+        .toBe('**more** of my pieces are adjacent to enemy pieces than before')
+    })
+  })
+
+  describe('relational — value (target-passive); aggregate_value treated as value', () => {
+    const v = (extra) => rel({
+      subjectComparisonMetric: 'aggregate_value', subjectComparator: 'greater_than', subjectComparisonSource: pbs, ...extra
+    })
+    it('shield, exclude filter', () => {
+      expect(s(v({ subject: 'enemy', subjectFilter: 'pawn', subjectFilterMode: 'exclude', operator: 'shield', target: 'enemy', targetFilter: 'queen' })))
+        .toBe('enemy queen is shielded by **more** non-pawn pieces than before')
+    })
+    it('attack, species filter', () => {
+      expect(s(v({ subject: 'allied', subjectFilter: 'knight', operator: 'attack', target: 'enemy', targetFilter: 'queen' })))
+        .toBe('enemy queen is attacked by **more** knights than before')
+    })
+    it('defend, species filter', () => {
+      expect(s(v({ subject: 'allied', subjectFilter: 'bishop', operator: 'defend', target: 'allied', targetFilter: 'queen' })))
+        .toBe('my queen is defended by **more** bishops than before')
+    })
+    it('shield, exclude filter, allied target', () => {
+      expect(s(v({ subject: 'allied', subjectFilter: 'pawn', subjectFilterMode: 'exclude', operator: 'shield', target: 'allied', targetFilter: 'queen' })))
+        .toBe('my queen is shielded by **more** non-pawn pieces than before')
+    })
+    it('attack, no filter (keeps "value")', () => {
+      expect(s(rel({ subject: 'allied', subjectFilter: 'any', subjectComparisonMetric: 'value', subjectComparator: 'greater_than', subjectComparisonSource: pbs, operator: 'attack', target: 'enemy', targetFilter: 'queen' })))
+        .toBe('enemy queen is attacked by **more** value than before')
+    })
+  })
+
+  describe('identity', () => {
+    it('enemy_moved_piece same_piece captured_piece', () => {
+      expect(s({ version: 2, kind: 'identity', subject: 'enemy_moved_piece', operator: 'same_piece', target: 'captured_piece' }))
+        .toBe('I captured the piece the enemy just moved')
+    })
+  })
+
+  describe('census — whole', () => {
+    it('enemy mobility = 0', () => {
+      expect(s(census({ subject: 'enemy', subjectFilter: 'any', operator: 'mobility', comparator: 'equal_to', target: 'exact_number', targetTotal: 0 })))
+        .toBe('enemy has **0** legal moves')
+    })
+    it('allied value < 5 (aggregate -> total value)', () => {
+      expect(s(census({ subject: 'allied', subjectFilter: 'any', operator: 'value', comparator: 'less_than', target: 'exact_number', targetTotal: 5 })))
+        .toBe('my pieces have **less than 5** total value')
+    })
+    it('allied pawn count = 0', () => {
+      expect(s(census({ subject: 'allied', subjectFilter: 'pawn', operator: 'count', comparator: 'equal_to', target: 'exact_number', targetTotal: 0 })))
+        .toBe('I have **0** pawns')
+    })
+    it('allied rook count > 0', () => {
+      expect(s(census({ subject: 'allied', subjectFilter: 'rook', operator: 'count', comparator: 'greater_than', target: 'exact_number', targetTotal: 0 })))
+        .toBe('I have **at least one** rook')
+    })
+    it('allied pawn count = 3', () => {
+      expect(s(census({ subject: 'allied', subjectFilter: 'pawn', operator: 'count', comparator: 'equal_to', target: 'exact_number', targetTotal: 3 })))
+        .toBe('I have **exactly 3** pawns')
+    })
+    it('captured_piece count > 0 (singular existence)', () => {
+      expect(s(census({ subject: 'captured_piece', subjectFilter: 'any', operator: 'count', comparator: 'greater_than', target: 'exact_number', targetTotal: 0 })))
+        .toBe('I **capture** a piece')
+    })
+    it('captured_piece count = 0', () => {
+      expect(s(census({ subject: 'captured_piece', subjectFilter: 'any', operator: 'count', comparator: 'equal_to', target: 'exact_number', targetTotal: 0 })))
+        .toBe('this move **captures nothing**')
+    })
+    it('moved_piece knight count = 0', () => {
+      expect(s(census({ subject: 'moved_piece', subjectFilter: 'knight', operator: 'count', comparator: 'equal_to', target: 'exact_number', targetTotal: 0 })))
+        .toBe('my moved piece is **not** a knight')
+    })
+    it('moved_piece knight mobility > PBS', () => {
+      expect(s(census({ subject: 'moved_piece', subjectFilter: 'knight', operator: 'mobility', comparator: 'greater_than', target: pbs })))
+        .toBe('my moved knight has **more** legal moves than before')
+    })
+    it('captured_piece value > enemy_captured_piece', () => {
+      expect(s(census({ subject: 'captured_piece', subjectFilter: 'any', operator: 'value', comparator: 'greater_than', target: 'enemy_captured_piece' })))
+        .toBe('I captured **more** value than the enemy just did')
+    })
+    it('allied value > PBS (promotion idiom)', () => {
+      expect(s(census({ subject: 'allied', subjectFilter: 'any', operator: 'value', comparator: 'greater_than', target: pbs })))
+        .toBe('I **promoted** a pawn')
+    })
+    it('allied value < PBS (capture idiom)', () => {
+      expect(s(census({ subject: 'allied', subjectFilter: 'any', operator: 'value', comparator: 'less_than', target: pbs })))
+        .toBe('I **captured** a piece')
+    })
+  })
+
+  describe('census — region', () => {
+    it('square equality (count > 0): bold the square', () => {
+      expect(s(census({ subject: 'allied', subjectFilter: 'bishop', positionAxis: 'square', positionComparator: 'equal_to', positionTarget: 7, operator: 'count', comparator: 'greater_than', target: 'exact_number', targetTotal: 0 })))
+        .toBe('I have at least one bishop on **h1**')
+    })
+    it('rank equality + count > PBS: bold the delta', () => {
+      expect(s(census({ subject: 'allied', subjectFilter: 'rook', positionAxis: 'rank', positionComparator: 'equal_to', positionTarget: 5, operator: 'count', comparator: 'greater_than', target: pbs })))
+        .toBe('**more** of my rooks are on rank 5 than before')
+    })
+    it('file equality + count < PBS', () => {
+      expect(s(census({ subject: 'enemy', subjectFilter: 'any', positionAxis: 'file', positionComparator: 'equal_to', positionTarget: 4, operator: 'count', comparator: 'less_than', target: pbs })))
+        .toBe('**fewer** enemy pieces are on the d-file than before')
+    })
+    it('rank inequality (>=): bold the bounds', () => {
+      expect(s(census({ subject: 'allied', subjectFilter: 'rook', positionAxis: 'rank', positionComparator: 'greater_than_or_equal_to', positionTarget: 7, operator: 'count', comparator: 'greater_than', target: 'exact_number', targetTotal: 0 })))
+        .toBe('I have at least one rook between ranks **7 & 8**')
+    })
+    it('rank equality (non-delta): bold the rank locator', () => {
+      expect(s(census({ subject: 'allied', subjectFilter: 'rook', positionAxis: 'rank', positionComparator: 'equal_to', positionTarget: 5, operator: 'count', comparator: 'greater_than', target: 'exact_number', targetTotal: 0 })))
+        .toBe('I have at least one rook on **rank 5**')
+    })
+    it('file equality (non-delta): bold the file locator', () => {
+      expect(s(census({ subject: 'allied', subjectFilter: 'rook', positionAxis: 'file', positionComparator: 'equal_to', positionTarget: 3, operator: 'count', comparator: 'greater_than', target: 'exact_number', targetTotal: 0 })))
+        .toBe('I have at least one rook on the **c-file**')
+    })
+  })
+
+  describe('review fixes (A–D, agreement)', () => {
+    it('allied-collection mobility uses "have" not "has"', () => {
+      expect(s(census({ subject: 'allied', subjectFilter: 'any', operator: 'mobility', comparator: 'greater_than', target: pbs })))
+        .toBe('my pieces have **more** legal moves than before')
+    })
+    it('value = capture family uses "as"', () => {
+      expect(s(census({ subject: 'captured_piece', subjectFilter: 'any', operator: 'value', comparator: 'equal_to', target: 'enemy_captured_piece' })))
+        .toBe('I captured **equal** value as the enemy just did')
+    })
+    it('value = PBS, no filter', () => {
+      expect(s(census({ subject: 'allied', subjectFilter: 'any', operator: 'value', comparator: 'equal_to', target: pbs })))
+        .toBe('my team value is **not changed**')
+    })
+    it('value = PBS, exclude-king filter', () => {
+      expect(s(census({ subject: 'allied', subjectFilter: 'king', subjectFilterMode: 'exclude', operator: 'value', comparator: 'equal_to', target: pbs })))
+        .toBe('the value of my non-king pieces is **not changed**')
+    })
+    it('exclude major → "non-major pieces" (no doubled noun)', () => {
+      expect(s(census({ subject: 'enemy', subjectFilter: 'major', subjectFilterMode: 'exclude', operator: 'count', comparator: 'equal_to', target: 'exact_number', targetTotal: 0 })))
+        .toBe('enemy has **0** non-major pieces')
+    })
+    it('exclude major, relational value target-passive', () => {
+      expect(s(rel({ subject: 'allied', subjectFilter: 'major', subjectFilterMode: 'exclude', subjectComparisonMetric: 'value', subjectComparator: 'greater_than', subjectComparisonSource: pbs, operator: 'attack', target: 'enemy', targetFilter: 'queen' })))
+        .toBe('enemy queen is attacked by **more** non-major pieces than before')
+    })
+  })
+
+  describe('rare value/PBS guards (#3, #4)', () => {
+    it('relational value = PBS, exclude filter', () => {
+      expect(s(rel({ subject: 'enemy', subjectFilter: 'pawn', subjectFilterMode: 'exclude', subjectComparisonMetric: 'value', subjectComparator: 'equal_to', subjectComparisonSource: pbs, operator: 'shield', target: 'enemy', targetFilter: 'queen' })))
+        .toBe('enemy queen is shielded by the **same** non-pawn pieces as before')
+    })
+    it('relational value = PBS, no filter', () => {
+      expect(s(rel({ subject: 'allied', subjectFilter: 'any', subjectComparisonMetric: 'value', subjectComparator: 'equal_to', subjectComparisonSource: pbs, operator: 'attack', target: 'enemy', targetFilter: 'queen' })))
+        .toBe('enemy queen is attacked by the **same** value as before')
+    })
+    it('census value >= PBS', () => {
+      expect(s(census({ subject: 'allied', subjectFilter: 'any', operator: 'value', comparator: 'greater_than_or_equal_to', target: pbs })))
+        .toBe('my team value is **not lower** than before')
+    })
+    it('census value <= PBS', () => {
+      expect(s(census({ subject: 'allied', subjectFilter: 'any', operator: 'value', comparator: 'less_than_or_equal_to', target: pbs })))
+        .toBe('my team value is **not higher** than before')
+    })
+    it('census value >= PBS, exclude-king filter', () => {
+      expect(s(census({ subject: 'allied', subjectFilter: 'king', subjectFilterMode: 'exclude', operator: 'value', comparator: 'greater_than_or_equal_to', target: pbs })))
+        .toBe('the value of my non-king pieces is **not lower** than before')
+    })
+  })
+})

--- a/app/javascript/editorV2/panels/BoardStatePreview.js
+++ b/app/javascript/editorV2/panels/BoardStatePreview.js
@@ -1,5 +1,5 @@
 import generateConditionExamples from 'editorV2/panels/condition_preview/orchestrator'
-import { formatConditionPreview } from 'editorV2/utils/conditionPreviewFormatter'
+import { formatConditionSentence, renderSentenceSegments } from 'editorV2/utils/conditionPreviewFormatter'
 import { exampleId } from 'editorV2/utils/example_id'
 import Board from 'gameplay/board'
 import Sound from 'gameplay/sound'
@@ -209,7 +209,7 @@ class BoardStatePreview {
     this._applyPreview({ status: 'loading', reason: 'Computing preview…', examples: [] })
     this._generationTimer = setTimeout(() => {
       const preview = generateConditionExamples(payload)
-      preview.conditionLabels = [formatConditionPreview(payload).text]
+      preview.conditionLabels = [formatConditionSentence(payload)]
       this._applyPreview(preview)
     }, 0)
   }
@@ -455,7 +455,7 @@ class BoardStatePreview {
     this.conditionLabels.forEach(label => {
       const item = document.createElement('li')
       item.className = 'board-state-preview__chain-item'
-      item.textContent = label
+      renderSentenceSegments(item, label)
       chain.appendChild(item)
     })
     this.content.appendChild(chain)

--- a/app/javascript/editorV2/panels/ConditionForm.js
+++ b/app/javascript/editorV2/panels/ConditionForm.js
@@ -1,4 +1,4 @@
-import { formatConditionPreview } from 'editorV2/utils/conditionPreviewFormatter'
+import { renderConditionSentence } from 'editorV2/utils/conditionPreviewFormatter'
 import { pillInputs } from 'editorV2/panels/condition_form/dom_helpers'
 import RelationalMode from 'editorV2/panels/condition_form/relational_mode'
 import CensusMode from 'editorV2/panels/condition_form/census_mode'
@@ -278,7 +278,7 @@ class ConditionForm {
     this.modes[this.state.mode].render(this.state[this.state.mode], fields)
 
     if (fields.formulationPreview) {
-      fields.formulationPreview.textContent = formatConditionPreview(this.buildPayload()).text
+      renderConditionSentence(fields.formulationPreview, this.buildPayload())
     }
 
     if (this.onStateChange) { this.onStateChange(this.buildPayload()) }

--- a/app/javascript/editorV2/utils/conditionPreviewFormatter.js
+++ b/app/javascript/editorV2/utils/conditionPreviewFormatter.js
@@ -295,3 +295,301 @@ export function formatConditionPreviewElement(element) {
     chunkElement.textContent = formatConditionPreviewChunk(parseChunkDataset(chunkElement))
   })
 }
+
+// ── Natural-language sentence composer ───────────────────────────────────────
+// Statement-voice rendering as ordered segments [{ text, emphasis? }]. Dispatch
+// is on the chunk-role signature (never node kind). See editorV2/RULES.md.
+
+const SINGULAR_ACTOR = {
+  moved_piece: 'my moved piece',
+  captured_piece: 'my capture',
+  enemy_moved_piece: "enemy's just-moved piece",
+  enemy_captured_piece: "enemy's just-captured piece"
+}
+const SPECIES = {
+  king: 'king', queen: 'queen', rook: 'rook', bishop: 'bishop',
+  knight: 'knight', pawn: 'pawn', major: 'major piece', minor: 'minor piece'
+}
+const ACTIVE_VERB = {
+  attack: ['attacks', 'attack'],
+  defend: ['defends', 'defend'],
+  cover: ['covers', 'cover'],
+  targets: ['targets', 'target'],
+  adjacent: ['is adjacent to', 'are adjacent to']
+}
+const PASSIVE_VERB = { attack: 'attacked', defend: 'defended', shield: 'shielded' }
+
+function noun(filter, filterMode, plural) {
+  if (!filter || filter === 'any') { return plural ? 'pieces' : 'piece' }
+  if (filterMode === 'exclude') {
+    if (filter === 'major' || filter === 'minor') { return `non-${filter} ${plural ? 'pieces' : 'piece'}` }
+    return plural ? `non-${filter}s` : `non-${filter}`
+  }
+  const base = SPECIES[filter] || filter
+  return plural ? `${base}s` : base
+}
+
+// Value/relation "pieces" phrase: exclude → "non-X pieces", species → plural,
+// no filter → "value". Shared by relational target-passive and census value.
+function filteredPieces(filter, filterMode) {
+  if (!filter || filter === 'any') { return 'value' }
+  if (filterMode === 'exclude') { return `non-${filter} pieces` }
+  return `${SPECIES[filter] || filter}s`
+}
+
+// Quantifier word/phrase + whether it carries emphasis, for count comparisons.
+function quantify({ comparator, source, total }) {
+  if (source === 'prior_board_state') {
+    switch (comparator) {
+      case 'greater_than': return { q: 'more', delta: true }
+      case 'less_than': return { q: 'fewer', delta: true }
+      case 'greater_than_or_equal_to': return { q: 'no fewer', delta: true }
+      case 'less_than_or_equal_to': return { q: 'no more', delta: true }
+      default: return { q: 'same number', delta: true, same: true }
+    }
+  }
+  const n = Number(total)
+  switch (comparator) {
+    case 'equal_to': return { q: n === 0 ? '0' : `exactly ${n}` }
+    case 'greater_than': return { q: n === 0 ? 'at least one' : `more than ${n}`, atLeastOne: n === 0 }
+    case 'greater_than_or_equal_to': return { q: `${n} or more` }
+    case 'less_than_or_equal_to': return { q: `${n} or fewer` }
+    case 'less_than': return { q: `fewer than ${n}` }
+    default: return { q: String(n) }
+  }
+}
+
+// "<Q> of my <plural>" / "<Q> enemy <noun>" — the locked of-my / enemy asymmetry.
+function countedGroup(token, filter, filterMode, info) {
+  if (token === 'allied') { return `of my ${noun(filter, filterMode, true)}` }
+  return `enemy ${noun(filter, filterMode, !info.atLeastOne)}`
+}
+
+function actorNoun(token, filter, filterMode) {
+  if (SINGULAR_ACTOR[token]) {
+    const base = SINGULAR_ACTOR[token]
+    if (filter && filter !== 'any' && base.endsWith('piece')) {
+      return base.replace(/piece$/, SPECIES[filter] || filter)
+    }
+    return base
+  }
+  const poss = token === 'allied' ? 'my' : 'enemy'
+  if (!filter || filter === 'any') { return `${poss} pieces` }
+  if (filterMode === 'exclude') { return `${poss} non-${filter} pieces` }
+  return `${poss} ${SPECIES[filter] || filter}`
+}
+
+function tail(info) {
+  if (!info.delta) { return '' }
+  return info.same ? ' as before' : ' than before'
+}
+
+function composeRelational(d) {
+  if (d.operator === 'same_piece') {
+    return [{ text: 'I captured the piece the enemy just moved' }]
+  }
+  const targetNP = actorNoun(d.target, d.targetFilter, d.targetFilterMode)
+  const metric = d.subjectComparisonMetric
+
+  if (metric && metric !== 'count') {
+    // value (incl. aggregate_value/individual_value) → target-passive
+    const info = quantify({
+      comparator: d.subjectComparator, source: d.subjectComparisonSource,
+      total: d.subjectComparisonSourceTotal
+    })
+    const pieces = filteredPieces(d.subjectFilter, d.subjectFilterMode)
+    const passive = PASSIVE_VERB[d.operator] || PASSIVE_VERB.attack
+    if (info.same) {
+      return [
+        { text: `${targetNP} is ${passive} by the ` },
+        { text: 'same', emphasis: true },
+        { text: ` ${pieces} as before` }
+      ]
+    }
+    return [
+      { text: `${targetNP} is ${passive} by ` },
+      { text: info.q, emphasis: true },
+      { text: ` ${pieces}${tail(info)}` }
+    ]
+  }
+
+  // count metric, or bare condition (implicit count > 0)
+  const info = metric
+    ? quantify({ comparator: d.subjectComparator, source: d.subjectComparisonSource, total: d.subjectComparisonSourceTotal })
+    : { q: 'at least one', atLeastOne: true }
+  const verbPair = ACTIVE_VERB[d.operator] || ACTIVE_VERB.attack
+  const verb = info.atLeastOne ? verbPair[0] : verbPair[1]
+  const group = countedGroup(d.subject, d.subjectFilter, d.subjectFilterMode, info)
+
+  if (info.same) {
+    return [
+      { text: 'the ' },
+      { text: 'same number', emphasis: true },
+      { text: ` of ${d.subject === 'allied' ? 'my' : 'enemy'} ${noun(d.subjectFilter, d.subjectFilterMode, true)} ${verbPair[1]} ${targetNP} as before` }
+    ]
+  }
+  return [
+    { text: info.q, emphasis: true },
+    { text: ` ${group} ${verb} ${targetNP}${tail(info)}` }
+  ]
+}
+
+function valueClause(comparator, n) {
+  switch (comparator) {
+    case 'less_than': return `less than ${n}`
+    case 'greater_than': return `more than ${n}`
+    case 'equal_to': return `exactly ${n}`
+    case 'greater_than_or_equal_to': return `${n} or more`
+    case 'less_than_or_equal_to': return `${n} or fewer`
+    default: return String(n)
+  }
+}
+
+function composeCensusWhole(d) {
+  const metric = d.operator
+  const collection = isCollectionSubject(d.subject)
+
+  if (metric === 'mobility') {
+    const subj = collection
+      ? (d.subject === 'enemy' ? 'enemy' : 'my pieces')
+      : actorNoun(d.subject, d.subjectFilter, d.subjectFilterMode)
+    const verb = collection && d.subject === 'allied' ? 'have' : 'has'
+    const info = quantify({ comparator: d.comparator, source: d.target, total: d.targetTotal })
+    return [
+      { text: `${subj} ${verb} ` },
+      { text: info.q, emphasis: true },
+      { text: ` legal moves${tail(info)}` }
+    ]
+  }
+
+  if (metric === 'value') {
+    if (d.target === 'prior_board_state') {
+      if (d.comparator === 'greater_than') {
+        return [{ text: 'I ' }, { text: 'promoted', emphasis: true }, { text: ' a pawn' }]
+      }
+      if (d.comparator === 'less_than') {
+        return [{ text: 'I ' }, { text: 'captured', emphasis: true }, { text: ' a piece' }]
+      }
+      const poss = d.subject === 'enemy' ? "the enemy's" : 'my'
+      const filtered = d.subjectFilter && d.subjectFilter !== 'any'
+      const lead = filtered
+        ? `the value of ${poss} ${filteredPieces(d.subjectFilter, d.subjectFilterMode)} is `
+        : `${poss} team value is `
+      const phrase = d.comparator === 'greater_than_or_equal_to' ? 'not lower'
+        : d.comparator === 'less_than_or_equal_to' ? 'not higher'
+        : 'not changed'
+      const suffix = d.comparator === 'equal_to' ? '' : ' than before'
+      return [{ text: lead }, { text: phrase, emphasis: true }, { text: suffix }]
+    }
+    if (SINGULAR_ACTOR[d.target]) {
+      const word = d.comparator === 'less_than' ? 'less'
+        : d.comparator === 'greater_than_or_equal_to' ? 'no less'
+        : d.comparator === 'less_than_or_equal_to' ? 'no more'
+        : d.comparator === 'equal_to' ? 'equal' : 'more'
+      const connector = d.comparator === 'equal_to' ? 'as' : 'than'
+      return [
+        { text: 'I captured ' },
+        { text: word, emphasis: true },
+        { text: ` value ${connector} the enemy just did` }
+      ]
+    }
+    return [
+      { text: `${d.subject === 'enemy' ? 'enemy' : 'my'} pieces have ` },
+      { text: valueClause(d.comparator, Number(d.targetTotal)), emphasis: true },
+      { text: ' total value' }
+    ]
+  }
+
+  // count
+  if (SINGULAR_ACTOR[d.subject]) {
+    const exists = d.comparator === 'greater_than'
+    if (d.subjectFilter && d.subjectFilter !== 'any') {
+      const sp = SPECIES[d.subjectFilter] || d.subjectFilter
+      return exists
+        ? [{ text: `${SINGULAR_ACTOR[d.subject]} ` }, { text: 'is', emphasis: true }, { text: ` a ${sp}` }]
+        : [{ text: `${SINGULAR_ACTOR[d.subject]} is ` }, { text: 'not', emphasis: true }, { text: ` a ${sp}` }]
+    }
+    if (exists) { return [{ text: 'I ' }, { text: 'capture', emphasis: true }, { text: ' a piece' }] }
+    return [{ text: 'this move ' }, { text: 'captures nothing', emphasis: true }]
+  }
+  const info = quantify({ comparator: d.comparator, source: d.target, total: d.targetTotal })
+  const n = noun(d.subjectFilter, d.subjectFilterMode, !info.atLeastOne)
+  return [
+    { text: d.subject === 'enemy' ? 'enemy has ' : 'I have ' },
+    { text: info.q, emphasis: true },
+    { text: ` ${n}` }
+  ]
+}
+
+const FILES = 'abcdefgh'
+
+// { prefix, bound } — only `bound` is emphasized; "on"/"the"/"between" stay plain.
+function regionPhrase(d) {
+  const cmp = d.positionComparator
+  const t = Number(d.positionTarget)
+  if (d.positionAxis === 'square') {
+    return { prefix: 'on ', bound: `${FILES[t % 8]}${Math.floor(t / 8) + 1}` }
+  }
+  if (d.positionAxis === 'file') {
+    const L = FILES[t - 1]
+    if (cmp === 'equal_to') { return { prefix: 'on the ', bound: `${L}-file` } }
+    if (cmp === 'greater_than_or_equal_to') { return { prefix: 'between files ', bound: `${L} & h` } }
+    return { prefix: 'between files ', bound: `a & ${L}` }
+  }
+  if (cmp === 'equal_to') { return { prefix: 'on ', bound: `rank ${t}` } }
+  if (cmp === 'greater_than_or_equal_to') { return { prefix: 'between ranks ', bound: `${t} & 8` } }
+  return { prefix: 'between ranks ', bound: `1 & ${t}` }
+}
+
+function composeCensusRegion(d) {
+  const region = regionPhrase(d)
+  if (d.target === 'prior_board_state') {
+    const info = quantify({ comparator: d.comparator, source: 'prior_board_state' })
+    const group = d.subject === 'allied'
+      ? `of my ${noun(d.subjectFilter, d.subjectFilterMode, true)}`
+      : `enemy ${noun(d.subjectFilter, d.subjectFilterMode, true)}`
+    return [
+      { text: info.q, emphasis: true },
+      { text: ` ${group} are ${region.prefix}${region.bound} than before` }
+    ]
+  }
+  const info = quantify({ comparator: d.comparator, source: d.target, total: d.targetTotal })
+  const n = noun(d.subjectFilter, d.subjectFilterMode, !info.atLeastOne)
+  const lead = d.subject === 'enemy' ? 'enemy has ' : 'I have '
+  return [
+    { text: `${lead}${info.q} ${n} ${region.prefix}` },
+    { text: region.bound, emphasis: true }
+  ]
+}
+
+export function formatConditionSentence(nodeData = {}) {
+  const spec = sentenceSpec()[nodeData.kind]
+  if (!spec) { return [{ text: '[invalid condition]' }] }
+  const chunks = sentenceDescriptors(spec, nodeData).map(dscr => buildSentenceChunk(dscr, nodeData))
+  const signature = chunks.map(c => c.role).join('|')
+  switch (signature) {
+    case 'side|operator|side': return composeRelational(nodeData)
+    case 'side|operator|comparison': return composeCensusWhole(nodeData)
+    case 'side|region|metric': return composeCensusRegion(nodeData)
+    default: return [{ text: '[invalid condition]' }]
+  }
+}
+
+// Shared DOM render: segments → text nodes + <strong>, no innerHTML.
+export function renderSentenceSegments(target, segments) {
+  target.textContent = ''
+  for (const seg of segments) {
+    if (seg.emphasis) {
+      const strong = document.createElement('strong')
+      strong.textContent = seg.text
+      target.appendChild(strong)
+    } else {
+      target.appendChild(document.createTextNode(seg.text))
+    }
+  }
+  return target
+}
+
+export function renderConditionSentence(target, nodeData) {
+  return renderSentenceSegments(target, formatConditionSentence(nodeData))
+}

--- a/app/javascript/gameplay/replay_trace_view.js
+++ b/app/javascript/gameplay/replay_trace_view.js
@@ -1,5 +1,5 @@
 import Board from "gameplay/board"
-import { formatConditionPreview } from "editorV2/utils/conditionPreviewFormatter"
+import { renderConditionSentence } from "editorV2/utils/conditionPreviewFormatter"
 
 class ReplayTraceView {
   constructor({ tracePanelElement, traceSummaryElement, traceBranchesElement }) {
@@ -173,7 +173,11 @@ class ReplayTraceView {
 
     const text = document.createElement('span')
     text.className = 'trace-tree-node__text'
-    text.innerText = this.conditionSummary(node.data)
+    if (Number(node.data?.version || 1) === 2) {
+      renderConditionSentence(text, node.data)
+    } else {
+      text.innerText = this.conditionSummary(node.data)
+    }
     header.appendChild(text)
 
     if (isShared && executionIndex !== null) header.appendChild(this.hitBadge(executionIndex))
@@ -254,7 +258,6 @@ class ReplayTraceView {
   }
 
   conditionSummary(data) {
-    if (Number(data.version || 1) === 2) { return formatConditionPreview(data).text }
     const relationLabel = this.relationLabel(data.relation)
     const relationSpecifier = data.relationSpecifier && data.relationSpecifier !== 'any'
       ? ` ${this.specifierSummary(data.relationSpecifier, data.relationSpecifierMode)}`


### PR DESCRIPTION
Natural-language condition sentences

  Renders V2 condition nodes as plain-English, statement-voice sentences instead of the terse subject : operator : target form, with the key discriminating word emphasized for scannability.

  Before: Enemy pawn (count = 0) : attack : Allied queen
  After: 0 enemy pawns attack my moved piece

  What changed

  - formatConditionSentence(nodeData) — returns ordered segments [{text, emphasis?}] (one bold span). Dispatches on the chunk-role signature (side|operator|side, side|operator|comparison, side|region|metric), never
   on node kind, reusing the existing SENTENCE_SPEC chunk assembly. formatConditionPreview and its terse .text identity string are left untouched.
  - Shared renderSentenceSegments / renderConditionSentence DOM helpers — text nodes + <strong>, no innerHTML.
  - Three surfaces switched to the sentence: the editor "Current Condition" line (ConditionForm), preview & chain labels (BoardStatePreview/EditorActions), and the replay "why this move" branch labels
  (replay_trace_view, legacy v1 path preserved).
  - RULES.md note: composition dispatches on role-shape, never kind (census proves kind ≠ structure).

  Phasing

  The canvas condition-node box (chunk-rendered) intentionally stays terse this phase — a known interim split, to be addressed in a follow-up.

  Testing

  - 53-case oracle validated against the forward-proposition benchmark payloads and a real 145-condition production bot.
  - Covers every signature, quantifier, operator/metric idiom, region form, and the rare value =/≥/≤ vs PBS and exclude major/minor edges.
  - BoardStatePreview.test.js mock updated for the new exports. Full JS suite green (1471 passed, 0 failures).
