### PR TITLE
Invalidate compiled_program in kind migration; add match-runner smoke…

### DIFF
--- a/RULES_INDEX.md
+++ b/RULES_INDEX.md
@@ -1,2 +1,3 @@
 - app/javascript/editorV2/panels/condition_preview/
 - app/javascript/bot_execution/
+- app/models/

--- a/app/javascript/gameplay/__fixtures__/smoke_black_compiled_program.json
+++ b/app/javascript/gameplay/__fixtures__/smoke_black_compiled_program.json
@@ -1,0 +1,926 @@
+{
+  "version": 1,
+  "root": "113027",
+  "nodes": {
+    "113091": {
+      "id": "113091",
+      "type": "score",
+      "data": {
+        "actionType": "add",
+        "value": 10000
+      },
+      "children": []
+    },
+    "113093": {
+      "id": "113093",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "relational",
+        "subject": "allied",
+        "subjectFilter": "any",
+        "operator": "attack",
+        "target": "enemy",
+        "targetFilter": "king",
+        "targetFilterMode": "include"
+      },
+      "children": [
+        "113091"
+      ]
+    },
+    "113092": {
+      "id": "113092",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "census",
+        "subject": "enemy",
+        "subjectFilter": "any",
+        "operator": "mobility",
+        "comparator": "greater_than",
+        "target": "exact_number",
+        "targetTotal": 0
+      },
+      "children": [
+        "113093"
+      ]
+    },
+    "113038": {
+      "id": "113038",
+      "type": "score",
+      "data": {
+        "actionType": "subtract",
+        "value": 5
+      },
+      "children": []
+    },
+    "113040": {
+      "id": "113040",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "relational",
+        "subject": "moved_piece",
+        "subjectFilter": "king",
+        "subjectFilterMode": "include",
+        "operator": "adjacent",
+        "target": "allied",
+        "targetFilter": "rook",
+        "targetFilterMode": "include",
+        "targetComparisonMetric": "count",
+        "targetComparator": "equal_to",
+        "targetComparisonSource": "exact_number",
+        "targetComparisonSourceTotal": 0
+      },
+      "children": [
+        "113038"
+      ]
+    },
+    "113032": {
+      "id": "113032",
+      "type": "score",
+      "data": {
+        "actionType": "add",
+        "value": 10
+      },
+      "children": []
+    },
+    "113035": {
+      "id": "113035",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "relational",
+        "subject": "moved_piece",
+        "subjectFilter": "bishop",
+        "subjectFilterMode": "include",
+        "operator": "adjacent",
+        "target": "allied",
+        "targetFilter": "king",
+        "targetFilterMode": "include",
+        "targetComparisonMetric": "count",
+        "targetComparator": "less_than",
+        "targetComparisonSource": "prior_board_state"
+      },
+      "children": [
+        "113032"
+      ]
+    },
+    "113080": {
+      "id": "113080",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "relational",
+        "subject": "moved_piece",
+        "subjectFilter": "bishop",
+        "subjectFilterMode": "include",
+        "operator": "adjacent",
+        "target": "allied",
+        "targetFilter": "queen",
+        "targetFilterMode": "include",
+        "targetComparisonMetric": "count",
+        "targetComparator": "less_than",
+        "targetComparisonSource": "prior_board_state"
+      },
+      "children": [
+        "113032"
+      ]
+    },
+    "113030": {
+      "id": "113030",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "relational",
+        "subject": "moved_piece",
+        "subjectFilter": "knight",
+        "subjectFilterMode": "include",
+        "operator": "adjacent",
+        "target": "allied",
+        "targetFilter": "rook",
+        "targetFilterMode": "include",
+        "targetComparisonMetric": "count",
+        "targetComparator": "less_than",
+        "targetComparisonSource": "prior_board_state"
+      },
+      "children": [
+        "113032"
+      ]
+    },
+    "113034": {
+      "id": "113034",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "census",
+        "subject": "moved_piece",
+        "subjectFilter": "any",
+        "operator": "mobility",
+        "comparator": "greater_than",
+        "target": "prior_board_state"
+      },
+      "children": [
+        "113035",
+        "113080",
+        "113030"
+      ]
+    },
+    "113037": {
+      "id": "113037",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "relational",
+        "subject": "enemy",
+        "subjectFilter": "any",
+        "subjectComparisonMetric": "count",
+        "subjectComparator": "equal_to",
+        "subjectComparisonSource": "exact_number",
+        "subjectComparisonSourceTotal": 0,
+        "operator": "attack",
+        "target": "moved_piece",
+        "targetFilter": "any"
+      },
+      "children": [
+        "113034"
+      ]
+    },
+    "113031": {
+      "id": "113031",
+      "type": "score",
+      "data": {
+        "actionType": "add",
+        "value": 12
+      },
+      "children": []
+    },
+    "113028": {
+      "id": "113028",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "relational",
+        "subject": "enemy",
+        "subjectFilter": "any",
+        "subjectComparisonMetric": "count",
+        "subjectComparator": "equal_to",
+        "subjectComparisonSource": "exact_number",
+        "subjectComparisonSourceTotal": 0,
+        "operator": "attack",
+        "target": "allied",
+        "targetFilter": "rook",
+        "targetFilterMode": "include"
+      },
+      "children": [
+        "113031"
+      ]
+    },
+    "113029": {
+      "id": "113029",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "relational",
+        "subject": "enemy",
+        "subjectFilter": "any",
+        "subjectComparisonMetric": "count",
+        "subjectComparator": "equal_to",
+        "subjectComparisonSource": "prior_board_state",
+        "operator": "attack",
+        "target": "moved_piece",
+        "targetFilter": "king",
+        "targetFilterMode": "include"
+      },
+      "children": [
+        "113028"
+      ]
+    },
+    "113033": {
+      "id": "113033",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "relational",
+        "subject": "allied",
+        "subjectFilter": "rook",
+        "subjectFilterMode": "include",
+        "subjectComparisonMetric": "count",
+        "subjectComparator": "equal_to",
+        "subjectComparisonSource": "prior_board_state",
+        "operator": "defend",
+        "target": "moved_piece",
+        "targetFilter": "king",
+        "targetFilterMode": "include"
+      },
+      "children": [
+        "113029"
+      ]
+    },
+    "113036": {
+      "id": "113036",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "relational",
+        "subject": "moved_piece",
+        "subjectFilter": "king",
+        "subjectFilterMode": "include",
+        "operator": "adjacent",
+        "target": "allied",
+        "targetFilter": "rook",
+        "targetFilterMode": "include",
+        "targetComparisonMetric": "count",
+        "targetComparator": "equal_to",
+        "targetComparisonSource": "exact_number",
+        "targetComparisonSourceTotal": 1
+      },
+      "children": [
+        "113033"
+      ]
+    },
+    "113039": {
+      "id": "113039",
+      "type": "organizer",
+      "data": {
+        "title": "castling"
+      },
+      "children": [
+        "113040",
+        "113037",
+        "113036"
+      ]
+    },
+    "113065": {
+      "id": "113065",
+      "type": "score",
+      "data": {
+        "actionType": "add",
+        "value": 30
+      },
+      "children": []
+    },
+    "113064": {
+      "id": "113064",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "relational",
+        "subject": "enemy",
+        "subjectFilter": "pawn",
+        "subjectFilterMode": "include",
+        "subjectComparisonMetric": "count",
+        "subjectComparator": "equal_to",
+        "subjectComparisonSource": "exact_number",
+        "subjectComparisonSourceTotal": 0,
+        "operator": "attack",
+        "target": "moved_piece",
+        "targetFilter": "any"
+      },
+      "children": [
+        "113065"
+      ]
+    },
+    "113067": {
+      "id": "113067",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "relational",
+        "subject": "allied",
+        "subjectFilter": "any",
+        "operator": "defend",
+        "target": "moved_piece",
+        "targetFilter": "any"
+      },
+      "children": [
+        "113064"
+      ]
+    },
+    "113066": {
+      "id": "113066",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "relational",
+        "subject": "enemy",
+        "subjectFilter": "any",
+        "subjectComparisonMetric": "count",
+        "subjectComparator": "equal_to",
+        "subjectComparisonSource": "exact_number",
+        "subjectComparisonSourceTotal": 0,
+        "operator": "attack",
+        "target": "moved_piece",
+        "targetFilter": "any"
+      },
+      "children": [
+        "113065"
+      ]
+    },
+    "113068": {
+      "id": "113068",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "relational",
+        "subject": "moved_piece",
+        "subjectFilter": "knight",
+        "subjectFilterMode": "include",
+        "operator": "attack",
+        "target": "enemy",
+        "targetFilter": "pawn",
+        "targetFilterMode": "exclude",
+        "targetComparisonMetric": "count",
+        "targetComparator": "greater_than",
+        "targetComparisonSource": "exact_number",
+        "targetComparisonSourceTotal": 1
+      },
+      "children": [
+        "113067",
+        "113066"
+      ]
+    },
+    "113070": {
+      "id": "113070",
+      "type": "organizer",
+      "data": {
+        "title": "Knight Fork"
+      },
+      "children": [
+        "113068"
+      ]
+    },
+    "113069": {
+      "id": "113069",
+      "type": "score",
+      "data": {
+        "actionType": "add",
+        "value": 20
+      },
+      "children": []
+    },
+    "113071": {
+      "id": "113071",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "relational",
+        "subject": "enemy",
+        "subjectFilter": "pawn",
+        "subjectFilterMode": "include",
+        "subjectComparisonMetric": "count",
+        "subjectComparator": "equal_to",
+        "subjectComparisonSource": "exact_number",
+        "subjectComparisonSourceTotal": 0,
+        "operator": "attack",
+        "target": "moved_piece",
+        "targetFilter": "any"
+      },
+      "children": [
+        "113069"
+      ]
+    },
+    "113072": {
+      "id": "113072",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "relational",
+        "subject": "allied",
+        "subjectFilter": "any",
+        "subjectComparisonMetric": "count",
+        "subjectComparator": "greater_than",
+        "subjectComparisonSource": "prior_board_state",
+        "operator": "attack",
+        "target": "enemy",
+        "targetFilter": "pawn",
+        "targetFilterMode": "exclude"
+      },
+      "children": [
+        "113071"
+      ]
+    },
+    "113075": {
+      "id": "113075",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "relational",
+        "subject": "moved_piece",
+        "subjectFilter": "any",
+        "operator": "attack",
+        "target": "enemy",
+        "targetFilter": "pawn",
+        "targetFilterMode": "exclude",
+        "targetComparisonMetric": "count",
+        "targetComparator": "equal_to",
+        "targetComparisonSource": "exact_number",
+        "targetComparisonSourceTotal": 0
+      },
+      "children": [
+        "113072"
+      ]
+    },
+    "113074": {
+      "id": "113074",
+      "type": "organizer",
+      "data": {
+        "title": "Discoverd attack"
+      },
+      "children": [
+        "113075"
+      ]
+    },
+    "113073": {
+      "id": "113073",
+      "type": "score",
+      "data": {
+        "actionType": "add",
+        "value": 7
+      },
+      "children": []
+    },
+    "113076": {
+      "id": "113076",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "relational",
+        "subject": "moved_piece",
+        "subjectFilter": "any",
+        "operator": "defend",
+        "target": "allied",
+        "targetFilter": "pawn",
+        "targetFilterMode": "include",
+        "targetComparisonMetric": "count",
+        "targetComparator": "less_than",
+        "targetComparisonSource": "prior_board_state"
+      },
+      "children": [
+        "113073"
+      ]
+    },
+    "113078": {
+      "id": "113078",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "relational",
+        "subject": "allied",
+        "subjectFilter": "major",
+        "subjectFilterMode": "include",
+        "operator": "defend",
+        "target": "moved_piece",
+        "targetFilter": "any"
+      },
+      "children": [
+        "113076"
+      ]
+    },
+    "113081": {
+      "id": "113081",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "relational",
+        "subject": "enemy",
+        "subjectFilter": "major",
+        "subjectFilterMode": "exclude",
+        "subjectComparisonMetric": "count",
+        "subjectComparator": "equal_to",
+        "subjectComparisonSource": "exact_number",
+        "subjectComparisonSourceTotal": 0,
+        "operator": "attack",
+        "target": "moved_piece",
+        "targetFilter": "any"
+      },
+      "children": [
+        "113078"
+      ]
+    },
+    "113079": {
+      "id": "113079",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "census",
+        "subject": "moved_piece",
+        "subjectFilter": "rook",
+        "subjectFilterMode": "include",
+        "operator": "mobility",
+        "comparator": "greater_than",
+        "target": "prior_board_state"
+      },
+      "children": [
+        "113081"
+      ]
+    },
+    "113077": {
+      "id": "113077",
+      "type": "organizer",
+      "data": {
+        "title": "Open file rook"
+      },
+      "children": [
+        "113079"
+      ]
+    },
+    "113060": {
+      "id": "113060",
+      "type": "score",
+      "data": {
+        "actionType": "return",
+        "value": 15
+      },
+      "children": []
+    },
+    "113058": {
+      "id": "113058",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "relational",
+        "subject": "allied",
+        "subjectFilter": "any",
+        "operator": "defend",
+        "target": "moved_piece",
+        "targetFilter": "any"
+      },
+      "children": [
+        "113060"
+      ]
+    },
+    "113059": {
+      "id": "113059",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "relational",
+        "subject": "enemy",
+        "subjectFilter": "any",
+        "subjectComparisonMetric": "count",
+        "subjectComparator": "equal_to",
+        "subjectComparisonSource": "exact_number",
+        "subjectComparisonSourceTotal": 0,
+        "operator": "attack",
+        "target": "moved_piece",
+        "targetFilter": "any"
+      },
+      "children": [
+        "113060"
+      ]
+    },
+    "113061": {
+      "id": "113061",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "relational",
+        "subject": "enemy",
+        "subjectFilter": "pawn",
+        "subjectFilterMode": "include",
+        "subjectComparisonMetric": "count",
+        "subjectComparator": "equal_to",
+        "subjectComparisonSource": "exact_number",
+        "subjectComparisonSourceTotal": 0,
+        "operator": "attack",
+        "target": "moved_piece",
+        "targetFilter": "any"
+      },
+      "children": [
+        "113058",
+        "113059"
+      ]
+    },
+    "113062": {
+      "id": "113062",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "relational",
+        "subject": "enemy",
+        "subjectFilter": "rook",
+        "subjectFilterMode": "include",
+        "subjectComparisonMetric": "individual_value",
+        "subjectComparator": "greater_than",
+        "subjectComparisonSource": "moved_piece",
+        "operator": "shield",
+        "target": "enemy",
+        "targetFilter": "pawn",
+        "targetFilterMode": "exclude"
+      },
+      "children": [
+        "113061"
+      ]
+    },
+    "113063": {
+      "id": "113063",
+      "type": "organizer",
+      "data": {
+        "title": "Rook skewer"
+      },
+      "children": [
+        "113062"
+      ]
+    },
+    "113041": {
+      "id": "113041",
+      "type": "score",
+      "data": {
+        "actionType": "add",
+        "value": 5
+      },
+      "children": []
+    },
+    "113045": {
+      "id": "113045",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "relational",
+        "subject": "allied",
+        "subjectFilter": "pawn",
+        "subjectFilterMode": "include",
+        "operator": "defend",
+        "target": "allied",
+        "targetFilter": "pawn",
+        "targetFilterMode": "include",
+        "targetComparisonMetric": "count",
+        "targetComparator": "greater_than",
+        "targetComparisonSource": "prior_board_state"
+      },
+      "children": [
+        "113041"
+      ]
+    },
+    "113044": {
+      "id": "113044",
+      "type": "organizer",
+      "data": {
+        "title": "Improve Pawn Mobility"
+      },
+      "children": [
+        "113045"
+      ]
+    },
+    "113050": {
+      "id": "113050",
+      "type": "score",
+      "data": {
+        "actionType": "add",
+        "value": 100
+      },
+      "children": []
+    },
+    "113042": {
+      "id": "113042",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "relational",
+        "subject": "enemy",
+        "subjectFilter": "any",
+        "subjectComparisonMetric": "count",
+        "subjectComparator": "equal_to",
+        "subjectComparisonSource": "exact_number",
+        "subjectComparisonSourceTotal": 0,
+        "operator": "attack",
+        "target": "moved_piece",
+        "targetFilter": "any"
+      },
+      "children": [
+        "113050"
+      ]
+    },
+    "113047": {
+      "id": "113047",
+      "type": "score",
+      "data": {
+        "actionType": "add",
+        "value": 30
+      },
+      "children": []
+    },
+    "113051": {
+      "id": "113051",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "census",
+        "subject": "moved_piece",
+        "subjectFilter": "any",
+        "operator": "value",
+        "comparator": "less_than",
+        "target": "captured_piece",
+        "targetFilter": "any"
+      },
+      "children": [
+        "113047"
+      ]
+    },
+    "113046": {
+      "id": "113046",
+      "type": "score",
+      "data": {
+        "actionType": "add",
+        "value": 20
+      },
+      "children": []
+    },
+    "113052": {
+      "id": "113052",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "relational",
+        "subject": "allied",
+        "subjectFilter": "any",
+        "operator": "defend",
+        "target": "moved_piece",
+        "targetFilter": "major",
+        "targetFilterMode": "exclude"
+      },
+      "children": [
+        "113046"
+      ]
+    },
+    "113054": {
+      "id": "113054",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "census",
+        "subject": "captured_piece",
+        "subjectFilter": "any",
+        "operator": "count",
+        "comparator": "greater_than",
+        "target": "exact_number",
+        "targetTotal": 0
+      },
+      "children": [
+        "113042",
+        "113051",
+        "113052"
+      ]
+    },
+    "113048": {
+      "id": "113048",
+      "type": "score",
+      "data": {
+        "actionType": "add",
+        "value": 10
+      },
+      "children": []
+    },
+    "113053": {
+      "id": "113053",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "relational",
+        "subject": "allied",
+        "subjectFilter": "any",
+        "operator": "defend",
+        "target": "moved_piece",
+        "targetFilter": "pawn",
+        "targetFilterMode": "include"
+      },
+      "children": [
+        "113048"
+      ]
+    },
+    "113043": {
+      "id": "113043",
+      "type": "score",
+      "data": {
+        "actionType": "add",
+        "value": 5
+      },
+      "children": []
+    },
+    "113049": {
+      "id": "113049",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "census",
+        "subject": "moved_piece",
+        "subjectFilter": "king",
+        "subjectFilterMode": "include",
+        "operator": "count",
+        "comparator": "greater_than",
+        "target": "exact_number",
+        "targetTotal": 0
+      },
+      "children": [
+        "113043"
+      ]
+    },
+    "113055": {
+      "id": "113055",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "relational",
+        "subject": "allied",
+        "subjectFilter": "any",
+        "operator": "defend",
+        "target": "moved_piece",
+        "targetFilter": "major",
+        "targetFilterMode": "exclude"
+      },
+      "children": [
+        "113049"
+      ]
+    },
+    "113056": {
+      "id": "113056",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "relational",
+        "subject": "enemy",
+        "subjectFilter": "any",
+        "subjectComparisonMetric": "count",
+        "subjectComparator": "less_than",
+        "subjectComparisonSource": "prior_board_state",
+        "operator": "attack",
+        "target": "allied",
+        "targetFilter": "king",
+        "targetFilterMode": "include"
+      },
+      "children": [
+        "113054",
+        "113053",
+        "113055"
+      ]
+    },
+    "113057": {
+      "id": "113057",
+      "type": "organizer",
+      "data": {
+        "title": "Escape check safely"
+      },
+      "children": [
+        "113056"
+      ]
+    },
+    "113027": {
+      "id": "113027",
+      "type": "root",
+      "data": {
+        "title": ""
+      },
+      "children": [
+        "113092",
+        "113039",
+        "113070",
+        "113074",
+        "113077",
+        "113063",
+        "113044",
+        "113057"
+      ]
+    }
+  }
+}

--- a/app/javascript/gameplay/__fixtures__/smoke_white_compiled_program.json
+++ b/app/javascript/gameplay/__fixtures__/smoke_white_compiled_program.json
@@ -1,0 +1,505 @@
+{
+  "version": 1,
+  "root": "113007",
+  "nodes": {
+    "113010": {
+      "id": "113010",
+      "type": "score",
+      "data": {
+        "actionType": "add",
+        "value": 10000
+      },
+      "children": []
+    },
+    "113009": {
+      "id": "113009",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "relational",
+        "subject": "allied",
+        "subjectFilter": "any",
+        "operator": "attack",
+        "target": "enemy",
+        "targetFilter": "king",
+        "targetFilterMode": "include"
+      },
+      "children": [
+        "113010"
+      ]
+    },
+    "113008": {
+      "id": "113008",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "census",
+        "subject": "enemy",
+        "subjectFilter": "any",
+        "operator": "mobility",
+        "comparator": "greater_than",
+        "target": "exact_number",
+        "targetTotal": 0
+      },
+      "children": [
+        "113009"
+      ]
+    },
+    "113012": {
+      "id": "113012",
+      "type": "score",
+      "data": {
+        "actionType": "add",
+        "value": 100
+      },
+      "children": []
+    },
+    "113011": {
+      "id": "113011",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "census",
+        "subject": "allied",
+        "subjectFilter": "pawn",
+        "subjectFilterMode": "include",
+        "operator": "count",
+        "comparator": "greater_than",
+        "target": "exact_number",
+        "targetTotal": 0,
+        "positionAxis": "rank",
+        "positionComparator": "equal_to",
+        "positionTarget": 7
+      },
+      "children": [
+        "113012"
+      ]
+    },
+    "113128": {
+      "id": "113128",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "identity",
+        "subject": "enemy_moved_piece",
+        "target": "captured_piece"
+      },
+      "children": [
+        "113012"
+      ]
+    },
+    "113026": {
+      "id": "113026",
+      "type": "score",
+      "data": {
+        "actionType": "add",
+        "value": 400
+      },
+      "children": []
+    },
+    "113015": {
+      "id": "113015",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "census",
+        "subject": "allied",
+        "subjectFilter": "any",
+        "operator": "value",
+        "comparator": "greater_than",
+        "target": "prior_board_state",
+        "positionAxis": "rank",
+        "positionComparator": "equal_to",
+        "positionTarget": 1
+      },
+      "children": [
+        "113026"
+      ]
+    },
+    "113025": {
+      "id": "113025",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "relational",
+        "subject": "enemy",
+        "subjectFilter": "any",
+        "subjectComparisonMetric": "count",
+        "subjectComparator": "equal_to",
+        "subjectComparisonSource": "exact_number",
+        "subjectComparisonSourceTotal": 0,
+        "operator": "attack",
+        "target": "moved_piece",
+        "targetFilter": "any"
+      },
+      "children": [
+        "113015"
+      ]
+    },
+    "113021": {
+      "id": "113021",
+      "type": "score",
+      "data": {
+        "actionType": "add",
+        "value": 15
+      },
+      "children": []
+    },
+    "113018": {
+      "id": "113018",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "relational",
+        "subject": "enemy",
+        "subjectFilter": "any",
+        "subjectComparisonMetric": "count",
+        "subjectComparator": "equal_to",
+        "subjectComparisonSource": "exact_number",
+        "subjectComparisonSourceTotal": 0,
+        "operator": "attack",
+        "target": "moved_piece",
+        "targetFilter": "any"
+      },
+      "children": [
+        "113021"
+      ]
+    },
+    "113019": {
+      "id": "113019",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "relational",
+        "subject": "allied",
+        "subjectFilter": "any",
+        "operator": "defend",
+        "target": "moved_piece",
+        "targetFilter": "any"
+      },
+      "children": [
+        "113021"
+      ]
+    },
+    "113020": {
+      "id": "113020",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "relational",
+        "subject": "enemy",
+        "subjectFilter": "pawn",
+        "subjectFilterMode": "include",
+        "subjectComparisonMetric": "count",
+        "subjectComparator": "equal_to",
+        "subjectComparisonSource": "exact_number",
+        "subjectComparisonSourceTotal": 0,
+        "operator": "attack",
+        "target": "moved_piece",
+        "targetFilter": "any"
+      },
+      "children": [
+        "113019"
+      ]
+    },
+    "113017": {
+      "id": "113017",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "relational",
+        "subject": "allied",
+        "subjectFilter": "any",
+        "operator": "attack",
+        "target": "enemy",
+        "targetFilter": "king",
+        "targetFilterMode": "include"
+      },
+      "children": [
+        "113018",
+        "113020"
+      ]
+    },
+    "113016": {
+      "id": "113016",
+      "type": "organizer",
+      "data": {
+        "title": "Direct King Pressure"
+      },
+      "children": [
+        "113017"
+      ]
+    },
+    "113082": {
+      "id": "113082",
+      "type": "score",
+      "data": {
+        "actionType": "add",
+        "value": 15
+      },
+      "children": []
+    },
+    "113084": {
+      "id": "113084",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "relational",
+        "subject": "allied",
+        "subjectFilter": "pawn",
+        "subjectFilterMode": "exclude",
+        "subjectComparisonMetric": "count",
+        "subjectComparator": "greater_than",
+        "subjectComparisonSource": "prior_board_state",
+        "operator": "attack",
+        "target": "enemy",
+        "targetFilter": "pawn",
+        "targetFilterMode": "include"
+      },
+      "children": [
+        "113082"
+      ]
+    },
+    "113090": {
+      "id": "113090",
+      "type": "score",
+      "data": {
+        "actionType": "add",
+        "value": 16
+      },
+      "children": []
+    },
+    "113085": {
+      "id": "113085",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "census",
+        "subject": "captured_piece",
+        "subjectFilter": "pawn",
+        "subjectFilterMode": "include",
+        "operator": "count",
+        "comparator": "equal_to",
+        "target": "exact_number",
+        "targetTotal": 1
+      },
+      "children": [
+        "113090"
+      ]
+    },
+    "113088": {
+      "id": "113088",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "relational",
+        "subject": "enemy",
+        "subjectFilter": "any",
+        "subjectComparisonMetric": "count",
+        "subjectComparator": "equal_to",
+        "subjectComparisonSource": "exact_number",
+        "subjectComparisonSourceTotal": 0,
+        "operator": "attack",
+        "target": "moved_piece",
+        "targetFilter": "any"
+      },
+      "children": [
+        "113084",
+        "113085"
+      ]
+    },
+    "113086": {
+      "id": "113086",
+      "type": "score",
+      "data": {
+        "actionType": "add",
+        "value": 19
+      },
+      "children": []
+    },
+    "113083": {
+      "id": "113083",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "relational",
+        "subject": "enemy",
+        "subjectFilter": "any",
+        "subjectComparisonMetric": "count",
+        "subjectComparator": "equal_to",
+        "subjectComparisonSource": "exact_number",
+        "subjectComparisonSourceTotal": 0,
+        "operator": "attack",
+        "target": "moved_piece",
+        "targetFilter": "any"
+      },
+      "children": [
+        "113086"
+      ]
+    },
+    "113089": {
+      "id": "113089",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "relational",
+        "subject": "moved_piece",
+        "subjectFilter": "any",
+        "operator": "attack",
+        "target": "enemy",
+        "targetFilter": "pawn",
+        "targetFilterMode": "include"
+      },
+      "children": [
+        "113083"
+      ]
+    },
+    "113087": {
+      "id": "113087",
+      "type": "organizer",
+      "data": {
+        "title": "Attack pawns"
+      },
+      "children": [
+        "113088",
+        "113089"
+      ]
+    },
+    "113115": {
+      "id": "113115",
+      "type": "score",
+      "data": {
+        "actionType": "return",
+        "value": 7
+      },
+      "children": []
+    },
+    "113125": {
+      "id": "113125",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "relational",
+        "subject": "allied",
+        "subjectFilter": "any",
+        "operator": "defend",
+        "target": "moved_piece",
+        "targetFilter": "pawn",
+        "targetFilterMode": "include"
+      },
+      "children": [
+        "113115"
+      ]
+    },
+    "113122": {
+      "id": "113122",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "relational",
+        "subject": "allied",
+        "subjectFilter": "any",
+        "subjectComparisonMetric": "count",
+        "subjectComparator": "greater_than",
+        "subjectComparisonSource": "prior_board_state",
+        "operator": "defend",
+        "target": "allied",
+        "targetFilter": "pawn",
+        "targetFilterMode": "include"
+      },
+      "children": [
+        "113115"
+      ]
+    },
+    "113124": {
+      "id": "113124",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "relational",
+        "subject": "enemy",
+        "subjectFilter": "any",
+        "subjectComparisonMetric": "count",
+        "subjectComparator": "equal_to",
+        "subjectComparisonSource": "exact_number",
+        "subjectComparisonSourceTotal": 0,
+        "operator": "attack",
+        "target": "moved_piece",
+        "targetFilter": "pawn",
+        "targetFilterMode": "include"
+      },
+      "children": [
+        "113115"
+      ]
+    },
+    "113120": {
+      "id": "113120",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "relational",
+        "subject": "moved_piece",
+        "subjectFilter": "king",
+        "subjectFilterMode": "include",
+        "operator": "defend",
+        "target": "allied",
+        "targetFilter": "pawn",
+        "targetFilterMode": "include",
+        "targetComparisonMetric": "count",
+        "targetComparator": "greater_than",
+        "targetComparisonSource": "prior_board_state"
+      },
+      "children": [
+        "113115"
+      ]
+    },
+    "113117": {
+      "id": "113117",
+      "type": "condition",
+      "data": {
+        "version": 2,
+        "kind": "relational",
+        "subject": "moved_piece",
+        "subjectFilter": "pawn",
+        "subjectFilterMode": "include",
+        "operator": "defend",
+        "target": "allied",
+        "targetFilter": "pawn",
+        "targetFilterMode": "include"
+      },
+      "children": [
+        "113115"
+      ]
+    },
+    "113123": {
+      "id": "113123",
+      "type": "organizer",
+      "data": {
+        "title": "push safe pawns"
+      },
+      "children": [
+        "113125",
+        "113122",
+        "113124",
+        "113120",
+        "113117"
+      ]
+    },
+    "113007": {
+      "id": "113007",
+      "type": "root",
+      "data": {
+        "title": ""
+      },
+      "children": [
+        "113008",
+        "113011",
+        "113128",
+        "113025",
+        "113016",
+        "113087",
+        "113123"
+      ]
+    }
+  }
+}

--- a/app/javascript/gameplay/__tests__/match_runner_smoke.test.js
+++ b/app/javascript/gameplay/__tests__/match_runner_smoke.test.js
@@ -1,0 +1,119 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+import Board from 'gameplay/board'
+import BotRunner from 'gameplay/bot_runner'
+import Layout from 'gameplay/layout'
+import MatchRunner from 'gameplay/match_runner'
+
+// Regression coverage for the "compiled program contains a kind the evaluator
+// rejects" class of bug (a stale compiled program with a retired `unary` kind
+// crashed every match while the entire suite stayed green). Every other layer
+// is mocked at the seam or fed synthetic node trees; nothing actually played a
+// realistic compiled program through the real BotRunner + ConditionEvaluator.
+//
+// The fixtures are generated from purpose-built, kind-rich dev bots via the
+// Ruby compile pipeline (see the BotCompiler spec / fixture rake). They are
+// intentionally small but cover every condition kind and the major payload
+// variants. Until they are committed this suite self-skips so the green suite
+// is honest rather than red-by-default.
+
+// Resolve via fileURLToPath/path (plain strings) rather than `new URL(...)`:
+// under the jsdom test environment the global URL is jsdom's class, which
+// node:fs does not treat as a file URL, so existsSync/readFileSync would
+// silently fail and the suite would self-skip even with fixtures present.
+const FIXTURE_DIR = join(dirname(fileURLToPath(import.meta.url)), '..', '__fixtures__')
+const WHITE_FIXTURE = join(FIXTURE_DIR, 'smoke_white_compiled_program.json')
+const BLACK_FIXTURE = join(FIXTURE_DIR, 'smoke_black_compiled_program.json')
+
+const MAX_PLIES = 20
+const RNG_SEED = 0x9e3779b9
+
+// Deterministic PRNG so BotRunner tie-breaking (this.random) can't make the
+// smoke test flaky.
+function mulberry32(seed) {
+  let state = seed >>> 0
+  return () => {
+    state |= 0
+    state = (state + 0x6d2b79f5) | 0
+    let t = Math.imul(state ^ (state >>> 15), 1 | state)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+const fixturesPresent = existsSync(WHITE_FIXTURE) && existsSync(BLACK_FIXTURE)
+
+function loadProgram(fixtureUrl) {
+  return JSON.parse(readFileSync(fixtureUrl, 'utf8'))
+}
+
+function conditionKinds(program) {
+  return Object.values(program.nodes)
+    .filter(node => node.type === 'condition')
+    .map(node => node.data && node.data.kind)
+}
+
+const describeMaybe = fixturesPresent ? describe : describe.skip
+
+describeMaybe('match runner smoke (real bots end-to-end)', () => {
+  const whiteProgram = fixturesPresent ? loadProgram(WHITE_FIXTURE) : null
+  const blackProgram = fixturesPresent ? loadProgram(BLACK_FIXTURE) : null
+
+  it('fixtures cover every live kind and contain no retired kinds', () => {
+    const kinds = new Set([
+      ...conditionKinds(whiteProgram),
+      ...conditionKinds(blackProgram)
+    ])
+
+    // Coverage guard: a degenerate fixture must not pass the play test below
+    // and give false confidence.
+    expect(kinds).toContain('census')
+    expect(kinds).toContain('relational')
+    expect(kinds).toContain('identity')
+
+    // The actual regression: retired kinds must never reach the runner.
+    expect(kinds.has('unary')).toBe(false)
+    expect(kinds.has('position')).toBe(false)
+  })
+
+  it('plays a full match without throwing and produces legal moves', () => {
+    const board = new Board({
+      layOut: Layout.default(),
+      capturedPieces: [],
+      allowedToMove: Board.WHITE,
+      movementNotation: []
+    })
+
+    const random = mulberry32(RNG_SEED)
+    const matchRunner = new MatchRunner({
+      board,
+      moveProviders: {
+        [Board.WHITE]: new BotRunner(whiteProgram, { random }),
+        [Board.BLACK]: new BotRunner(blackProgram, { random })
+      }
+    })
+
+    let turns
+    expect(() => {
+      turns = matchRunner.play({ maxPlies: MAX_PLIES })
+    }).not.toThrow()
+
+    // Either the game ended on its own or we hit the ply cap — but real moves
+    // must have been selected and applied along the way.
+    expect(turns.length).toBeGreaterThan(0)
+    expect(board.gameOver || turns.length === MAX_PLIES).toBe(true)
+
+    let expectedTeam = Board.WHITE
+    for (const turn of turns) {
+      expect(turn.team).toBe(expectedTeam)
+      expect(turn.moveObject).toBeTruthy()
+      expect(Number.isInteger(turn.moveObject.startPosition)).toBe(true)
+      expect(Number.isInteger(turn.moveObject.endPosition)).toBe(true)
+      expectedTeam = expectedTeam === Board.WHITE ? Board.BLACK : Board.WHITE
+    }
+  })
+})

--- a/app/models/RULES.md
+++ b/app/models/RULES.md
@@ -1,0 +1,10 @@
+# app/models rules
+
+## Invalidate compiled_program on non-ActiveRecord writes
+
+The `Node`/`Connection` `after_commit` staleness hooks fire only for
+ActiveRecord persistence. Any raw SQL / migration / `update_all` /
+`update_column` / bulk write that touches node data or connections must
+also set `compiled_program_stale = true` for the affected bots in the
+same transaction. Over-marking only forces a recompile; under-marking
+crashes every match.

--- a/db/migrate/20260516120000_migrate_condition_kinds_to_census_and_identity.rb
+++ b/db/migrate/20260516120000_migrate_condition_kinds_to_census_and_identity.rb
@@ -21,6 +21,16 @@ class MigrateConditionKindsToCensusAndIdentity < ActiveRecord::Migration[7.1]
       WHERE node_type = 'condition'
         AND data->>'kind' = 'relational'
         AND data->>'operator' = 'same_piece';
+
+      -- Raw SQL bypasses the Node/Connection after_commit hooks that mark a
+      -- bot's compiled_program stale. Without this every bot whose nodes we
+      -- just rewrote keeps serving its pre-migration compiled program -- one
+      -- that still carries the retired 'unary'/'position' kinds the V2
+      -- evaluator now rejects, crashing every match. Invalidate the cache so
+      -- the existing recompile-before-match path regenerates it.
+      UPDATE bots
+      SET compiled_program_stale = true
+      WHERE compiled_program_stale = false;
     SQL
   end
 

--- a/lib/tasks/smoke_fixtures.rake
+++ b/lib/tasks/smoke_fixtures.rake
@@ -1,0 +1,53 @@
+# Regenerates the match-runner smoke-test fixtures from purpose-built dev bots.
+#
+# These two bots are kept in the dev DB and deliberately cover every live
+# condition kind (census whole-board + region, relational incl. value metrics,
+# identity). The compiled programs they produce are committed as fixtures and
+# played end-to-end by app/javascript/gameplay/__tests__/match_runner_smoke.test.js
+# — the regression net for "compiled program contains a kind the evaluator
+# rejects" (the stale-`unary` crash that took down every match with a green
+# suite).
+#
+# This is a generator, not a spec: it depends on the dev DB and is run by hand
+# whenever the source bots change. It validates the compiler output at
+# generation time so a regenerated fixture can never carry a retired/unknown
+# kind into the committed file.
+#
+#   bin/rails smoke_fixtures:generate
+
+namespace :smoke_fixtures do
+  LIVE_KINDS = %w[relational census identity].freeze
+  RETIRED_KINDS = %w[unary position].freeze
+  FIXTURE_DIR = Rails.root.join("app/javascript/gameplay/__fixtures__")
+
+  SOURCE_BOTS = {
+    "test bot 1" => "smoke_white_compiled_program.json",
+    "test bot 2" => "smoke_black_compiled_program.json"
+  }.freeze
+
+  desc "Regenerate match-runner smoke fixtures from the dev test bots"
+  task generate: :environment do
+    SOURCE_BOTS.each do |bot_name, filename|
+      bot = Bot.find_by(name: bot_name)
+      raise "Smoke bot not found: #{bot_name.inspect}" unless bot
+
+      compiled = BotCompiler.new(bot).compile
+
+      kinds = compiled[:nodes].values
+        .select { |node| node[:type] == "condition" }
+        .map { |node| node[:data][:kind] || node[:data]["kind"] }
+
+      retired = kinds & RETIRED_KINDS
+      raise "#{bot_name.inspect} compiles retired kinds: #{retired.uniq.inspect}" if retired.any?
+
+      unknown = kinds.uniq - LIVE_KINDS
+      raise "#{bot_name.inspect} compiles unknown kinds: #{unknown.inspect}" if unknown.any?
+
+      path = FIXTURE_DIR.join(filename)
+      File.write(path, "#{JSON.pretty_generate(compiled)}\n")
+
+      puts "#{bot_name.inspect} -> #{filename} " \
+           "(#{compiled[:nodes].size} nodes, kinds=#{kinds.tally})"
+    end
+  end
+end


### PR DESCRIPTION
Invalidate compiled_program in the kind migration; add a real match-runner smoke test

  Problem

  The 20260516120000 migration rewrites condition kinds (unary/position → census, same_piece relational → identity) via raw SQL. Bots cache a compiled_program, and the only thing that marks that cache stale is the
  after_commit hook on Node/Connection (app/models/node.rb:29, app/models/connection.rb:23) — which fires only on the ActiveRecord lifecycle, never on raw UPDATE.

  Result: after the migration, every bot kept serving its pre-migration compiled program, still carrying the retired unary/position kinds the V2 evaluator now rejects — crashing every match. The entire JS suite
  stayed green throughout, because every layer was mocked at the seam; nothing played a realistic compiled program through the real BotRunner + ConditionEvaluator.

  Changes

  - Migration fix: append UPDATE bots SET compiled_program_stale = true to the same heredoc as the node rewrites, so cache invalidation is atomic with the data change. The existing recompile-before-match path then
  regenerates each program.
  - Regression net: match_runner_smoke.test.js plays two committed compiled-program fixtures end-to-end through the real MatchRunner/BotRunner with a seeded PRNG. Guards assert the fixtures cover every live kind
  (census/relational/identity) and contain no retired kinds.
  - Fixture generator: smoke_fixtures:generate rake regenerates the fixtures from purpose-built dev bots and fails loudly if a regenerated fixture would carry a retired/unknown kind.
  - Invariant documented: new app/models/RULES.md ("any raw/bulk write touching node data must set compiled_program_stale in the same transaction"), registered in RULES_INDEX.md.

  Notes / trade-offs

  - The bots update is intentionally fleet-wide (WHERE compiled_program_stale = false), not scoped to affected bots — over-marking only forces a recompile; under-marking crashes matches.
  - down is an IrreversibleMigration: the kind unification is genuinely lossy.
  - The smoke suite self-skips if fixtures are absent, by design, so the green suite stays honest rather than red-by-default.