### PR TITLE
Worktree sentences

### DIFF
--- a/app/assets/stylesheets/node_editor.css
+++ b/app/assets/stylesheets/node_editor.css
@@ -98,11 +98,6 @@
   white-space: nowrap;
 }
 
-.toolbar-section button.active {
-  background: #A855F7;
-  color: #1a1815;
-}
-
 .btn-add-node {
   background: #1a1815;
   color: #A855F7;
@@ -189,19 +184,6 @@
 .btn-zoom:hover {
   background: #252220;
   border-color: #7a7670;
-}
-
-.btn-zoom-reset {
-  background: #1a1815;
-  color: #9CA3AF;
-  font-size: 11px;
-  padding: 6px 10px;
-  border: 1px solid #3d3a35;
-}
-
-.btn-zoom-reset:hover {
-  background: #252220;
-  color: #E5E5E5;
 }
 
 #zoom-level {

--- a/app/javascript/editorV2/__tests__/ToolbarHandler.test.js
+++ b/app/javascript/editorV2/__tests__/ToolbarHandler.test.js
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import ToolbarHandler from '../handlers/ToolbarHandler.js'
 import Store from '../state/Store.js'
+import { setConditionPreviewMode } from '../utils/conditionPreviewFormatter.js'
 
 describe('ToolbarHandler', () => {
   let store
@@ -36,6 +37,21 @@ describe('ToolbarHandler', () => {
   afterEach(() => {
     vi.restoreAllMocks()
     document.body.innerHTML = ''
+  })
+
+  it('syncPreviewModeButton reflects the current preview mode', () => {
+    const btn = document.createElement('button')
+    setConditionPreviewMode('sentence')
+    toolbarHandler.syncPreviewModeButton(btn)
+    expect(btn.textContent).toBe('Sentences: on')
+    expect(btn.getAttribute('aria-pressed')).toBe('true')
+
+    setConditionPreviewMode('chunks')
+    toolbarHandler.syncPreviewModeButton(btn)
+    expect(btn.textContent).toBe('Sentences: off')
+    expect(btn.getAttribute('aria-pressed')).toBe('false')
+
+    setConditionPreviewMode('sentence')
   })
 
   it('enables the delete button when actions.canDelete() returns true', () => {

--- a/app/javascript/editorV2/__tests__/conditionPreviewFormatter.test.js
+++ b/app/javascript/editorV2/__tests__/conditionPreviewFormatter.test.js
@@ -107,6 +107,23 @@ describe('conditionPreviewFormatter', () => {
       ).toBe('Allies any : rank = 5 : count > 0')
     })
 
+    it('formats a region census preview with PBS target (no "undefined")', () => {
+      expect(
+        formatConditionPreview({
+          version: 2,
+          kind: 'census',
+          subject: 'allied',
+          subjectFilter: 'rook',
+          positionAxis: 'rank',
+          positionComparator: 'equal_to',
+          positionTarget: 5,
+          operator: 'count',
+          comparator: 'greater_than',
+          target: 'prior_board_state'
+        }).text
+      ).toBe('Allied rook/s : rank = 5 : count > Prior Board State')
+    })
+
     it('formats an identity condition with the explicit same-piece phrase', () => {
       expect(
         formatConditionPreview({
@@ -208,15 +225,27 @@ describe('conditionPreviewFormatter', () => {
       ).toBe('square a1')
     })
 
-    it('formats a metric chunk as operator comparator total', () => {
+    it('formats a metric chunk as operator comparator total (exact_number)', () => {
       expect(
         formatConditionPreviewChunk({
           role: 'metric',
           operator: 'count',
           comparator: 'greater_than',
+          target: 'exact_number',
           targetTotal: 0
         })
       ).toBe('count > 0')
+    })
+
+    it('formats a metric chunk against prior_board_state', () => {
+      expect(
+        formatConditionPreviewChunk({
+          role: 'metric',
+          operator: 'count',
+          comparator: 'greater_than',
+          target: 'prior_board_state'
+        })
+      ).toBe('count > Prior Board State')
     })
 
     it('formats excluded major and minor filters', () => {

--- a/app/javascript/editorV2/__tests__/conditionPreviewSentence.test.js
+++ b/app/javascript/editorV2/__tests__/conditionPreviewSentence.test.js
@@ -171,8 +171,8 @@ describe('formatConditionSentence', () => {
       expect(s(census({ subject: 'allied', subjectFilter: 'pawn', operator: 'count', comparator: 'equal_to', target: 'exact_number', targetTotal: 3 })))
         .toBe('I have **exactly 3** pawns')
     })
-    it('captured_piece count > 0 (singular existence)', () => {
-      expect(s(census({ subject: 'captured_piece', subjectFilter: 'any', operator: 'count', comparator: 'greater_than', target: 'exact_number', targetTotal: 0 })))
+    it('captured_piece count = 1 (singular existence)', () => {
+      expect(s(census({ subject: 'captured_piece', subjectFilter: 'any', operator: 'count', comparator: 'equal_to', target: 'exact_number', targetTotal: 1 })))
         .toBe('I **capture** a piece')
     })
     it('captured_piece count = 0', () => {
@@ -187,9 +187,13 @@ describe('formatConditionSentence', () => {
       expect(s(census({ subject: 'captured_piece', subjectFilter: 'pawn', operator: 'count', comparator: 'equal_to', target: 'exact_number', targetTotal: 1 })))
         .toBe('my capture **is** a pawn')
     })
-    it('moved_piece knight count >= 1', () => {
-      expect(s(census({ subject: 'moved_piece', subjectFilter: 'knight', operator: 'count', comparator: 'greater_than_or_equal_to', target: 'exact_number', targetTotal: 1 })))
+    it('moved_piece knight count = 1', () => {
+      expect(s(census({ subject: 'moved_piece', subjectFilter: 'knight', operator: 'count', comparator: 'equal_to', target: 'exact_number', targetTotal: 1 })))
         .toBe('my moved piece **is** a knight')
+    })
+    it('moved_piece knight count > 0 (disallowed comparator warns)', () => {
+      expect(s(census({ subject: 'moved_piece', subjectFilter: 'knight', operator: 'count', comparator: 'greater_than', target: 'exact_number', targetTotal: 0 })))
+        .toBe("my moved piece ⚠ couldn't render count comparison")
     })
     it('moved_piece knight mobility > PBS', () => {
       expect(s(census({ subject: 'moved_piece', subjectFilter: 'knight', operator: 'mobility', comparator: 'greater_than', target: pbs })))
@@ -280,6 +284,26 @@ describe('formatConditionSentence', () => {
       expect(s(census({ subject: 'allied', subjectFilter: 'rook', positionAxis: 'file', positionComparator: 'equal_to', positionTarget: 3, operator: 'count', comparator: 'greater_than', target: 'exact_number', targetTotal: 0 })))
         .toBe('I have at least one rook on the **c-file**')
     })
+    it('singular subject count = 1, no filter: existence in region', () => {
+      expect(s(census({ subject: 'moved_piece', subjectFilter: 'any', positionAxis: 'rank', positionComparator: 'equal_to', positionTarget: 5, operator: 'count', comparator: 'equal_to', target: 'exact_number', targetTotal: 1 })))
+        .toBe('my moved piece **is** on rank 5')
+    })
+    it('singular subject count = 1, with filter: existence + species in region', () => {
+      expect(s(census({ subject: 'moved_piece', subjectFilter: 'knight', positionAxis: 'rank', positionComparator: 'equal_to', positionTarget: 5, operator: 'count', comparator: 'equal_to', target: 'exact_number', targetTotal: 1 })))
+        .toBe('my moved piece **is** a knight on rank 5')
+    })
+    it('singular subject count = 0, no filter: negated existence in region', () => {
+      expect(s(census({ subject: 'moved_piece', subjectFilter: 'any', positionAxis: 'rank', positionComparator: 'equal_to', positionTarget: 5, operator: 'count', comparator: 'equal_to', target: 'exact_number', targetTotal: 0 })))
+        .toBe('my moved piece is **not** on rank 5')
+    })
+    it('singular subject count = 0, with filter: negated existence + species in region', () => {
+      expect(s(census({ subject: 'moved_piece', subjectFilter: 'knight', positionAxis: 'rank', positionComparator: 'equal_to', positionTarget: 5, operator: 'count', comparator: 'equal_to', target: 'exact_number', targetTotal: 0 })))
+        .toBe('my moved piece is **not** a knight on rank 5')
+    })
+    it('singular subject count, disallowed comparator warns', () => {
+      expect(s(census({ subject: 'moved_piece', subjectFilter: 'knight', positionAxis: 'rank', positionComparator: 'equal_to', positionTarget: 5, operator: 'count', comparator: 'greater_than', target: 'exact_number', targetTotal: 0 })))
+        .toBe("my moved piece ⚠ couldn't render count comparison")
+    })
     it('value + region + PBS: "value of X on rank Y is higher than before"', () => {
       expect(s(census({ subject: 'allied', subjectFilter: 'rook', positionAxis: 'rank', positionComparator: 'equal_to', positionTarget: 5, operator: 'value', comparator: 'greater_than', target: pbs })))
         .toBe('my rooks on rank 5 are **more valuable** than before')
@@ -350,6 +374,82 @@ describe('formatConditionSentence', () => {
         targetComparisonSource: 'exact_number', targetComparisonSourceTotal: 0
       })))
         .toBe("my pieces attack my moved piece ⚠ couldn't render target's count comparison")
+    })
+  })
+
+  describe('relational — singular-actor count is existence (=1 omit, =0 negate)', () => {
+    it('moved_piece count = 1 attack enemy: count omitted, affirmative', () => {
+      expect(s(rel({
+        subject: 'moved_piece', subjectFilter: 'any', operator: 'attack',
+        target: 'enemy', targetFilter: 'any',
+        subjectComparisonMetric: 'count', subjectComparator: 'equal_to',
+        subjectComparisonSource: 'exact_number', subjectComparisonSourceTotal: 1
+      })))
+        .toBe('my moved piece attacks enemy pieces')
+    })
+    it('moved_piece count = 0 attack enemy: negated', () => {
+      expect(s(rel({
+        subject: 'moved_piece', subjectFilter: 'any', operator: 'attack',
+        target: 'enemy', targetFilter: 'any',
+        subjectComparisonMetric: 'count', subjectComparator: 'equal_to',
+        subjectComparisonSource: 'exact_number', subjectComparisonSourceTotal: 0
+      })))
+        .toBe('my moved piece does not attack enemy pieces')
+    })
+    it('moved_piece count = 1 + target value: integrated, count omitted', () => {
+      expect(s(rel({
+        subject: 'moved_piece', subjectFilter: 'any', operator: 'attack',
+        target: 'enemy', targetFilter: 'any',
+        subjectComparisonMetric: 'count', subjectComparator: 'equal_to',
+        subjectComparisonSource: 'exact_number', subjectComparisonSourceTotal: 1,
+        targetComparisonMetric: 'aggregate_value', targetComparator: 'greater_than',
+        targetComparisonSource: 'exact_number', targetComparisonSourceTotal: 5
+      })))
+        .toBe('my moved piece attacks enemy pieces **more valuable** than 5')
+    })
+    it('moved_piece count = 0 + target value: integrated, negated', () => {
+      expect(s(rel({
+        subject: 'moved_piece', subjectFilter: 'any', operator: 'attack',
+        target: 'enemy', targetFilter: 'any',
+        subjectComparisonMetric: 'count', subjectComparator: 'equal_to',
+        subjectComparisonSource: 'exact_number', subjectComparisonSourceTotal: 0,
+        targetComparisonMetric: 'aggregate_value', targetComparator: 'greater_than',
+        targetComparisonSource: 'exact_number', targetComparisonSourceTotal: 5
+      })))
+        .toBe('my moved piece does not attack enemy pieces **more valuable** than 5')
+    })
+    it('subject value + enemy_moved_piece count = 1: integrated continuous, affirmative', () => {
+      expect(s(rel({
+        subject: 'allied', subjectFilter: 'any',
+        subjectComparisonMetric: 'aggregate_value', subjectComparator: 'greater_than',
+        subjectComparisonSource: 'exact_number', subjectComparisonSourceTotal: 5,
+        operator: 'attack',
+        target: 'enemy_moved_piece', targetFilter: 'any',
+        targetComparisonMetric: 'count', targetComparator: 'equal_to',
+        targetComparisonSource: 'exact_number', targetComparisonSourceTotal: 1
+      })))
+        .toBe("my pieces, **more valuable** than 5, are attacking enemy's just-moved piece")
+    })
+    it('subject value + enemy_moved_piece count = 0: integrated continuous, negated', () => {
+      expect(s(rel({
+        subject: 'allied', subjectFilter: 'any',
+        subjectComparisonMetric: 'aggregate_value', subjectComparator: 'greater_than',
+        subjectComparisonSource: 'exact_number', subjectComparisonSourceTotal: 5,
+        operator: 'attack',
+        target: 'enemy_moved_piece', targetFilter: 'any',
+        targetComparisonMetric: 'count', targetComparator: 'equal_to',
+        targetComparisonSource: 'exact_number', targetComparisonSourceTotal: 0
+      })))
+        .toBe("my pieces, **more valuable** than 5, are not attacking enemy's just-moved piece")
+    })
+    it('moved_piece count = 0 adjacent allied knight: "is not adjacent to"', () => {
+      expect(s(rel({
+        subject: 'moved_piece', subjectFilter: 'any', operator: 'adjacent',
+        target: 'allied', targetFilter: 'knight', targetFilterMode: 'include',
+        subjectComparisonMetric: 'count', subjectComparator: 'equal_to',
+        subjectComparisonSource: 'exact_number', subjectComparisonSourceTotal: 0
+      })))
+        .toBe('my moved piece is not adjacent to my knight')
     })
   })
 

--- a/app/javascript/editorV2/__tests__/conditionPreviewSentence.test.js
+++ b/app/javascript/editorV2/__tests__/conditionPreviewSentence.test.js
@@ -1,6 +1,6 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 
-import { formatConditionSentence } from 'editorV2/utils/conditionPreviewFormatter'
+import { formatConditionSentence, getConditionPreviewMode, setConditionPreviewMode } from 'editorV2/utils/conditionPreviewFormatter'
 
 // Render segments to a marked string: the emphasized segment wrapped in **…**.
 // Lets each assertion read exactly like the locked phrasing spec.
@@ -15,6 +15,24 @@ const census = (extra) => ({ version: 2, kind: 'census', ...extra })
 const pbs = 'prior_board_state'
 
 describe('formatConditionSentence', () => {
+  describe('preview mode toggle', () => {
+    afterEach(() => setConditionPreviewMode('sentence'))
+    const sample = census({ subject: 'allied', subjectFilter: 'rook', operator: 'count', comparator: 'greater_than', target: 'exact_number', targetTotal: 0 })
+    it('defaults to sentence prose', () => {
+      expect(getConditionPreviewMode()).toBe('sentence')
+      expect(s(sample)).toBe('I have **at least one** rook')
+    })
+    it('chunks mode falls back to terse chunk text', () => {
+      setConditionPreviewMode('chunks')
+      expect(s(sample)).toBe('Allied rook/s : count : > 0')
+    })
+    it('flips back to prose', () => {
+      setConditionPreviewMode('chunks')
+      setConditionPreviewMode('sentence')
+      expect(s(sample)).toBe('I have **at least one** rook')
+    })
+  })
+
   describe('relational — bare (implicit count > 0)', () => {
     it('allied any attack enemy king', () => {
       expect(s(rel({ subject: 'allied', subjectFilter: 'any', operator: 'attack', target: 'enemy', targetFilter: 'king' })))
@@ -89,30 +107,46 @@ describe('formatConditionSentence', () => {
     })
     it('shield, exclude filter', () => {
       expect(s(v({ subject: 'enemy', subjectFilter: 'pawn', subjectFilterMode: 'exclude', operator: 'shield', target: 'enemy', targetFilter: 'queen' })))
-        .toBe('enemy queen is shielded by **more** non-pawn pieces than before')
+        .toBe('enemy queens are shielded by enemy non-pawns **more valuable** than before')
     })
     it('attack, species filter', () => {
       expect(s(v({ subject: 'allied', subjectFilter: 'knight', operator: 'attack', target: 'enemy', targetFilter: 'queen' })))
-        .toBe('enemy queen is attacked by **more** knights than before')
+        .toBe('enemy queens are attacked by my knights **more valuable** than before')
     })
     it('defend, species filter', () => {
       expect(s(v({ subject: 'allied', subjectFilter: 'bishop', operator: 'defend', target: 'allied', targetFilter: 'queen' })))
-        .toBe('my queen is defended by **more** bishops than before')
+        .toBe('my queens are defended by my bishops **more valuable** than before')
     })
     it('shield, exclude filter, allied target', () => {
       expect(s(v({ subject: 'allied', subjectFilter: 'pawn', subjectFilterMode: 'exclude', operator: 'shield', target: 'allied', targetFilter: 'queen' })))
-        .toBe('my queen is shielded by **more** non-pawn pieces than before')
+        .toBe('my queens are shielded by my non-pawns **more valuable** than before')
     })
-    it('attack, no filter (keeps "value")', () => {
+    it('attack, no filter', () => {
       expect(s(rel({ subject: 'allied', subjectFilter: 'any', subjectComparisonMetric: 'value', subjectComparator: 'greater_than', subjectComparisonSource: pbs, operator: 'attack', target: 'enemy', targetFilter: 'queen' })))
-        .toBe('enemy queen is attacked by **more** value than before')
+        .toBe('enemy queens are attacked by my pieces **more valuable** than before')
     })
   })
 
   describe('identity', () => {
     it('enemy_moved_piece same_piece captured_piece', () => {
-      expect(s({ version: 2, kind: 'identity', subject: 'enemy_moved_piece', operator: 'same_piece', target: 'captured_piece' }))
+      expect(s({ version: 2, kind: 'identity', subject: 'enemy_moved_piece', target: 'captured_piece' }))
         .toBe('I captured the piece the enemy just moved')
+    })
+    it('captured_piece same_piece enemy_moved_piece (symmetric order)', () => {
+      expect(s({ version: 2, kind: 'identity', subject: 'captured_piece', target: 'enemy_moved_piece' }))
+        .toBe('I captured the piece the enemy just moved')
+    })
+    it('moved_piece same_piece captured_piece (en passant from my side)', () => {
+      expect(s({ version: 2, kind: 'identity', subject: 'moved_piece', target: 'captured_piece' }))
+        .toBe('I moved and captured the same piece')
+    })
+    it('moved_piece same_piece enemy_captured_piece', () => {
+      expect(s({ version: 2, kind: 'identity', subject: 'moved_piece', target: 'enemy_captured_piece' }))
+        .toBe('the enemy captured the piece I just moved')
+    })
+    it('enemy_moved_piece same_piece enemy_captured_piece (en passant from enemy side)', () => {
+      expect(s({ version: 2, kind: 'identity', subject: 'enemy_moved_piece', target: 'enemy_captured_piece' }))
+        .toBe('the enemy moved and captured the same piece')
     })
   })
 
@@ -149,6 +183,14 @@ describe('formatConditionSentence', () => {
       expect(s(census({ subject: 'moved_piece', subjectFilter: 'knight', operator: 'count', comparator: 'equal_to', target: 'exact_number', targetTotal: 0 })))
         .toBe('my moved piece is **not** a knight')
     })
+    it('captured_piece pawn count = 1 (singular actor matches filter)', () => {
+      expect(s(census({ subject: 'captured_piece', subjectFilter: 'pawn', operator: 'count', comparator: 'equal_to', target: 'exact_number', targetTotal: 1 })))
+        .toBe('my capture **is** a pawn')
+    })
+    it('moved_piece knight count >= 1', () => {
+      expect(s(census({ subject: 'moved_piece', subjectFilter: 'knight', operator: 'count', comparator: 'greater_than_or_equal_to', target: 'exact_number', targetTotal: 1 })))
+        .toBe('my moved piece **is** a knight')
+    })
     it('moved_piece knight mobility > PBS', () => {
       expect(s(census({ subject: 'moved_piece', subjectFilter: 'knight', operator: 'mobility', comparator: 'greater_than', target: pbs })))
         .toBe('my moved knight has **more** legal moves than before')
@@ -164,6 +206,52 @@ describe('formatConditionSentence', () => {
     it('allied value < PBS (capture idiom)', () => {
       expect(s(census({ subject: 'allied', subjectFilter: 'any', operator: 'value', comparator: 'less_than', target: pbs })))
         .toBe('I **captured** a piece')
+    })
+  })
+
+  describe('census mobility — filter must not be dropped', () => {
+    it('allied major mobility > PBS', () => {
+      expect(s(census({ subject: 'allied', subjectFilter: 'major', operator: 'mobility', comparator: 'greater_than', target: pbs })))
+        .toBe('my major pieces have **more** legal moves than before')
+    })
+    it('allied knight mobility = 0', () => {
+      expect(s(census({ subject: 'allied', subjectFilter: 'knight', operator: 'mobility', comparator: 'equal_to', target: 'exact_number', targetTotal: 0 })))
+        .toBe('my knights have **0** legal moves')
+    })
+    it('enemy knight mobility = 0', () => {
+      expect(s(census({ subject: 'enemy', subjectFilter: 'knight', operator: 'mobility', comparator: 'equal_to', target: 'exact_number', targetTotal: 0 })))
+        .toBe('enemy knights have **0** legal moves')
+    })
+    it('enemy pawn-exclude mobility > PBS', () => {
+      expect(s(census({ subject: 'enemy', subjectFilter: 'pawn', subjectFilterMode: 'exclude', operator: 'mobility', comparator: 'greater_than', target: pbs })))
+        .toBe('enemy non-pawns have **more** legal moves than before')
+    })
+  })
+
+  describe('census value — idioms gated; honest fallthrough for enemy / filtered', () => {
+    it('enemy value > PBS (no promotion idiom)', () => {
+      expect(s(census({ subject: 'enemy', subjectFilter: 'any', operator: 'value', comparator: 'greater_than', target: pbs })))
+        .toBe("the enemy's team is **more valuable** than before")
+    })
+    it('enemy value < PBS (no capture idiom)', () => {
+      expect(s(census({ subject: 'enemy', subjectFilter: 'any', operator: 'value', comparator: 'less_than', target: pbs })))
+        .toBe("the enemy's team is **less valuable** than before")
+    })
+    it('allied knight value > PBS (filter preserved, no promotion idiom)', () => {
+      expect(s(census({ subject: 'allied', subjectFilter: 'knight', operator: 'value', comparator: 'greater_than', target: pbs })))
+        .toBe('my knights are **more valuable** than before')
+    })
+    it('allied knight value < PBS (filter preserved, no capture idiom)', () => {
+      expect(s(census({ subject: 'allied', subjectFilter: 'knight', operator: 'value', comparator: 'less_than', target: pbs })))
+        .toBe('my knights are **less valuable** than before')
+    })
+    it('allied non-king value > PBS (exclude filter preserved)', () => {
+      expect(s(census({ subject: 'allied', subjectFilter: 'king', subjectFilterMode: 'exclude', operator: 'value', comparator: 'greater_than', target: pbs })))
+        .toBe('my non-kings are **more valuable** than before')
+    })
+    it('allied any value > moved_piece (collection vs singular target)', () => {
+      expect(s(census({ subject: 'allied', subjectFilter: 'any', operator: 'value', comparator: 'greater_than', target: 'moved_piece' })))
+        .toBe('my team is **more valuable** than my moved piece')
     })
   })
 
@@ -192,6 +280,88 @@ describe('formatConditionSentence', () => {
       expect(s(census({ subject: 'allied', subjectFilter: 'rook', positionAxis: 'file', positionComparator: 'equal_to', positionTarget: 3, operator: 'count', comparator: 'greater_than', target: 'exact_number', targetTotal: 0 })))
         .toBe('I have at least one rook on the **c-file**')
     })
+    it('value + region + PBS: "value of X on rank Y is higher than before"', () => {
+      expect(s(census({ subject: 'allied', subjectFilter: 'rook', positionAxis: 'rank', positionComparator: 'equal_to', positionTarget: 5, operator: 'value', comparator: 'greater_than', target: pbs })))
+        .toBe('my rooks on rank 5 are **more valuable** than before')
+    })
+    it('value + region + numeric: "X on rank Y have N total value"', () => {
+      expect(s(census({ subject: 'allied', subjectFilter: 'rook', positionAxis: 'rank', positionComparator: 'equal_to', positionTarget: 5, operator: 'value', comparator: 'equal_to', target: 'exact_number', targetTotal: 10 })))
+        .toBe('my rooks on rank 5 have **exactly 10** total value')
+    })
+    it('mobility + region + PBS: "X on rank Y have more legal moves than before"', () => {
+      expect(s(census({ subject: 'allied', subjectFilter: 'rook', positionAxis: 'rank', positionComparator: 'equal_to', positionTarget: 5, operator: 'mobility', comparator: 'greater_than', target: pbs })))
+        .toBe('my rooks on rank 5 have **more** legal moves than before')
+    })
+    it('mobility + region + numeric: "X on rank Y have N legal moves"', () => {
+      expect(s(census({ subject: 'allied', subjectFilter: 'rook', positionAxis: 'rank', positionComparator: 'equal_to', positionTarget: 5, operator: 'mobility', comparator: 'equal_to', target: 'exact_number', targetTotal: 0 })))
+        .toBe('my rooks on rank 5 have **0** legal moves')
+    })
+  })
+
+  describe('census region vs singular_actor target', () => {
+    const reg = (op, cmp, extra) => census({
+      subject: 'allied', subjectFilter: 'rook', positionAxis: 'rank', positionComparator: 'equal_to', positionTarget: 5,
+      operator: op, comparator: cmp, target: 'moved_piece', ...extra
+    })
+    it('value > moved_piece (B)', () => {
+      expect(s(reg('value', 'greater_than')))
+        .toBe('I have at least one rook on rank 5 **more valuable** than my moved piece')
+    })
+    it('value < moved_piece', () => {
+      expect(s(reg('value', 'less_than')))
+        .toBe('I have at least one rook on rank 5 **less valuable** than my moved piece')
+    })
+    it('value >= moved_piece', () => {
+      expect(s(reg('value', 'greater_than_or_equal_to')))
+        .toBe('I have at least one rook on rank 5 **no less valuable** than my moved piece')
+    })
+    it('value <= moved_piece', () => {
+      expect(s(reg('value', 'less_than_or_equal_to')))
+        .toBe('I have at least one rook on rank 5 **no more valuable** than my moved piece')
+    })
+    it('value = moved_piece', () => {
+      expect(s(reg('value', 'equal_to')))
+        .toBe('I have at least one rook on rank 5 **equally valuable** to my moved piece')
+    })
+    it('count > moved_piece', () => {
+      expect(s(reg('count', 'greater_than')))
+        .toBe('I have **more** rooks on rank 5 than my moved piece')
+    })
+    it('count = moved_piece', () => {
+      expect(s(reg('count', 'equal_to')))
+        .toBe('I have the **same number** of rooks on rank 5 as my moved piece')
+    })
+    it('mobility > moved_piece', () => {
+      expect(s(reg('mobility', 'greater_than')))
+        .toBe('my rooks on rank 5 have **more** legal moves than my moved piece')
+    })
+    it('mobility = moved_piece', () => {
+      expect(s(reg('mobility', 'equal_to')))
+        .toBe('my rooks on rank 5 have the **same number** of legal moves as my moved piece')
+    })
+  })
+
+  describe('safeguard: unrenderable comparison surfaces a warning', () => {
+    it('SINGULAR_ACTOR target with count comparison', () => {
+      expect(s(rel({
+        subject: 'allied', subjectFilter: 'any', operator: 'attack',
+        target: 'moved_piece', targetFilter: 'any',
+        targetComparisonMetric: 'count', targetComparator: 'greater_than',
+        targetComparisonSource: 'exact_number', targetComparisonSourceTotal: 0
+      })))
+        .toBe("my pieces attack my moved piece ⚠ couldn't render target's count comparison")
+    })
+  })
+
+  describe('identity — degenerate same_piece pairs covered', () => {
+    it('captured_piece same_piece enemy_captured_piece', () => {
+      expect(s({ version: 2, kind: 'identity', subject: 'captured_piece', target: 'enemy_captured_piece' }))
+        .toBe("my capture is the same piece as enemy's just-captured piece")
+    })
+    it('moved_piece same_piece enemy_moved_piece', () => {
+      expect(s({ version: 2, kind: 'identity', subject: 'moved_piece', target: 'enemy_moved_piece' }))
+        .toBe("my moved piece is the same piece as enemy's just-moved piece")
+    })
   })
 
   describe('review fixes (A–D, agreement)', () => {
@@ -205,11 +375,11 @@ describe('formatConditionSentence', () => {
     })
     it('value = PBS, no filter', () => {
       expect(s(census({ subject: 'allied', subjectFilter: 'any', operator: 'value', comparator: 'equal_to', target: pbs })))
-        .toBe('my team value is **not changed**')
+        .toBe('my team is **equally valuable** as before')
     })
     it('value = PBS, exclude-king filter', () => {
       expect(s(census({ subject: 'allied', subjectFilter: 'king', subjectFilterMode: 'exclude', operator: 'value', comparator: 'equal_to', target: pbs })))
-        .toBe('the value of my non-king pieces is **not changed**')
+        .toBe('my non-kings are **equally valuable** as before')
     })
     it('exclude major → "non-major pieces" (no doubled noun)', () => {
       expect(s(census({ subject: 'enemy', subjectFilter: 'major', subjectFilterMode: 'exclude', operator: 'count', comparator: 'equal_to', target: 'exact_number', targetTotal: 0 })))
@@ -217,30 +387,312 @@ describe('formatConditionSentence', () => {
     })
     it('exclude major, relational value target-passive', () => {
       expect(s(rel({ subject: 'allied', subjectFilter: 'major', subjectFilterMode: 'exclude', subjectComparisonMetric: 'value', subjectComparator: 'greater_than', subjectComparisonSource: pbs, operator: 'attack', target: 'enemy', targetFilter: 'queen' })))
-        .toBe('enemy queen is attacked by **more** non-major pieces than before')
+        .toBe('enemy queens are attacked by my non-major pieces **more valuable** than before')
     })
   })
 
   describe('rare value/PBS guards (#3, #4)', () => {
     it('relational value = PBS, exclude filter', () => {
       expect(s(rel({ subject: 'enemy', subjectFilter: 'pawn', subjectFilterMode: 'exclude', subjectComparisonMetric: 'value', subjectComparator: 'equal_to', subjectComparisonSource: pbs, operator: 'shield', target: 'enemy', targetFilter: 'queen' })))
-        .toBe('enemy queen is shielded by the **same** non-pawn pieces as before')
+        .toBe('enemy queens are shielded by enemy non-pawns **equally valuable** as before')
     })
     it('relational value = PBS, no filter', () => {
       expect(s(rel({ subject: 'allied', subjectFilter: 'any', subjectComparisonMetric: 'value', subjectComparator: 'equal_to', subjectComparisonSource: pbs, operator: 'attack', target: 'enemy', targetFilter: 'queen' })))
-        .toBe('enemy queen is attacked by the **same** value as before')
+        .toBe('enemy queens are attacked by my pieces **equally valuable** as before')
     })
     it('census value >= PBS', () => {
       expect(s(census({ subject: 'allied', subjectFilter: 'any', operator: 'value', comparator: 'greater_than_or_equal_to', target: pbs })))
-        .toBe('my team value is **not lower** than before')
+        .toBe('my team is **no less valuable** than before')
     })
     it('census value <= PBS', () => {
       expect(s(census({ subject: 'allied', subjectFilter: 'any', operator: 'value', comparator: 'less_than_or_equal_to', target: pbs })))
-        .toBe('my team value is **not higher** than before')
+        .toBe('my team is **no more valuable** than before')
     })
     it('census value >= PBS, exclude-king filter', () => {
       expect(s(census({ subject: 'allied', subjectFilter: 'king', subjectFilterMode: 'exclude', operator: 'value', comparator: 'greater_than_or_equal_to', target: pbs })))
-        .toBe('the value of my non-king pieces is **not lower** than before')
+        .toBe('my non-kings are **no less valuable** than before')
+    })
+  })
+
+  describe('relational — moved_piece as subject (singular, active voice)', () => {
+    it('moved_piece any attack enemy king', () => {
+      expect(s(rel({ subject: 'moved_piece', subjectFilter: 'any', operator: 'attack', target: 'enemy', targetFilter: 'king' })))
+        .toBe('my moved piece attacks enemy king')
+    })
+    it('moved_piece queen attack enemy king', () => {
+      expect(s(rel({ subject: 'moved_piece', subjectFilter: 'queen', subjectFilterMode: 'include', operator: 'attack', target: 'enemy', targetFilter: 'king' })))
+        .toBe('my moved queen attacks enemy king')
+    })
+    it('moved_piece king adjacent allied rook', () => {
+      expect(s(rel({ subject: 'moved_piece', subjectFilter: 'king', subjectFilterMode: 'include', operator: 'adjacent', target: 'allied', targetFilter: 'rook', targetFilterMode: 'include' })))
+        .toBe('my moved king is adjacent to my rook')
+    })
+    it('moved_piece any adjacent allied knight', () => {
+      expect(s(rel({ subject: 'moved_piece', subjectFilter: 'any', operator: 'adjacent', target: 'allied', targetFilter: 'knight', targetFilterMode: 'include' })))
+        .toBe('my moved piece is adjacent to my knight')
+    })
+    it('moved_piece pawn defend allied pawn (target count > PBS)', () => {
+      expect(s(rel({
+        subject: 'moved_piece', subjectFilter: 'pawn', subjectFilterMode: 'include',
+        operator: 'defend',
+        target: 'allied', targetFilter: 'pawn', targetFilterMode: 'include',
+        targetComparisonMetric: 'count', targetComparator: 'greater_than', targetComparisonSource: pbs
+      })))
+        .toBe('my moved pawn defends **more** of my pawns than before')
+    })
+    it('moved_piece any defend allied major (target count > PBS)', () => {
+      expect(s(rel({
+        subject: 'moved_piece', subjectFilter: 'any',
+        operator: 'defend',
+        target: 'allied', targetFilter: 'major', targetFilterMode: 'include',
+        targetComparisonMetric: 'count', targetComparator: 'greater_than', targetComparisonSource: pbs
+      })))
+        .toBe('my moved piece defends **more** of my major pieces than before')
+    })
+    it('target count = PBS: "X attack the same number of Y as before"', () => {
+      expect(s(rel({
+        subject: 'allied', subjectFilter: 'any',
+        operator: 'attack',
+        target: 'enemy', targetFilter: 'queen',
+        targetComparisonMetric: 'count', targetComparator: 'equal_to', targetComparisonSource: pbs
+      })))
+        .toBe('my pieces attack the **same number** of enemy queens as before')
+    })
+    it('moved_piece + target count = PBS: "my moved piece attacks the same number of Y as before"', () => {
+      expect(s(rel({
+        subject: 'moved_piece', subjectFilter: 'any',
+        operator: 'attack',
+        target: 'enemy', targetFilter: 'queen',
+        targetComparisonMetric: 'count', targetComparator: 'equal_to', targetComparisonSource: pbs
+      })))
+        .toBe('my moved piece attacks the **same number** of enemy queens as before')
+    })
+    it('subject count numeric + target count > PBS — target delta tail rendered', () => {
+      expect(s(rel({
+        subject: 'allied', subjectFilter: 'any',
+        subjectComparisonMetric: 'count', subjectComparator: 'greater_than', subjectComparisonSource: 'exact_number', subjectComparisonSourceTotal: 5,
+        operator: 'attack',
+        target: 'enemy', targetFilter: 'queen',
+        targetComparisonMetric: 'count', targetComparator: 'greater_than', targetComparisonSource: pbs
+      })))
+        .toBe('**more than 5** of my pieces attack **more** enemy queens than before')
+    })
+  })
+
+  describe('census value vs exact_number — filter awareness', () => {
+    it('allied non-king value = 34', () => {
+      expect(s(census({ subject: 'allied', subjectFilter: 'king', subjectFilterMode: 'exclude', operator: 'value', comparator: 'equal_to', target: 'exact_number', targetTotal: 34 })))
+        .toBe('my non-kings have **exactly 34** total value')
+    })
+    it('enemy major value > 20', () => {
+      expect(s(census({ subject: 'enemy', subjectFilter: 'major', subjectFilterMode: 'include', operator: 'value', comparator: 'greater_than', target: 'exact_number', targetTotal: 20 })))
+        .toBe('enemy major pieces have **more than 20** total value')
+    })
+    it('allied knight value < 10', () => {
+      expect(s(census({ subject: 'allied', subjectFilter: 'knight', operator: 'value', comparator: 'less_than', target: 'exact_number', targetTotal: 10 })))
+        .toBe('my knights have **less than 10** total value')
+    })
+  })
+
+  describe('relational value passive — target plurality drives is/are', () => {
+    it('plural target (exclude filter): "are shielded"', () => {
+      expect(s(rel({
+        subject: 'allied', subjectFilter: 'any',
+        subjectComparisonMetric: 'value', subjectComparator: 'greater_than', subjectComparisonSource: pbs,
+        operator: 'shield', target: 'enemy', targetFilter: 'pawn', targetFilterMode: 'exclude'
+      })))
+        .toBe('enemy non-pawns are shielded by my pieces **more valuable** than before')
+    })
+    it('plural target (any filter): "are attacked"', () => {
+      expect(s(rel({
+        subject: 'allied', subjectFilter: 'knight',
+        subjectComparisonMetric: 'value', subjectComparator: 'greater_than', subjectComparisonSource: pbs,
+        operator: 'attack', target: 'enemy', targetFilter: 'any'
+      })))
+        .toBe('enemy pieces are attacked by my knights **more valuable** than before')
+    })
+    it('allied major subject is plural (target count > PBS)', () => {
+      expect(s(rel({
+        subject: 'allied', subjectFilter: 'major',
+        operator: 'attack', target: 'enemy', targetFilter: 'queen',
+        targetComparisonMetric: 'count', targetComparator: 'greater_than', targetComparisonSource: pbs
+      })))
+        .toBe('my major pieces attack **more** enemy queens than before')
+    })
+    it('enemy minor subject is plural, passive value', () => {
+      expect(s(rel({
+        subject: 'allied', subjectFilter: 'any',
+        subjectComparisonMetric: 'value', subjectComparator: 'greater_than', subjectComparisonSource: pbs,
+        operator: 'attack', target: 'enemy', targetFilter: 'minor'
+      })))
+        .toBe('enemy minor pieces are attacked by my pieces **more valuable** than before')
+    })
+    it('plural target with same (= PBS): "are shielded by the same"', () => {
+      expect(s(rel({
+        subject: 'allied', subjectFilter: 'any',
+        subjectComparisonMetric: 'value', subjectComparator: 'equal_to', subjectComparisonSource: pbs,
+        operator: 'shield', target: 'enemy', targetFilter: 'pawn', targetFilterMode: 'exclude'
+      })))
+        .toBe('enemy non-pawns are shielded by my pieces **equally valuable** as before')
+    })
+  })
+
+  describe('relational value vs singular_actor source (template V)', () => {
+    it('value > moved_piece', () => {
+      expect(s(rel({
+        subject: 'allied', subjectFilter: 'any',
+        subjectComparisonMetric: 'value', subjectComparator: 'greater_than', subjectComparisonSource: 'moved_piece',
+        operator: 'attack', target: 'enemy', targetFilter: 'queen'
+      })))
+        .toBe('my pieces attacking enemy queens are **more valuable** than my moved piece')
+    })
+    it('value < captured_piece (also fixes captured_piece+filter in actorNoun)', () => {
+      expect(s(rel({
+        subject: 'allied', subjectFilter: 'knight',
+        subjectComparisonMetric: 'value', subjectComparator: 'less_than', subjectComparisonSource: 'captured_piece',
+        operator: 'attack', target: 'enemy', targetFilter: 'queen'
+      })))
+        .toBe('my knights attacking enemy queens are **less valuable** than my capture')
+    })
+    it('value = enemy_moved_piece', () => {
+      expect(s(rel({
+        subject: 'allied', subjectFilter: 'any',
+        subjectComparisonMetric: 'value', subjectComparator: 'equal_to', subjectComparisonSource: 'enemy_moved_piece',
+        operator: 'attack', target: 'enemy', targetFilter: 'queen'
+      })))
+        .toBe("my pieces attacking enemy queens are **equally valuable** to enemy's just-moved piece")
+    })
+    it('value < 5 (numeric)', () => {
+      expect(s(rel({
+        subject: 'allied', subjectFilter: 'knight',
+        subjectComparisonMetric: 'value', subjectComparator: 'less_than', subjectComparisonSource: 'exact_number', subjectComparisonSourceTotal: 5,
+        operator: 'attack', target: 'enemy', targetFilter: 'queen'
+      })))
+        .toBe('my knights attacking enemy queens are **less valuable** than 5')
+    })
+    it('value = 5 (numeric)', () => {
+      expect(s(rel({
+        subject: 'allied', subjectFilter: 'any',
+        subjectComparisonMetric: 'value', subjectComparator: 'equal_to', subjectComparisonSource: 'exact_number', subjectComparisonSourceTotal: 5,
+        operator: 'attack', target: 'enemy', targetFilter: 'queen'
+      })))
+        .toBe('my pieces attacking enemy queens are **equally valuable** to 5')
+    })
+  })
+
+  describe('relational target-side value (template V-flipped)', () => {
+    it('target individual_value > 5', () => {
+      expect(s(rel({
+        subject: 'allied', subjectFilter: 'knight',
+        operator: 'attack', target: 'enemy', targetFilter: 'any',
+        targetComparisonMetric: 'individual_value', targetComparator: 'greater_than',
+        targetComparisonSource: 'exact_number', targetComparisonSourceTotal: 5
+      })))
+        .toBe('enemy pieces attacked by my knights are **more valuable** than 5')
+    })
+    it('target individual_value > PBS', () => {
+      expect(s(rel({
+        subject: 'allied', subjectFilter: 'knight',
+        operator: 'attack', target: 'enemy', targetFilter: 'any',
+        targetComparisonMetric: 'individual_value', targetComparator: 'greater_than',
+        targetComparisonSource: pbs
+      })))
+        .toBe('enemy pieces attacked by my knights are **more valuable** than before')
+    })
+    it('target individual_value > moved_piece', () => {
+      expect(s(rel({
+        subject: 'allied', subjectFilter: 'knight',
+        operator: 'defend', target: 'allied', targetFilter: 'any',
+        targetComparisonMetric: 'individual_value', targetComparator: 'greater_than',
+        targetComparisonSource: 'moved_piece'
+      })))
+        .toBe('my pieces defended by my knights are **more valuable** than my moved piece')
+    })
+    it('target value = PBS', () => {
+      expect(s(rel({
+        subject: 'allied', subjectFilter: 'any',
+        operator: 'shield', target: 'enemy', targetFilter: 'queen',
+        targetComparisonMetric: 'value', targetComparator: 'equal_to', targetComparisonSource: pbs
+      })))
+        .toBe('enemy queens shielded by my pieces are **equally valuable** as before')
+    })
+    it('target individual_value < 3', () => {
+      expect(s(rel({
+        subject: 'allied', subjectFilter: 'any',
+        operator: 'attack', target: 'enemy', targetFilter: 'any',
+        targetComparisonMetric: 'individual_value', targetComparator: 'less_than',
+        targetComparisonSource: 'exact_number', targetComparisonSourceTotal: 3
+      })))
+        .toBe('enemy pieces attacked by my pieces are **less valuable** than 3')
+    })
+  })
+
+  describe('relational mixed/both-sides metric — integrated single sentence (neither PBS)', () => {
+    it('A1: subject value > 5 + target count > 3', () => {
+      expect(s(rel({
+        subject: 'allied', subjectFilter: 'any',
+        subjectComparisonMetric: 'value', subjectComparator: 'greater_than',
+        subjectComparisonSource: 'exact_number', subjectComparisonSourceTotal: 5,
+        operator: 'attack', target: 'enemy', targetFilter: 'any',
+        targetComparisonMetric: 'count', targetComparator: 'greater_than',
+        targetComparisonSource: 'exact_number', targetComparisonSourceTotal: 3
+      })))
+        .toBe('my pieces, **more valuable** than 5, are attacking **more than 3** enemy pieces')
+    })
+    it('A3: subject count > 3 + target individual_value > 5', () => {
+      expect(s(rel({
+        subject: 'allied', subjectFilter: 'any',
+        subjectComparisonMetric: 'count', subjectComparator: 'greater_than',
+        subjectComparisonSource: 'exact_number', subjectComparisonSourceTotal: 3,
+        operator: 'attack', target: 'enemy', targetFilter: 'any',
+        targetComparisonMetric: 'individual_value', targetComparator: 'greater_than',
+        targetComparisonSource: 'exact_number', targetComparisonSourceTotal: 5
+      })))
+        .toBe('**more than 3** of my pieces attack enemy pieces **more valuable** than 5')
+    })
+    it('A4: subject value > 5 + target individual_value > 3 (both value)', () => {
+      expect(s(rel({
+        subject: 'allied', subjectFilter: 'any',
+        subjectComparisonMetric: 'value', subjectComparator: 'greater_than',
+        subjectComparisonSource: 'exact_number', subjectComparisonSourceTotal: 5,
+        operator: 'attack', target: 'enemy', targetFilter: 'any',
+        targetComparisonMetric: 'individual_value', targetComparator: 'greater_than',
+        targetComparisonSource: 'exact_number', targetComparisonSourceTotal: 3
+      })))
+        .toBe('my pieces, **more valuable** than 5, are attacking enemy pieces **more valuable** than 3')
+    })
+    it('A5: subject value > moved_piece + target count > 3', () => {
+      expect(s(rel({
+        subject: 'allied', subjectFilter: 'any',
+        subjectComparisonMetric: 'value', subjectComparator: 'greater_than', subjectComparisonSource: 'moved_piece',
+        operator: 'attack', target: 'enemy', targetFilter: 'any',
+        targetComparisonMetric: 'count', targetComparator: 'greater_than',
+        targetComparisonSource: 'exact_number', targetComparisonSourceTotal: 3
+      })))
+        .toBe('my pieces, **more valuable** than my moved piece, are attacking **more than 3** enemy pieces')
+    })
+  })
+
+  describe('census value with singular_actor subject (filter preserved)', () => {
+    it('moved_piece knight value = 5 (exact_number)', () => {
+      expect(s(census({ subject: 'moved_piece', subjectFilter: 'knight', operator: 'value', comparator: 'equal_to', target: 'exact_number', targetTotal: 5 })))
+        .toBe('my moved knight has value **exactly 5**')
+    })
+    it('moved_piece pawn value < 3 (exact_number)', () => {
+      expect(s(census({ subject: 'moved_piece', subjectFilter: 'pawn', operator: 'value', comparator: 'less_than', target: 'exact_number', targetTotal: 3 })))
+        .toBe('my moved pawn has value **less than 3**')
+    })
+    it('captured_piece knight value = 3 (exact_number, captured_piece + filter)', () => {
+      expect(s(census({ subject: 'captured_piece', subjectFilter: 'knight', operator: 'value', comparator: 'equal_to', target: 'exact_number', targetTotal: 3 })))
+        .toBe('my captured knight has value **exactly 3**')
+    })
+    it('moved_piece knight value = PBS', () => {
+      expect(s(census({ subject: 'moved_piece', subjectFilter: 'knight', operator: 'value', comparator: 'equal_to', target: pbs })))
+        .toBe('my moved knight is **equally valuable** as before')
+    })
+    it('moved_piece knight value > PBS', () => {
+      expect(s(census({ subject: 'moved_piece', subjectFilter: 'knight', operator: 'value', comparator: 'greater_than', target: pbs })))
+        .toBe('my moved knight is **more valuable** than before')
     })
   })
 })

--- a/app/javascript/editorV2/__tests__/conditionPreviewSentence.test.js
+++ b/app/javascript/editorV2/__tests__/conditionPreviewSentence.test.js
@@ -453,6 +453,47 @@ describe('formatConditionSentence', () => {
     })
   })
 
+  describe("relational — adjacent never falls back to attack's verb forms", () => {
+    it('subject value direct: "adjacent to", not "attacking"', () => {
+      expect(s(rel({
+        subject: 'allied', subjectFilter: 'any',
+        subjectComparisonMetric: 'aggregate_value', subjectComparator: 'greater_than',
+        subjectComparisonSource: 'exact_number', subjectComparisonSourceTotal: 5,
+        operator: 'adjacent', target: 'enemy', targetFilter: 'any'
+      })))
+        .toBe('my pieces adjacent to enemy pieces are **more valuable** than 5')
+    })
+    it('subject value = PBS (passive frame): "adjacent to", not "attacked by"', () => {
+      expect(s(rel({
+        subject: 'allied', subjectFilter: 'any',
+        subjectComparisonMetric: 'aggregate_value', subjectComparator: 'equal_to',
+        subjectComparisonSource: pbs,
+        operator: 'adjacent', target: 'enemy', targetFilter: 'queen'
+      })))
+        .toBe('enemy queens are adjacent to my pieces **equally valuable** as before')
+    })
+    it('target value (passive clause): "adjacent to", not "attacked by"', () => {
+      expect(s(rel({
+        subject: 'allied', subjectFilter: 'any',
+        operator: 'adjacent', target: 'enemy', targetFilter: 'queen',
+        targetComparisonMetric: 'aggregate_value', targetComparator: 'greater_than',
+        targetComparisonSource: 'exact_number', targetComparisonSourceTotal: 5
+      })))
+        .toBe('enemy queens adjacent to my pieces are **more valuable** than 5')
+    })
+    it('integrated continuous: "are adjacent to", not "are attacking"', () => {
+      expect(s(rel({
+        subject: 'allied', subjectFilter: 'any',
+        subjectComparisonMetric: 'aggregate_value', subjectComparator: 'greater_than',
+        subjectComparisonSource: 'exact_number', subjectComparisonSourceTotal: 5,
+        operator: 'adjacent', target: 'enemy_moved_piece', targetFilter: 'any',
+        targetComparisonMetric: 'count', targetComparator: 'equal_to',
+        targetComparisonSource: 'exact_number', targetComparisonSourceTotal: 1
+      })))
+        .toBe("my pieces, **more valuable** than 5, are adjacent to enemy's just-moved piece")
+    })
+  })
+
   describe('identity — degenerate same_piece pairs covered', () => {
     it('captured_piece same_piece enemy_captured_piece', () => {
       expect(s({ version: 2, kind: 'identity', subject: 'captured_piece', target: 'enemy_captured_piece' }))

--- a/app/javascript/editorV2/handlers/ToolbarHandler.js
+++ b/app/javascript/editorV2/handlers/ToolbarHandler.js
@@ -1,5 +1,6 @@
 import TemplatePicker from 'editorV2/templates/TemplatePicker'
 import { findTemplateAnchor } from 'editorV2/templates/TemplatePlacement'
+import { getConditionPreviewMode, setConditionPreviewMode } from 'editorV2/utils/conditionPreviewFormatter'
 
 
 class ToolbarHandler {
@@ -61,6 +62,15 @@ class ToolbarHandler {
     if (deleteBtn) {
       deleteBtn.addEventListener('click', () => this.handleDeleteClick())
     }
+    // Condition-preview mode toggle (sentences ↔ chunks)
+    const previewModeBtn = document.querySelector('.btn-toggle-preview-mode')
+    if (previewModeBtn) {
+      this.syncPreviewModeButton(previewModeBtn)
+      previewModeBtn.addEventListener('click', () => {
+        setConditionPreviewMode(getConditionPreviewMode() === 'chunks' ? 'sentence' : 'chunks')
+        this.syncPreviewModeButton(previewModeBtn)
+      })
+    }
     if (this.renameButton) {
       this.renameButton.addEventListener('click', this.boundHandleRenameOpen)
     }
@@ -81,6 +91,12 @@ class ToolbarHandler {
     this.attachTemplatePicker()
   }
   
+  syncPreviewModeButton(button) {
+    const sentences = getConditionPreviewMode() !== 'chunks'
+    button.setAttribute('aria-pressed', String(sentences))
+    button.textContent = `Sentences: ${sentences ? 'on' : 'off'}`
+  }
+
   async handleAddNode(e) {
     const type = e.target.dataset.type
     if (type) await this.actions?.addNode(type)

--- a/app/javascript/editorV2/handlers/ToolbarHandler.js
+++ b/app/javascript/editorV2/handlers/ToolbarHandler.js
@@ -62,7 +62,6 @@ class ToolbarHandler {
     if (deleteBtn) {
       deleteBtn.addEventListener('click', () => this.handleDeleteClick())
     }
-    // Condition-preview mode toggle (sentences ↔ chunks)
     const previewModeBtn = document.querySelector('.btn-toggle-preview-mode')
     if (previewModeBtn) {
       this.syncPreviewModeButton(previewModeBtn)

--- a/app/javascript/editorV2/rendering/CanvasViewport.js
+++ b/app/javascript/editorV2/rendering/CanvasViewport.js
@@ -30,12 +30,10 @@ class CanvasViewport {
     this.rafId = null
     this.zoomInButton = document.getElementById('zoom-in')
     this.zoomOutButton = document.getElementById('zoom-out')
-    this.zoomResetButton = document.getElementById('zoom-reset')
 
     this.boundHandleResize = this.handleResize.bind(this)
     this.boundZoomIn = this.zoomIn.bind(this)
     this.boundZoomOut = this.zoomOut.bind(this)
-    this.boundZoomReset = this.zoomReset.bind(this)
     this.unsubscribe = this.store.subscribe(this.handleStoreChange.bind(this))
 
     if (typeof ResizeObserver !== 'undefined') {
@@ -53,7 +51,6 @@ class CanvasViewport {
   attachControls() {
     this.zoomInButton?.addEventListener('click', this.boundZoomIn)
     this.zoomOutButton?.addEventListener('click', this.boundZoomOut)
-    this.zoomResetButton?.addEventListener('click', this.boundZoomReset)
   }
 
   handleResize() {
@@ -411,10 +408,6 @@ class CanvasViewport {
     this.zoomBy(-ZOOM_STEP)
   }
 
-  zoomReset() {
-    this.fitToGraph()
-  }
-
   destroy() {
     if (this.rafId) {
       cancelAnimationFrame(this.rafId)
@@ -422,7 +415,6 @@ class CanvasViewport {
 
     this.zoomInButton?.removeEventListener('click', this.boundZoomIn)
     this.zoomOutButton?.removeEventListener('click', this.boundZoomOut)
-    this.zoomResetButton?.removeEventListener('click', this.boundZoomReset)
 
     this.unsubscribe()
 

--- a/app/javascript/editorV2/utils/conditionPreviewFormatter.js
+++ b/app/javascript/editorV2/utils/conditionPreviewFormatter.js
@@ -172,8 +172,8 @@ function unaryTargetComparisonPreview({ comparator, target, targetFilter, target
   return `${comparatorLabel(comparator)} ${unaryTargetPreview({ target, targetFilter, targetFilterMode, targetTotal })}`
 }
 
-function metricPreview({ operator, comparator, targetTotal }) {
-  return `${operatorLabel(operator)} ${comparatorLabel(comparator)} ${targetTotal}`
+function metricPreview({ operator, comparator, target, targetTotal }) {
+  return `${operatorLabel(operator)} ${comparatorLabel(comparator)} ${unaryTargetPreview({ target, targetTotal })}`
 }
 
 function previewText({ left, operator, right }) {
@@ -310,14 +310,18 @@ const SPECIES = {
   king: 'king', queen: 'queen', rook: 'rook', bishop: 'bishop',
   knight: 'knight', pawn: 'pawn', major: 'major piece', minor: 'minor piece'
 }
-const ACTIVE_VERB = {
-  attack: ['attacks', 'attack'],
-  defend: ['defends', 'defend'],
-  cover: ['covers', 'cover'],
-  targets: ['targets', 'target'],
-  adjacent: ['is adjacent to', 'are adjacent to']
+const OPERATORS = {
+  attack:   { active: ['attacks', 'attack'],                 passive: 'attacked',  gerund: 'attacking' },
+  defend:   { active: ['defends', 'defend'],                 passive: 'defended',  gerund: 'defending' },
+  cover:    { active: ['covers', 'cover'],                   passive: 'covered',   gerund: 'covering' },
+  shield:   { active: ['shields', 'shield'],                 passive: 'shielded',  gerund: 'shielding' },
+  targets:  { active: ['targets', 'target'],                 passive: 'targeted',  gerund: 'targeting' },
+  adjacent: { active: ['is adjacent to', 'are adjacent to'] }
 }
-const PASSIVE_VERB = { attack: 'attacked', defend: 'defended', shield: 'shielded' }
+
+function opForm(operator, form) {
+  return OPERATORS[operator]?.[form] || OPERATORS.attack[form]
+}
 
 function noun(filter, filterMode, plural) {
   if (!filter || filter === 'any') { return plural ? 'pieces' : 'piece' }
@@ -329,16 +333,7 @@ function noun(filter, filterMode, plural) {
   return plural ? `${base}s` : base
 }
 
-// Value/relation "pieces" phrase: exclude → "non-X pieces", species → plural,
-// no filter → "value". Shared by relational target-passive and census value.
-function filteredPieces(filter, filterMode) {
-  if (!filter || filter === 'any') { return 'value' }
-  if (filterMode === 'exclude') { return `non-${filter} pieces` }
-  return `${SPECIES[filter] || filter}s`
-}
-
-// Quantifier word/phrase + whether it carries emphasis, for count comparisons.
-function quantify({ comparator, source, total }) {
+function quantifyCount({ comparator, source, total }) {
   if (source === 'prior_board_state') {
     switch (comparator) {
       case 'greater_than': return { q: 'more', delta: true }
@@ -359,78 +354,31 @@ function quantify({ comparator, source, total }) {
   }
 }
 
-// "<Q> of my <plural>" / "<Q> enemy <noun>" — the locked of-my / enemy asymmetry.
-function countedGroup(token, filter, filterMode, info) {
-  if (token === 'allied') { return `of my ${noun(filter, filterMode, true)}` }
-  return `enemy ${noun(filter, filterMode, !info.atLeastOne)}`
+function comparatorValuableWord(comparator) {
+  switch (comparator) {
+    case 'greater_than': return 'more valuable'
+    case 'less_than': return 'less valuable'
+    case 'greater_than_or_equal_to': return 'no less valuable'
+    case 'less_than_or_equal_to': return 'no more valuable'
+    default: return 'equally valuable'
+  }
 }
 
-function actorNoun(token, filter, filterMode) {
-  if (SINGULAR_ACTOR[token]) {
-    const base = SINGULAR_ACTOR[token]
-    if (filter && filter !== 'any' && base.endsWith('piece')) {
-      return base.replace(/piece$/, SPECIES[filter] || filter)
-    }
-    return base
-  }
-  const poss = token === 'allied' ? 'my' : 'enemy'
-  if (!filter || filter === 'any') { return `${poss} pieces` }
-  if (filterMode === 'exclude') { return `${poss} non-${filter} pieces` }
-  return `${poss} ${SPECIES[filter] || filter}`
+function valuableConnector(comparator, source) {
+  if (comparator !== 'equal_to') return 'than'
+  return source === 'prior_board_state' ? 'as' : 'to'
 }
 
-function tail(info) {
-  if (!info.delta) { return '' }
-  return info.same ? ' as before' : ' than before'
+function valuableRef(source, total) {
+  if (source === 'prior_board_state') return 'before'
+  if (SINGULAR_ACTOR[source]) return SINGULAR_ACTOR[source]
+  return String(Number(total))
 }
 
-function composeRelational(d) {
-  if (d.operator === 'same_piece') {
-    return [{ text: 'I captured the piece the enemy just moved' }]
-  }
-  const targetNP = actorNoun(d.target, d.targetFilter, d.targetFilterMode)
-  const metric = d.subjectComparisonMetric
-
-  if (metric && metric !== 'count') {
-    // value (incl. aggregate_value/individual_value) → target-passive
-    const info = quantify({
-      comparator: d.subjectComparator, source: d.subjectComparisonSource,
-      total: d.subjectComparisonSourceTotal
-    })
-    const pieces = filteredPieces(d.subjectFilter, d.subjectFilterMode)
-    const passive = PASSIVE_VERB[d.operator] || PASSIVE_VERB.attack
-    if (info.same) {
-      return [
-        { text: `${targetNP} is ${passive} by the ` },
-        { text: 'same', emphasis: true },
-        { text: ` ${pieces} as before` }
-      ]
-    }
-    return [
-      { text: `${targetNP} is ${passive} by ` },
-      { text: info.q, emphasis: true },
-      { text: ` ${pieces}${tail(info)}` }
-    ]
-  }
-
-  // count metric, or bare condition (implicit count > 0)
-  const info = metric
-    ? quantify({ comparator: d.subjectComparator, source: d.subjectComparisonSource, total: d.subjectComparisonSourceTotal })
-    : { q: 'at least one', atLeastOne: true }
-  const verbPair = ACTIVE_VERB[d.operator] || ACTIVE_VERB.attack
-  const verb = info.atLeastOne ? verbPair[0] : verbPair[1]
-  const group = countedGroup(d.subject, d.subjectFilter, d.subjectFilterMode, info)
-
-  if (info.same) {
-    return [
-      { text: 'the ' },
-      { text: 'same number', emphasis: true },
-      { text: ` of ${d.subject === 'allied' ? 'my' : 'enemy'} ${noun(d.subjectFilter, d.subjectFilterMode, true)} ${verbPair[1]} ${targetNP} as before` }
-    ]
-  }
+function valueModifierSegments(comparator, source, total) {
   return [
-    { text: info.q, emphasis: true },
-    { text: ` ${group} ${verb} ${targetNP}${tail(info)}` }
+    { text: comparatorValuableWord(comparator), emphasis: true },
+    { text: ` ${valuableConnector(comparator, source)} ${valuableRef(source, total)}` }
   ]
 }
 
@@ -445,74 +393,362 @@ function valueClause(comparator, n) {
   }
 }
 
+function actorNP(token, filter, filterMode, { plural: forcePlural = false } = {}) {
+  if (SINGULAR_ACTOR[token]) {
+    const base = SINGULAR_ACTOR[token]
+    if (filter && filter !== 'any') {
+      const sp = SPECIES[filter] || filter
+      if (base.endsWith('piece')) return { text: base.replace(/piece$/, sp), plural: false }
+      if (token === 'captured_piece') return { text: `my captured ${sp}`, plural: false }
+    }
+    return { text: base, plural: false }
+  }
+  const poss = token === 'allied' ? 'my' : 'enemy'
+  // 'any', exclude, and major/minor are inherently plural; a species pluralizes on demand.
+  const plural = forcePlural || !filter || filter === 'any' || filterMode === 'exclude' || filter === 'major' || filter === 'minor'
+  return { text: `${poss} ${noun(filter, filterMode, plural)}`, plural }
+}
+
+function relationalSideNP(token, filter, filterMode, info) {
+  if (!info || SINGULAR_ACTOR[token]) {
+    const np = actorNP(token, filter, filterMode)
+    return {
+      segments: [{ text: np.text }],
+      info: null,
+      plural: np.plural,
+      droppedInfo: !!(info && SINGULAR_ACTOR[token])
+    }
+  }
+  const body = token === 'allied'
+    ? `of my ${noun(filter, filterMode, true)}`
+    : `enemy ${noun(filter, filterMode, !info.atLeastOne)}`
+  return {
+    segments: [{ text: info.q, emphasis: true }, { text: ` ${body}` }],
+    info,
+    plural: !info.atLeastOne,
+    droppedInfo: false
+  }
+}
+
+function tail(info) {
+  if (!info || !info.delta) { return '' }
+  return info.same ? ' as before' : ' than before'
+}
+
+function composeRelationalValuePBS(d) {
+  const target = actorNP(d.target, d.targetFilter, d.targetFilterMode, { plural: true })
+  const subject = actorNP(d.subject, d.subjectFilter, d.subjectFilterMode, { plural: true })
+  const be = target.plural ? 'are' : 'is'
+  const passive = opForm(d.operator, 'passive')
+  return [
+    { text: `${target.text} ${be} ${passive} by ${subject.text} ` },
+    ...valueModifierSegments(d.subjectComparator, 'prior_board_state', undefined)
+  ]
+}
+
+function composeRelationalValueDirect(d) {
+  const subject = actorNP(d.subject, d.subjectFilter, d.subjectFilterMode, { plural: true })
+  const target = actorNP(d.target, d.targetFilter, d.targetFilterMode, { plural: true })
+  const gerund = opForm(d.operator, 'gerund')
+  const be = subject.plural ? 'are' : 'is'
+  return [
+    { text: `${subject.text} ${gerund} ${target.text} ${be} ` },
+    ...valueModifierSegments(d.subjectComparator, d.subjectComparisonSource, d.subjectComparisonSourceTotal)
+  ]
+}
+
+function composeRelationalTargetValueClause(d, { includePassive = true } = {}) {
+  const target = actorNP(d.target, d.targetFilter, d.targetFilterMode, { plural: true })
+  const subject = actorNP(d.subject, d.subjectFilter, d.subjectFilterMode, { plural: true })
+  const passive = opForm(d.operator, 'passive')
+  const passivePart = includePassive ? ` ${passive} by ${subject.text}` : ''
+  const be = target.plural ? 'are' : 'is'
+  return [
+    { text: `${target.text}${passivePart} ${be} ` },
+    ...valueModifierSegments(d.targetComparator, d.targetComparisonSource, d.targetComparisonSourceTotal)
+  ]
+}
+
+const SAME_PIECE_IDIOMS = {
+  'captured_piece+enemy_moved_piece': 'I captured the piece the enemy just moved',
+  'captured_piece+moved_piece': 'I moved and captured the same piece',
+  'enemy_captured_piece+enemy_moved_piece': 'the enemy moved and captured the same piece',
+  'enemy_captured_piece+moved_piece': 'the enemy captured the piece I just moved',
+  'captured_piece+enemy_captured_piece': "my capture is the same piece as enemy's just-captured piece",
+  'enemy_moved_piece+moved_piece': "my moved piece is the same piece as enemy's just-moved piece"
+}
+
+function composeRelationalSamePiece(d) {
+  const key = [d.subject, d.target].sort().join('+')
+  const idiom = SAME_PIECE_IDIOMS[key]
+  if (idiom) return [{ text: idiom }]
+  const subj = actorNP(d.subject, undefined, undefined).text
+  const tgt = actorNP(d.target, undefined, undefined).text
+  return [{ text: `${subj} is the same piece as ${tgt}` }]
+}
+
+function composeRelational(d) {
+  if (d.operator === 'same_piece') return composeRelationalSamePiece(d)
+  const subjectMetric = d.subjectComparisonMetric
+  const targetMetric = d.targetComparisonMetric
+  const subjectIsValue = subjectMetric && subjectMetric !== 'count'
+  const targetIsValue = targetMetric && targetMetric !== 'count'
+  const subjectIsCount = subjectMetric === 'count'
+  const targetIsCount = targetMetric === 'count'
+
+  if ((subjectIsValue && (targetIsValue || targetIsCount)) || (subjectIsCount && targetIsValue)) {
+    return composeRelationalIntegrated(d)
+  }
+  if (subjectIsValue) {
+    return d.subjectComparisonSource === 'prior_board_state'
+      ? composeRelationalValuePBS(d)
+      : composeRelationalValueDirect(d)
+  }
+  if (targetIsValue) {
+    return composeRelationalTargetValueClause(d, { includePassive: true })
+  }
+  return composeRelationalCountBranch(d)
+}
+
+function composeRelationalIntegrated(d) {
+  const subjectSide = renderRelationalSideWithMetric(d, 'subject')
+  const targetSide = renderRelationalSideWithMetric(d, 'target')
+  const verbPair = opForm(d.operator, 'active')
+  const gerund = opForm(d.operator, 'gerund')
+  // Verb: continuous when subject NP has a value modifier (parenthetical),
+  // simple when subject NP has a count quantifier or no modifier.
+  const verb = subjectSide.hasValueModifier
+    ? `${subjectSide.plural ? 'are' : 'is'} ${gerund}`
+    : (subjectSide.plural ? verbPair[1] : verbPair[0])
+  return [
+    ...subjectSide.segments,
+    { text: ` ${verb} ` },
+    ...targetSide.segments
+  ]
+}
+
+function renderRelationalSideWithMetric(d, side) {
+  const token = side === 'subject' ? d.subject : d.target
+  const filter = side === 'subject' ? d.subjectFilter : d.targetFilter
+  const filterMode = side === 'subject' ? d.subjectFilterMode : d.targetFilterMode
+  const metric = side === 'subject' ? d.subjectComparisonMetric : d.targetComparisonMetric
+  const comparator = side === 'subject' ? d.subjectComparator : d.targetComparator
+  const source = side === 'subject' ? d.subjectComparisonSource : d.targetComparisonSource
+  const total = side === 'subject' ? d.subjectComparisonSourceTotal : d.targetComparisonSourceTotal
+
+  if (metric === 'count') {
+    const info = quantifyCount({ comparator, source, total })
+    const np = relationalSideNP(token, filter, filterMode, info)
+    return { segments: np.segments, plural: np.plural, hasValueModifier: false }
+  }
+  if (metric) {
+    // value metric — postpositive modifier; commas on subject side, none on target side
+    const np = actorNP(token, filter, filterMode, { plural: true })
+    const valSegs = valueModifierSegments(comparator, source, total)
+    if (side === 'subject') {
+      return {
+        segments: [{ text: `${np.text}, ` }, ...valSegs, { text: ',' }],
+        plural: np.plural,
+        hasValueModifier: true
+      }
+    }
+    return {
+      segments: [{ text: `${np.text} ` }, ...valSegs],
+      plural: np.plural,
+      hasValueModifier: true
+    }
+  }
+  // No metric — plain NP
+  const np = actorNP(token, filter, filterMode, { plural: side === 'target' })
+  return { segments: [{ text: np.text }], plural: np.plural, hasValueModifier: false }
+}
+
+function composeRelationalCountBranch(d) {
+  const subjectInfo = d.subjectComparisonMetric === 'count'
+    ? quantifyCount({ comparator: d.subjectComparator, source: d.subjectComparisonSource, total: d.subjectComparisonSourceTotal })
+    : null
+  const targetInfo = d.targetComparisonMetric === 'count'
+    ? quantifyCount({ comparator: d.targetComparator, source: d.targetComparisonSource, total: d.targetComparisonSourceTotal })
+    : null
+  const defaultSubjectInfo = (!subjectInfo && !targetInfo && !SINGULAR_ACTOR[d.subject])
+    ? { q: 'at least one', atLeastOne: true } : null
+  const effectiveSubjectInfo = subjectInfo || defaultSubjectInfo
+
+  const verbPair = opForm(d.operator, 'active')
+
+  if (subjectInfo?.same) {
+    const targetNP = actorNP(d.target, d.targetFilter, d.targetFilterMode).text
+    return [
+      { text: 'the ' },
+      { text: 'same number', emphasis: true },
+      { text: ` of ${d.subject === 'allied' ? 'my' : 'enemy'} ${noun(d.subjectFilter, d.subjectFilterMode, true)} ${verbPair[1]} ${targetNP} as before` }
+    ]
+  }
+
+  if (targetInfo?.same && isCollectionSubject(d.target)) {
+    const subjectNP = relationalSideNP(d.subject, d.subjectFilter, d.subjectFilterMode, effectiveSubjectInfo)
+    const verb = subjectNP.plural ? verbPair[1] : verbPair[0]
+    return [
+      ...subjectNP.segments,
+      { text: ` ${verb} the ` },
+      { text: 'same number', emphasis: true },
+      { text: ` of ${d.target === 'allied' ? 'my' : 'enemy'} ${noun(d.targetFilter, d.targetFilterMode, true)} as before` }
+    ]
+  }
+
+  const subjectNP = relationalSideNP(d.subject, d.subjectFilter, d.subjectFilterMode, effectiveSubjectInfo)
+  const targetNP = relationalSideNP(d.target, d.targetFilter, d.targetFilterMode, targetInfo)
+  const verb = subjectNP.plural ? verbPair[1] : verbPair[0]
+
+  const warnings = []
+  if (subjectNP.droppedInfo) warnings.push("subject's count comparison")
+  if (targetNP.droppedInfo) warnings.push("target's count comparison")
+
+  const result = [
+    ...subjectNP.segments,
+    { text: ` ${verb} ` },
+    ...targetNP.segments,
+    { text: tail(subjectInfo) || tail(targetInfo) }
+  ]
+  if (warnings.length) {
+    result.push({ text: ` ⚠ couldn't render ${warnings.join(' and ')}` })
+  }
+  return result
+}
+
+function composeCensusValueSingularSubject(d) {
+  const subjectNP = actorNP(d.subject, d.subjectFilter, d.subjectFilterMode).text
+  if (d.target === 'exact_number') {
+    return [
+      { text: `${subjectNP} has value ` },
+      { text: valueClause(d.comparator, Number(d.targetTotal)), emphasis: true }
+    ]
+  }
+  return [
+    { text: `${subjectNP} is ` },
+    ...valueModifierSegments(d.comparator, d.target, undefined)
+  ]
+}
+
 function composeCensusWhole(d) {
-  const metric = d.operator
+  if (d.operator === 'mobility') return composeCensusMobility(d)
+  if (d.operator === 'value') return composeCensusValue(d)
+  return composeCensusCount(d)
+}
+
+function composeCensusMobility(d) {
   const collection = isCollectionSubject(d.subject)
+  const filtered = d.subjectFilter && d.subjectFilter !== 'any'
+  const np = collection && !filtered
+    ? { text: d.subject === 'enemy' ? 'enemy' : 'my pieces', plural: d.subject === 'allied' }
+    : actorNP(d.subject, d.subjectFilter, d.subjectFilterMode, { plural: collection })
+  const verb = np.plural ? 'have' : 'has'
+  const info = quantifyCount({ comparator: d.comparator, source: d.target, total: d.targetTotal })
+  return [
+    { text: `${np.text} ${verb} ` },
+    { text: info.q, emphasis: true },
+    { text: ` legal moves${tail(info)}` }
+  ]
+}
 
-  if (metric === 'mobility') {
-    const subj = collection
-      ? (d.subject === 'enemy' ? 'enemy' : 'my pieces')
-      : actorNoun(d.subject, d.subjectFilter, d.subjectFilterMode)
-    const verb = collection && d.subject === 'allied' ? 'have' : 'has'
-    const info = quantify({ comparator: d.comparator, source: d.target, total: d.targetTotal })
-    return [
-      { text: `${subj} ${verb} ` },
-      { text: info.q, emphasis: true },
-      { text: ` legal moves${tail(info)}` }
-    ]
-  }
+function composeCensusValue(d) {
+  if (canUsePromotionIdiom(d)) return composeCensusValuePromotionIdiom(d)
+  if (canUseCaptureIdiom(d)) return composeCensusValueCaptureIdiom(d)
+  if (SINGULAR_ACTOR[d.subject]) return composeCensusValueSingularSubject(d)
+  if (d.target === 'exact_number') return composeCensusValueCollectionExact(d)
+  return composeCensusValueCollection(d) // target is PBS or a singular actor
+}
 
-  if (metric === 'value') {
-    if (d.target === 'prior_board_state') {
-      if (d.comparator === 'greater_than') {
-        return [{ text: 'I ' }, { text: 'promoted', emphasis: true }, { text: ' a pawn' }]
-      }
-      if (d.comparator === 'less_than') {
-        return [{ text: 'I ' }, { text: 'captured', emphasis: true }, { text: ' a piece' }]
-      }
-      const poss = d.subject === 'enemy' ? "the enemy's" : 'my'
-      const filtered = d.subjectFilter && d.subjectFilter !== 'any'
-      const lead = filtered
-        ? `the value of ${poss} ${filteredPieces(d.subjectFilter, d.subjectFilterMode)} is `
-        : `${poss} team value is `
-      const phrase = d.comparator === 'greater_than_or_equal_to' ? 'not lower'
-        : d.comparator === 'less_than_or_equal_to' ? 'not higher'
-        : 'not changed'
-      const suffix = d.comparator === 'equal_to' ? '' : ' than before'
-      return [{ text: lead }, { text: phrase, emphasis: true }, { text: suffix }]
-    }
-    if (SINGULAR_ACTOR[d.target]) {
-      const word = d.comparator === 'less_than' ? 'less'
-        : d.comparator === 'greater_than_or_equal_to' ? 'no less'
-        : d.comparator === 'less_than_or_equal_to' ? 'no more'
-        : d.comparator === 'equal_to' ? 'equal' : 'more'
-      const connector = d.comparator === 'equal_to' ? 'as' : 'than'
-      return [
-        { text: 'I captured ' },
-        { text: word, emphasis: true },
-        { text: ` value ${connector} the enemy just did` }
-      ]
-    }
-    return [
-      { text: `${d.subject === 'enemy' ? 'enemy' : 'my'} pieces have ` },
-      { text: valueClause(d.comparator, Number(d.targetTotal)), emphasis: true },
-      { text: ' total value' }
-    ]
-  }
+function canUsePromotionIdiom(d) {
+  return d.subject === 'allied'
+    && (!d.subjectFilter || d.subjectFilter === 'any')
+    && d.target === 'prior_board_state'
+    && (d.comparator === 'greater_than' || d.comparator === 'less_than')
+}
 
-  // count
-  if (SINGULAR_ACTOR[d.subject]) {
-    const exists = d.comparator === 'greater_than'
-    if (d.subjectFilter && d.subjectFilter !== 'any') {
-      const sp = SPECIES[d.subjectFilter] || d.subjectFilter
-      return exists
-        ? [{ text: `${SINGULAR_ACTOR[d.subject]} ` }, { text: 'is', emphasis: true }, { text: ` a ${sp}` }]
-        : [{ text: `${SINGULAR_ACTOR[d.subject]} is ` }, { text: 'not', emphasis: true }, { text: ` a ${sp}` }]
-    }
-    if (exists) { return [{ text: 'I ' }, { text: 'capture', emphasis: true }, { text: ' a piece' }] }
-    return [{ text: 'this move ' }, { text: 'captures nothing', emphasis: true }]
+function canUseCaptureIdiom(d) {
+  return d.subject === 'captured_piece'
+    && d.target === 'enemy_captured_piece'
+    && (!d.subjectFilter || d.subjectFilter === 'any')
+}
+
+function composeCensusValuePromotionIdiom(d) {
+  const word = d.comparator === 'greater_than' ? 'promoted' : 'captured'
+  const tail_ = d.comparator === 'greater_than' ? ' a pawn' : ' a piece'
+  return [{ text: 'I ' }, { text: word, emphasis: true }, { text: tail_ }]
+}
+
+function composeCensusValueCaptureIdiom(d) {
+  const word = d.comparator === 'less_than' ? 'less'
+    : d.comparator === 'greater_than_or_equal_to' ? 'no less'
+    : d.comparator === 'less_than_or_equal_to' ? 'no more'
+    : d.comparator === 'equal_to' ? 'equal' : 'more'
+  const connector = d.comparator === 'equal_to' ? 'as' : 'than'
+  return [
+    { text: 'I captured ' },
+    { text: word, emphasis: true },
+    { text: ` value ${connector} the enemy just did` }
+  ]
+}
+
+function censusValueCollectionNP(d) {
+  const filtered = d.subjectFilter && d.subjectFilter !== 'any'
+  if (filtered) {
+    return actorNP(d.subject, d.subjectFilter, d.subjectFilterMode, { plural: true })
   }
-  const info = quantify({ comparator: d.comparator, source: d.target, total: d.targetTotal })
+  const poss = d.subject === 'enemy' ? "the enemy's" : 'my'
+  return { text: `${poss} team`, plural: false }
+}
+
+function composeCensusValueCollection(d) {
+  const np = censusValueCollectionNP(d)
+  const be = np.plural ? 'are' : 'is'
+  return [
+    { text: `${np.text} ${be} ` },
+    ...valueModifierSegments(d.comparator, d.target, undefined)
+  ]
+}
+
+function composeCensusValueCollectionExact(d) {
+  const np = actorNP(d.subject, d.subjectFilter, d.subjectFilterMode, { plural: true })
+  const verb = np.plural ? 'have' : 'has'
+  return [
+    { text: `${np.text} ${verb} ` },
+    { text: valueClause(d.comparator, Number(d.targetTotal)), emphasis: true },
+    { text: ' total value' }
+  ]
+}
+
+function composeCensusCount(d) {
+  if (SINGULAR_ACTOR[d.subject]) return composeCensusCountSingularSubject(d)
+  return composeCensusCountCollection(d)
+}
+
+function singularActorExists(comparator, total) {
+  const n = Number(total)
+  switch (comparator) {
+    case 'equal_to': return n === 1
+    case 'greater_than': return n >= 0
+    case 'greater_than_or_equal_to': return n >= 1
+    case 'less_than_or_equal_to': return n >= 1
+    default: return false
+  }
+}
+
+function composeCensusCountSingularSubject(d) {
+  const exists = singularActorExists(d.comparator, d.targetTotal)
+  if (d.subjectFilter && d.subjectFilter !== 'any') {
+    const sp = SPECIES[d.subjectFilter] || d.subjectFilter
+    return exists
+      ? [{ text: `${SINGULAR_ACTOR[d.subject]} ` }, { text: 'is', emphasis: true }, { text: ` a ${sp}` }]
+      : [{ text: `${SINGULAR_ACTOR[d.subject]} is ` }, { text: 'not', emphasis: true }, { text: ` a ${sp}` }]
+  }
+  if (exists) return [{ text: 'I ' }, { text: 'capture', emphasis: true }, { text: ' a piece' }]
+  return [{ text: 'this move ' }, { text: 'captures nothing', emphasis: true }]
+}
+
+function composeCensusCountCollection(d) {
+  const info = quantifyCount({ comparator: d.comparator, source: d.target, total: d.targetTotal })
   const n = noun(d.subjectFilter, d.subjectFilterMode, !info.atLeastOne)
   return [
     { text: d.subject === 'enemy' ? 'enemy has ' : 'I have ' },
@@ -542,9 +778,27 @@ function regionPhrase(d) {
 }
 
 function composeCensusRegion(d) {
+  if (d.operator === 'mobility') return composeCensusRegionMobility(d)
+  if (d.operator === 'value') return composeCensusRegionValue(d)
+  return composeCensusRegionCount(d)
+}
+
+// Count word for region comparisons against a singular actor.
+function regionCountWord(comparator) {
+  switch (comparator) {
+    case 'greater_than': return 'more'
+    case 'less_than': return 'fewer'
+    case 'greater_than_or_equal_to': return 'no fewer'
+    case 'less_than_or_equal_to': return 'no more'
+    default: return 'same number'
+  }
+}
+
+function composeCensusRegionCount(d) {
   const region = regionPhrase(d)
+  if (SINGULAR_ACTOR[d.target]) { return composeCensusRegionCountVsSingular(d) }
   if (d.target === 'prior_board_state') {
-    const info = quantify({ comparator: d.comparator, source: 'prior_board_state' })
+    const info = quantifyCount({ comparator: d.comparator, source: 'prior_board_state' })
     const group = d.subject === 'allied'
       ? `of my ${noun(d.subjectFilter, d.subjectFilterMode, true)}`
       : `enemy ${noun(d.subjectFilter, d.subjectFilterMode, true)}`
@@ -553,7 +807,7 @@ function composeCensusRegion(d) {
       { text: ` ${group} are ${region.prefix}${region.bound} than before` }
     ]
   }
-  const info = quantify({ comparator: d.comparator, source: d.target, total: d.targetTotal })
+  const info = quantifyCount({ comparator: d.comparator, source: d.target, total: d.targetTotal })
   const n = noun(d.subjectFilter, d.subjectFilterMode, !info.atLeastOne)
   const lead = d.subject === 'enemy' ? 'enemy has ' : 'I have '
   return [
@@ -562,15 +816,111 @@ function composeCensusRegion(d) {
   ]
 }
 
+function composeCensusRegionCountVsSingular(d) {
+  const region = regionPhrase(d)
+  const lead = d.subject === 'enemy' ? 'enemy has' : 'I have'
+  const n = noun(d.subjectFilter, d.subjectFilterMode, true)
+  const ref = SINGULAR_ACTOR[d.target]
+  if (d.comparator === 'equal_to') {
+    return [
+      { text: `${lead} the ` },
+      { text: 'same number', emphasis: true },
+      { text: ` of ${n} ${region.prefix}${region.bound} as ${ref}` }
+    ]
+  }
+  return [
+    { text: `${lead} ` },
+    { text: regionCountWord(d.comparator), emphasis: true },
+    { text: ` ${n} ${region.prefix}${region.bound} than ${ref}` }
+  ]
+}
+
+function composeCensusRegionMobility(d) {
+  const region = regionPhrase(d)
+  if (SINGULAR_ACTOR[d.target]) { return composeCensusRegionMobilityVsSingular(d) }
+  const np = actorNP(d.subject, d.subjectFilter, d.subjectFilterMode, { plural: true })
+  const verb = np.plural ? 'have' : 'has'
+  const info = quantifyCount({ comparator: d.comparator, source: d.target, total: d.targetTotal })
+  return [
+    { text: `${np.text} ${region.prefix}${region.bound} ${verb} ` },
+    { text: info.q, emphasis: true },
+    { text: ` legal moves${tail(info)}` }
+  ]
+}
+
+function composeCensusRegionMobilityVsSingular(d) {
+  const region = regionPhrase(d)
+  const np = actorNP(d.subject, d.subjectFilter, d.subjectFilterMode, { plural: true })
+  const verb = np.plural ? 'have' : 'has'
+  const ref = SINGULAR_ACTOR[d.target]
+  if (d.comparator === 'equal_to') {
+    return [
+      { text: `${np.text} ${region.prefix}${region.bound} ${verb} the ` },
+      { text: 'same number', emphasis: true },
+      { text: ` of legal moves as ${ref}` }
+    ]
+  }
+  return [
+    { text: `${np.text} ${region.prefix}${region.bound} ${verb} ` },
+    { text: regionCountWord(d.comparator), emphasis: true },
+    { text: ` legal moves than ${ref}` }
+  ]
+}
+
+function composeCensusRegionValue(d) {
+  const region = regionPhrase(d)
+  const np = actorNP(d.subject, d.subjectFilter, d.subjectFilterMode, { plural: true })
+  if (d.target === 'prior_board_state') {
+    const be = np.plural ? 'are' : 'is'
+    return [
+      { text: `${np.text} ${region.prefix}${region.bound} ${be} ` },
+      ...valueModifierSegments(d.comparator, 'prior_board_state', undefined)
+    ]
+  }
+  if (SINGULAR_ACTOR[d.target]) {
+    const lead = d.subject === 'enemy' ? 'enemy has' : 'I have'
+    const n = noun(d.subjectFilter, d.subjectFilterMode, false)
+    return [
+      { text: `${lead} at least one ${n} ${region.prefix}${region.bound} ` },
+      ...valueModifierSegments(d.comparator, d.target, undefined)
+    ]
+  }
+  const verb = np.plural ? 'have' : 'has'
+  return [
+    { text: `${np.text} ${region.prefix}${region.bound} ${verb} ` },
+    { text: valueClause(d.comparator, Number(d.targetTotal)), emphasis: true },
+    { text: ' total value' }
+  ]
+}
+
+const PREVIEW_MODE_KEY = 'conditionPreviewMode'
+
+export function getConditionPreviewMode() {
+  if (typeof window === 'undefined' || !window.localStorage) return 'sentence'
+  return window.localStorage.getItem(PREVIEW_MODE_KEY) === 'chunks' ? 'chunks' : 'sentence'
+}
+
+export function setConditionPreviewMode(mode) {
+  if (typeof window === 'undefined' || !window.localStorage) return
+  window.localStorage.setItem(PREVIEW_MODE_KEY, mode === 'chunks' ? 'chunks' : 'sentence')
+}
+
 export function formatConditionSentence(nodeData = {}) {
+  if (getConditionPreviewMode() === 'chunks') {
+    return [{ text: formatConditionPreview(nodeData).text }]
+  }
   const spec = sentenceSpec()[nodeData.kind]
   if (!spec) { return [{ text: '[invalid condition]' }] }
   const chunks = sentenceDescriptors(spec, nodeData).map(dscr => buildSentenceChunk(dscr, nodeData))
   const signature = chunks.map(c => c.role).join('|')
+  // The operator can be a spec const (identity → 'same_piece') absent from the
+  // raw payload, so read it from the assembled chunk rather than nodeData.
+  const operatorChunk = chunks.find(c => c.role === 'operator')
+  const d = operatorChunk ? { ...nodeData, operator: operatorChunk.operator } : nodeData
   switch (signature) {
-    case 'side|operator|side': return composeRelational(nodeData)
-    case 'side|operator|comparison': return composeCensusWhole(nodeData)
-    case 'side|region|metric': return composeCensusRegion(nodeData)
+    case 'side|operator|side': return composeRelational(d)
+    case 'side|operator|comparison': return composeCensusWhole(d)
+    case 'side|region|metric': return composeCensusRegion(d)
     default: return [{ text: '[invalid condition]' }]
   }
 }

--- a/app/javascript/editorV2/utils/conditionPreviewFormatter.js
+++ b/app/javascript/editorV2/utils/conditionPreviewFormatter.js
@@ -316,11 +316,16 @@ const OPERATORS = {
   cover:    { active: ['covers', 'cover'],                   passive: 'covered',   gerund: 'covering' },
   shield:   { active: ['shields', 'shield'],                 passive: 'shielded',  gerund: 'shielding' },
   targets:  { active: ['targets', 'target'],                 passive: 'targeted',  gerund: 'targeting' },
-  adjacent: { active: ['is adjacent to', 'are adjacent to'] }
+  adjacent: { active: ['is adjacent to', 'are adjacent to'], gerund: 'adjacent to' }
 }
 
 function opForm(operator, form) {
   return OPERATORS[operator]?.[form] || OPERATORS.attack[form]
+}
+
+// "attacked by" for directional verbs; the symmetric "adjacent to" takes no agent marker.
+function passiveBy(operator) {
+  return operator === 'adjacent' ? 'adjacent to' : `${opForm(operator, 'passive')} by`
 }
 
 function noun(filter, filterMode, plural) {
@@ -477,9 +482,8 @@ function composeRelationalValuePBS(d) {
   const target = actorNP(d.target, d.targetFilter, d.targetFilterMode, { plural: true })
   const subject = actorNP(d.subject, d.subjectFilter, d.subjectFilterMode, { plural: true })
   const be = areIs(target.plural)
-  const passive = opForm(d.operator, 'passive')
   return [
-    { text: `${target.text} ${be} ${passive} by ${subject.text} ` },
+    { text: `${target.text} ${be} ${passiveBy(d.operator)} ${subject.text} ` },
     ...valueModifierSegments(d.subjectComparator, 'prior_board_state', undefined)
   ]
 }
@@ -498,8 +502,7 @@ function composeRelationalValueDirect(d) {
 function composeRelationalTargetValueClause(d, { includePassive = true } = {}) {
   const target = actorNP(d.target, d.targetFilter, d.targetFilterMode, { plural: true })
   const subject = actorNP(d.subject, d.subjectFilter, d.subjectFilterMode, { plural: true })
-  const passive = opForm(d.operator, 'passive')
-  const passivePart = includePassive ? ` ${passive} by ${subject.text}` : ''
+  const passivePart = includePassive ? ` ${passiveBy(d.operator)} ${subject.text}` : ''
   const be = areIs(target.plural)
   return [
     { text: `${target.text}${passivePart} ${be} ` },

--- a/app/javascript/editorV2/utils/conditionPreviewFormatter.js
+++ b/app/javascript/editorV2/utils/conditionPreviewFormatter.js
@@ -329,19 +329,30 @@ function noun(filter, filterMode, plural) {
     if (filter === 'major' || filter === 'minor') { return `non-${filter} ${plural ? 'pieces' : 'piece'}` }
     return plural ? `non-${filter}s` : `non-${filter}`
   }
-  const base = SPECIES[filter] || filter
+  const base = speciesNoun(filter)
   return plural ? `${base}s` : base
+}
+
+function speciesNoun(filter) { return SPECIES[filter] || filter }
+function haveHas(plural) { return plural ? 'have' : 'has' }
+function areIs(plural) { return plural ? 'are' : 'is' }
+function teamHas(subject) { return subject === 'enemy' ? 'enemy has' : 'I have' }
+
+// Comparator → bare delta word, for "X more/fewer than before" and "vs a singular actor".
+function deltaCountWord(comparator) {
+  switch (comparator) {
+    case 'greater_than': return 'more'
+    case 'less_than': return 'fewer'
+    case 'greater_than_or_equal_to': return 'no fewer'
+    case 'less_than_or_equal_to': return 'no more'
+    default: return 'same number'
+  }
 }
 
 function quantifyCount({ comparator, source, total }) {
   if (source === 'prior_board_state') {
-    switch (comparator) {
-      case 'greater_than': return { q: 'more', delta: true }
-      case 'less_than': return { q: 'fewer', delta: true }
-      case 'greater_than_or_equal_to': return { q: 'no fewer', delta: true }
-      case 'less_than_or_equal_to': return { q: 'no more', delta: true }
-      default: return { q: 'same number', delta: true, same: true }
-    }
+    const q = deltaCountWord(comparator)
+    return { q, delta: true, same: q === 'same number' }
   }
   const n = Number(total)
   switch (comparator) {
@@ -397,7 +408,7 @@ function actorNP(token, filter, filterMode, { plural: forcePlural = false } = {}
   if (SINGULAR_ACTOR[token]) {
     const base = SINGULAR_ACTOR[token]
     if (filter && filter !== 'any') {
-      const sp = SPECIES[filter] || filter
+      const sp = speciesNoun(filter)
       if (base.endsWith('piece')) return { text: base.replace(/piece$/, sp), plural: false }
       if (token === 'captured_piece') return { text: `my captured ${sp}`, plural: false }
     }
@@ -415,8 +426,7 @@ function relationalSideNP(token, filter, filterMode, info) {
     return {
       segments: [{ text: np.text }],
       info: null,
-      plural: np.plural,
-      droppedInfo: !!(info && SINGULAR_ACTOR[token])
+      plural: np.plural
     }
   }
   const body = token === 'allied'
@@ -425,8 +435,7 @@ function relationalSideNP(token, filter, filterMode, info) {
   return {
     segments: [{ text: info.q, emphasis: true }, { text: ` ${body}` }],
     info,
-    plural: !info.atLeastOne,
-    droppedInfo: false
+    plural: !info.atLeastOne
   }
 }
 
@@ -435,10 +444,39 @@ function tail(info) {
   return info.same ? ' as before' : ' than before'
 }
 
+// Singular actors carry count only as existence: =1 participates (count omitted),
+// =0 negates. Other comparisons can't be rendered (gating prevents them).
+function countExistenceSense(comparator, total) {
+  if (comparator === 'equal_to' && Number(total) === 0) { return 'negate' }
+  if (comparator === 'equal_to' && Number(total) === 1) { return 'affirm' }
+  return 'warn'
+}
+
+function singularCountSense(d, side) {
+  const token = side === 'subject' ? d.subject : d.target
+  const metric = side === 'subject' ? d.subjectComparisonMetric : d.targetComparisonMetric
+  if (!SINGULAR_ACTOR[token] || metric !== 'count') { return null }
+  const comparator = side === 'subject' ? d.subjectComparator : d.targetComparator
+  const total = side === 'subject' ? d.subjectComparisonSourceTotal : d.targetComparisonSourceTotal
+  return countExistenceSense(comparator, total)
+}
+
+function negatedVerb(operator, plural) {
+  if (operator === 'adjacent') { return plural ? 'are not adjacent to' : 'is not adjacent to' }
+  return `${plural ? 'do' : 'does'} not ${opForm(operator, 'active')[1]}`
+}
+
+function appendCountWarnings(result, subjectSense, targetSense) {
+  const warnings = []
+  if (subjectSense === 'warn') { warnings.push("subject's count comparison") }
+  if (targetSense === 'warn') { warnings.push("target's count comparison") }
+  if (warnings.length) { result.push({ text: ` ⚠ couldn't render ${warnings.join(' and ')}` }) }
+}
+
 function composeRelationalValuePBS(d) {
   const target = actorNP(d.target, d.targetFilter, d.targetFilterMode, { plural: true })
   const subject = actorNP(d.subject, d.subjectFilter, d.subjectFilterMode, { plural: true })
-  const be = target.plural ? 'are' : 'is'
+  const be = areIs(target.plural)
   const passive = opForm(d.operator, 'passive')
   return [
     { text: `${target.text} ${be} ${passive} by ${subject.text} ` },
@@ -450,7 +488,7 @@ function composeRelationalValueDirect(d) {
   const subject = actorNP(d.subject, d.subjectFilter, d.subjectFilterMode, { plural: true })
   const target = actorNP(d.target, d.targetFilter, d.targetFilterMode, { plural: true })
   const gerund = opForm(d.operator, 'gerund')
-  const be = subject.plural ? 'are' : 'is'
+  const be = areIs(subject.plural)
   return [
     { text: `${subject.text} ${gerund} ${target.text} ${be} ` },
     ...valueModifierSegments(d.subjectComparator, d.subjectComparisonSource, d.subjectComparisonSourceTotal)
@@ -462,7 +500,7 @@ function composeRelationalTargetValueClause(d, { includePassive = true } = {}) {
   const subject = actorNP(d.subject, d.subjectFilter, d.subjectFilterMode, { plural: true })
   const passive = opForm(d.operator, 'passive')
   const passivePart = includePassive ? ` ${passive} by ${subject.text}` : ''
-  const be = target.plural ? 'are' : 'is'
+  const be = areIs(target.plural)
   return [
     { text: `${target.text}${passivePart} ${be} ` },
     ...valueModifierSegments(d.targetComparator, d.targetComparisonSource, d.targetComparisonSourceTotal)
@@ -511,20 +549,30 @@ function composeRelational(d) {
 }
 
 function composeRelationalIntegrated(d) {
+  // relational_mode locks the opposing comparison when one side uses prior_board_state, so neither side here is a prior_board_state source.
   const subjectSide = renderRelationalSideWithMetric(d, 'subject')
   const targetSide = renderRelationalSideWithMetric(d, 'target')
   const verbPair = opForm(d.operator, 'active')
   const gerund = opForm(d.operator, 'gerund')
+  const subjectSense = singularCountSense(d, 'subject')
+  const targetSense = singularCountSense(d, 'target')
+  const negate = subjectSense === 'negate' || targetSense === 'negate'
   // Verb: continuous when subject NP has a value modifier (parenthetical),
   // simple when subject NP has a count quantifier or no modifier.
-  const verb = subjectSide.hasValueModifier
-    ? `${subjectSide.plural ? 'are' : 'is'} ${gerund}`
-    : (subjectSide.plural ? verbPair[1] : verbPair[0])
-  return [
+  let verb
+  if (subjectSide.hasValueModifier) {
+    const be = areIs(subjectSide.plural)
+    verb = negate ? `${be} not ${gerund}` : `${be} ${gerund}`
+  } else {
+    verb = negate ? negatedVerb(d.operator, subjectSide.plural) : (subjectSide.plural ? verbPair[1] : verbPair[0])
+  }
+  const result = [
     ...subjectSide.segments,
     { text: ` ${verb} ` },
     ...targetSide.segments
   ]
+  appendCountWarnings(result, subjectSense, targetSense)
+  return result
 }
 
 function renderRelationalSideWithMetric(d, side) {
@@ -542,7 +590,6 @@ function renderRelationalSideWithMetric(d, side) {
     return { segments: np.segments, plural: np.plural, hasValueModifier: false }
   }
   if (metric) {
-    // value metric — postpositive modifier; commas on subject side, none on target side
     const np = actorNP(token, filter, filterMode, { plural: true })
     const valSegs = valueModifierSegments(comparator, source, total)
     if (side === 'subject') {
@@ -558,7 +605,6 @@ function renderRelationalSideWithMetric(d, side) {
       hasValueModifier: true
     }
   }
-  // No metric — plain NP
   const np = actorNP(token, filter, filterMode, { plural: side === 'target' })
   return { segments: [{ text: np.text }], plural: np.plural, hasValueModifier: false }
 }
@@ -598,11 +644,10 @@ function composeRelationalCountBranch(d) {
 
   const subjectNP = relationalSideNP(d.subject, d.subjectFilter, d.subjectFilterMode, effectiveSubjectInfo)
   const targetNP = relationalSideNP(d.target, d.targetFilter, d.targetFilterMode, targetInfo)
-  const verb = subjectNP.plural ? verbPair[1] : verbPair[0]
-
-  const warnings = []
-  if (subjectNP.droppedInfo) warnings.push("subject's count comparison")
-  if (targetNP.droppedInfo) warnings.push("target's count comparison")
+  const subjectSense = singularCountSense(d, 'subject')
+  const targetSense = singularCountSense(d, 'target')
+  const negate = subjectSense === 'negate' || targetSense === 'negate'
+  const verb = negate ? negatedVerb(d.operator, subjectNP.plural) : (subjectNP.plural ? verbPair[1] : verbPair[0])
 
   const result = [
     ...subjectNP.segments,
@@ -610,9 +655,7 @@ function composeRelationalCountBranch(d) {
     ...targetNP.segments,
     { text: tail(subjectInfo) || tail(targetInfo) }
   ]
-  if (warnings.length) {
-    result.push({ text: ` ⚠ couldn't render ${warnings.join(' and ')}` })
-  }
+  appendCountWarnings(result, subjectSense, targetSense)
   return result
 }
 
@@ -642,7 +685,7 @@ function composeCensusMobility(d) {
   const np = collection && !filtered
     ? { text: d.subject === 'enemy' ? 'enemy' : 'my pieces', plural: d.subject === 'allied' }
     : actorNP(d.subject, d.subjectFilter, d.subjectFilterMode, { plural: collection })
-  const verb = np.plural ? 'have' : 'has'
+  const verb = haveHas(np.plural)
   const info = quantifyCount({ comparator: d.comparator, source: d.target, total: d.targetTotal })
   return [
     { text: `${np.text} ${verb} ` },
@@ -702,7 +745,7 @@ function censusValueCollectionNP(d) {
 
 function composeCensusValueCollection(d) {
   const np = censusValueCollectionNP(d)
-  const be = np.plural ? 'are' : 'is'
+  const be = areIs(np.plural)
   return [
     { text: `${np.text} ${be} ` },
     ...valueModifierSegments(d.comparator, d.target, undefined)
@@ -711,7 +754,7 @@ function composeCensusValueCollection(d) {
 
 function composeCensusValueCollectionExact(d) {
   const np = actorNP(d.subject, d.subjectFilter, d.subjectFilterMode, { plural: true })
-  const verb = np.plural ? 'have' : 'has'
+  const verb = haveHas(np.plural)
   return [
     { text: `${np.text} ${verb} ` },
     { text: valueClause(d.comparator, Number(d.targetTotal)), emphasis: true },
@@ -724,34 +767,34 @@ function composeCensusCount(d) {
   return composeCensusCountCollection(d)
 }
 
-function singularActorExists(comparator, total) {
-  const n = Number(total)
-  switch (comparator) {
-    case 'equal_to': return n === 1
-    case 'greater_than': return n >= 0
-    case 'greater_than_or_equal_to': return n >= 1
-    case 'less_than_or_equal_to': return n >= 1
-    default: return false
-  }
+// Singular-actor existence (=1/=0). `warn` for any other (gated-out) comparator.
+function existenceWarn(d) {
+  return [{ text: `${SINGULAR_ACTOR[d.subject]} ` }, { text: "⚠ couldn't render count comparison" }]
+}
+
+// "{actor} is {predicate}" (affirm) / "{actor} is not {predicate}" (negate)
+function existenceSegments(actor, affirm, predicate) {
+  return affirm
+    ? [{ text: `${actor} ` }, { text: 'is', emphasis: true }, { text: ` ${predicate}` }]
+    : [{ text: `${actor} is ` }, { text: 'not', emphasis: true }, { text: ` ${predicate}` }]
 }
 
 function composeCensusCountSingularSubject(d) {
-  const exists = singularActorExists(d.comparator, d.targetTotal)
+  const sense = countExistenceSense(d.comparator, d.targetTotal)
+  if (sense === 'warn') { return existenceWarn(d) }
   if (d.subjectFilter && d.subjectFilter !== 'any') {
-    const sp = SPECIES[d.subjectFilter] || d.subjectFilter
-    return exists
-      ? [{ text: `${SINGULAR_ACTOR[d.subject]} ` }, { text: 'is', emphasis: true }, { text: ` a ${sp}` }]
-      : [{ text: `${SINGULAR_ACTOR[d.subject]} is ` }, { text: 'not', emphasis: true }, { text: ` a ${sp}` }]
+    return existenceSegments(SINGULAR_ACTOR[d.subject], sense === 'affirm', `a ${speciesNoun(d.subjectFilter)}`)
   }
-  if (exists) return [{ text: 'I ' }, { text: 'capture', emphasis: true }, { text: ' a piece' }]
-  return [{ text: 'this move ' }, { text: 'captures nothing', emphasis: true }]
+  return sense === 'affirm'
+    ? [{ text: 'I ' }, { text: 'capture', emphasis: true }, { text: ' a piece' }]
+    : [{ text: 'this move ' }, { text: 'captures nothing', emphasis: true }]
 }
 
 function composeCensusCountCollection(d) {
   const info = quantifyCount({ comparator: d.comparator, source: d.target, total: d.targetTotal })
   const n = noun(d.subjectFilter, d.subjectFilterMode, !info.atLeastOne)
   return [
-    { text: d.subject === 'enemy' ? 'enemy has ' : 'I have ' },
+    { text: `${teamHas(d.subject)} ` },
     { text: info.q, emphasis: true },
     { text: ` ${n}` }
   ]
@@ -783,18 +826,36 @@ function composeCensusRegion(d) {
   return composeCensusRegionCount(d)
 }
 
-// Count word for region comparisons against a singular actor.
-function regionCountWord(comparator) {
-  switch (comparator) {
-    case 'greater_than': return 'more'
-    case 'less_than': return 'fewer'
-    case 'greater_than_or_equal_to': return 'no fewer'
-    case 'less_than_or_equal_to': return 'no more'
-    default: return 'same number'
+function regionText(region) { return `${region.prefix}${region.bound}` }
+
+// "{lead} the **same number** of {unit} as {ref}" (equal_to)
+// "{lead} **{deltaWord}** {unit} than {ref}"        (otherwise)
+function comparisonVsSingular(lead, comparator, unit, ref) {
+  if (comparator === 'equal_to') {
+    return [
+      { text: `${lead} the ` },
+      { text: 'same number', emphasis: true },
+      { text: ` of ${unit} as ${ref}` }
+    ]
   }
+  return [
+    { text: `${lead} ` },
+    { text: deltaCountWord(comparator), emphasis: true },
+    { text: ` ${unit} than ${ref}` }
+  ]
+}
+
+function composeCensusRegionCountSingularSubject(d) {
+  const sense = countExistenceSense(d.comparator, d.targetTotal)
+  if (sense === 'warn') { return existenceWarn(d) }
+  const where = regionText(regionPhrase(d))
+  const filtered = d.subjectFilter && d.subjectFilter !== 'any'
+  const predicate = filtered ? `a ${speciesNoun(d.subjectFilter)} ${where}` : where
+  return existenceSegments(SINGULAR_ACTOR[d.subject], sense === 'affirm', predicate)
 }
 
 function composeCensusRegionCount(d) {
+  if (SINGULAR_ACTOR[d.subject]) { return composeCensusRegionCountSingularSubject(d) }
   const region = regionPhrase(d)
   if (SINGULAR_ACTOR[d.target]) { return composeCensusRegionCountVsSingular(d) }
   if (d.target === 'prior_board_state') {
@@ -804,90 +865,59 @@ function composeCensusRegionCount(d) {
       : `enemy ${noun(d.subjectFilter, d.subjectFilterMode, true)}`
     return [
       { text: info.q, emphasis: true },
-      { text: ` ${group} are ${region.prefix}${region.bound} than before` }
+      { text: ` ${group} are ${regionText(region)} than before` }
     ]
   }
   const info = quantifyCount({ comparator: d.comparator, source: d.target, total: d.targetTotal })
   const n = noun(d.subjectFilter, d.subjectFilterMode, !info.atLeastOne)
-  const lead = d.subject === 'enemy' ? 'enemy has ' : 'I have '
   return [
-    { text: `${lead}${info.q} ${n} ${region.prefix}` },
+    { text: `${teamHas(d.subject)} ${info.q} ${n} ${region.prefix}` },
     { text: region.bound, emphasis: true }
   ]
 }
 
 function composeCensusRegionCountVsSingular(d) {
-  const region = regionPhrase(d)
-  const lead = d.subject === 'enemy' ? 'enemy has' : 'I have'
-  const n = noun(d.subjectFilter, d.subjectFilterMode, true)
-  const ref = SINGULAR_ACTOR[d.target]
-  if (d.comparator === 'equal_to') {
-    return [
-      { text: `${lead} the ` },
-      { text: 'same number', emphasis: true },
-      { text: ` of ${n} ${region.prefix}${region.bound} as ${ref}` }
-    ]
-  }
-  return [
-    { text: `${lead} ` },
-    { text: regionCountWord(d.comparator), emphasis: true },
-    { text: ` ${n} ${region.prefix}${region.bound} than ${ref}` }
-  ]
+  const unit = `${noun(d.subjectFilter, d.subjectFilterMode, true)} ${regionText(regionPhrase(d))}`
+  return comparisonVsSingular(teamHas(d.subject), d.comparator, unit, SINGULAR_ACTOR[d.target])
 }
 
 function composeCensusRegionMobility(d) {
   const region = regionPhrase(d)
   if (SINGULAR_ACTOR[d.target]) { return composeCensusRegionMobilityVsSingular(d) }
   const np = actorNP(d.subject, d.subjectFilter, d.subjectFilterMode, { plural: true })
-  const verb = np.plural ? 'have' : 'has'
+  const verb = haveHas(np.plural)
   const info = quantifyCount({ comparator: d.comparator, source: d.target, total: d.targetTotal })
   return [
-    { text: `${np.text} ${region.prefix}${region.bound} ${verb} ` },
+    { text: `${np.text} ${regionText(region)} ${verb} ` },
     { text: info.q, emphasis: true },
     { text: ` legal moves${tail(info)}` }
   ]
 }
 
 function composeCensusRegionMobilityVsSingular(d) {
-  const region = regionPhrase(d)
   const np = actorNP(d.subject, d.subjectFilter, d.subjectFilterMode, { plural: true })
-  const verb = np.plural ? 'have' : 'has'
-  const ref = SINGULAR_ACTOR[d.target]
-  if (d.comparator === 'equal_to') {
-    return [
-      { text: `${np.text} ${region.prefix}${region.bound} ${verb} the ` },
-      { text: 'same number', emphasis: true },
-      { text: ` of legal moves as ${ref}` }
-    ]
-  }
-  return [
-    { text: `${np.text} ${region.prefix}${region.bound} ${verb} ` },
-    { text: regionCountWord(d.comparator), emphasis: true },
-    { text: ` legal moves than ${ref}` }
-  ]
+  const lead = `${np.text} ${regionText(regionPhrase(d))} ${haveHas(np.plural)}`
+  return comparisonVsSingular(lead, d.comparator, 'legal moves', SINGULAR_ACTOR[d.target])
 }
 
 function composeCensusRegionValue(d) {
   const region = regionPhrase(d)
   const np = actorNP(d.subject, d.subjectFilter, d.subjectFilterMode, { plural: true })
   if (d.target === 'prior_board_state') {
-    const be = np.plural ? 'are' : 'is'
     return [
-      { text: `${np.text} ${region.prefix}${region.bound} ${be} ` },
+      { text: `${np.text} ${regionText(region)} ${areIs(np.plural)} ` },
       ...valueModifierSegments(d.comparator, 'prior_board_state', undefined)
     ]
   }
   if (SINGULAR_ACTOR[d.target]) {
-    const lead = d.subject === 'enemy' ? 'enemy has' : 'I have'
     const n = noun(d.subjectFilter, d.subjectFilterMode, false)
     return [
-      { text: `${lead} at least one ${n} ${region.prefix}${region.bound} ` },
+      { text: `${teamHas(d.subject)} at least one ${n} ${regionText(region)} ` },
       ...valueModifierSegments(d.comparator, d.target, undefined)
     ]
   }
-  const verb = np.plural ? 'have' : 'has'
   return [
-    { text: `${np.text} ${region.prefix}${region.bound} ${verb} ` },
+    { text: `${np.text} ${regionText(region)} ${haveHas(np.plural)} ` },
     { text: valueClause(d.comparator, Number(d.targetTotal)), emphasis: true },
     { text: ' total value' }
   ]

--- a/app/javascript/vitest.setup.js
+++ b/app/javascript/vitest.setup.js
@@ -36,7 +36,7 @@ const SENTENCE_SPEC = {
       { role: 'region', fields: {
         position_axis: 'positionAxis', position_comparator: 'positionComparator',
         position_target: 'positionTarget' } },
-      { role: 'metric', fields: { operator: 'operator', comparator: 'comparator', target_total: 'targetTotal' } }
+      { role: 'metric', fields: { operator: 'operator', comparator: 'comparator', target: 'target', target_total: 'targetTotal' } }
     ]
   }
 }

--- a/app/presenters/node_presenter.rb
+++ b/app/presenters/node_presenter.rb
@@ -37,7 +37,7 @@ class NodePresenter
           'position_axis' => 'positionAxis', 'position_comparator' => 'positionComparator',
           'position_target' => 'positionTarget' } },
         { 'role' => 'metric', 'fields' => {
-          'operator' => 'operator', 'comparator' => 'comparator', 'target_total' => 'targetTotal' } }
+          'operator' => 'operator', 'comparator' => 'comparator', 'target' => 'target', 'target_total' => 'targetTotal' } }
       ]
     }
   }.freeze
@@ -49,7 +49,7 @@ class NodePresenter
     'operator' => %w[operator],
     'comparison' => %w[comparator target target_filter target_filter_mode target_total],
     'region' => %w[position_axis position_comparator position_target],
-    'metric' => %w[operator comparator target_total]
+    'metric' => %w[operator comparator target target_total]
   }.freeze
 
   def self.sentence_spec

--- a/app/views/bots/edit.html.erb
+++ b/app/views/bots/edit.html.erb
@@ -24,7 +24,6 @@
     
     <div class="toolbar-section">
       <h3>Tool</h3>
-      <button type="button" class="tool-select active" data-tool="select">Select</button>
       <button type="button" class="btn-delete-node" disabled title="Delete selected node (Delete/Backspace)">Delete</button>
       <button
         type="button"
@@ -36,10 +35,11 @@
 
     <div class="toolbar-section">
       <h3>View</h3>
+      <button type="button" class="btn-toggle-preview-mode" aria-pressed="true"
+        title="Show condition previews as plain-language sentences or terse chunks (reopen a panel to apply)">Sentences: on</button>
       <button type="button" id="zoom-out" class="btn-zoom">-</button>
       <span id="zoom-level">100%</span>
       <button type="button" id="zoom-in" class="btn-zoom">+</button>
-      <button type="button" id="zoom-reset" class="btn-zoom-reset">Reset</button>
     </div>
 
     <div class="toolbar-section">

--- a/spec/presenters/node_presenter_spec.rb
+++ b/spec/presenters/node_presenter_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe NodePresenter do
         { role: 'spacer' },
         { role: 'region', position_axis: 'rank', position_comparator: 'equal_to', position_target: 5 },
         { role: 'spacer' },
-        { role: 'metric', operator: 'count', comparator: 'greater_than', target_total: 0 }
+        { role: 'metric', operator: 'count', comparator: 'greater_than', target: 'exact_number', target_total: 0 }
       ])
     end
 


### PR DESCRIPTION
Overhauls the condition-preview panel in editorV2 so conditions render as plain-language sentences, adds a toolbar toggle to switch back to the terse chunk view, and removes dead toolbar controls. Builds on the
  NodePresenter chunk spec as the single source of truth (mirrored in vitest.setup.js).

  What changed

  Sentence composer (conditionPreviewFormatter.js)
  - Renders conditions as statement-voice sentences, dispatched on the chunk-role signature (side|operator|side, side|operator|comparison, side|region|metric) — never on node kind.
  - "Valuable" phrasing throughout (more valuable than, equally valuable as before, etc.); mixed-metric conditions render as one integrated sentence rather than and-joined clauses.
  - Singular actors (moved_piece, etc.) carry count as existence: =1 omits the count (affirmative), =0 negates ("my moved piece does not attack…"), other comparators surface a ⚠ safeguard. Applied consistently
  across relational and census (whole + region).
  - Fixed the adjacent operator falling back to attack's verb forms ("attacking"/"attacked by") in value frames.
  - Unrecognized/dropped chunk parts surface ⚠ couldn't render <field> rather than failing silently.

  Toolbar / view
  - New "Sentences: on/off" toggle (localStorage-backed, read at render time so reopening a panel reflects it).
  - Removed the dead Select and Reset buttons and their vestigial code/CSS.

  Presenter
  - NodePresenter region-metric chunk now carries target (so the terse preview shows the source instead of "undefined"); mirrored in vitest.setup.js.

  Test plan

  - conditionPreviewSentence / conditionPreviewFormatter / ToolbarHandler vitest suites
  - node_presenter_spec (RSpec)
  - Full JS suite green (1564 passed)
  - Manual: toggle sentences ↔ chunks in the editor; spot-check relational/census/identity/region previews