### PR TITLE
Main  UI intro

### DIFF
--- a/app/assets/stylesheets/chessboard.css
+++ b/app/assets/stylesheets/chessboard.css
@@ -157,6 +157,26 @@
   line-height: 1;
 }
 
+#chess-board.flipped {
+  transform: rotate(180deg);
+}
+
+#chess-board.flipped .board-piece-glyph {
+  transform: rotate(180deg);
+}
+
+.board-player-name {
+  margin: 8px auto;
+  text-align: center;
+  font-weight: bold;
+  color: #E5E5E5;
+}
+
+.board-player-name--active {
+  color: #d8c160;
+  text-shadow: 0 0 6px rgba(216, 193, 96, 0.7), 0 0 14px rgba(216, 193, 96, 0.4);
+}
+
 #W-captures {
   /* White's captured pieces - above board */
 }

--- a/app/assets/stylesheets/match_replay.css
+++ b/app/assets/stylesheets/match_replay.css
@@ -147,6 +147,24 @@
   padding: 0.2rem 0.5rem;
 }
 
+.match-replay-page .match-replay-controls button.replay-control--hint {
+  background: #d8c160;
+  color: #1a1815;
+  border-color: #d8c160;
+  box-shadow: 0 0 6px rgba(216, 193, 96, 0.6);
+  animation: replay-control-hint-pulse 4s ease-in-out infinite;
+}
+
+@keyframes replay-control-hint-pulse {
+  0%, 100% { box-shadow: 0 0 4px rgba(216, 193, 96, 0.4); }
+  50% { box-shadow: 0 0 10px rgba(216, 193, 96, 0.7); }
+}
+
+input[type="submit"].btn-rematch {
+  font-size: 0.75rem;
+  padding: 0.2rem 0.6rem;
+}
+
 .match-replay-page .match-replay-speed-buttons button {
   font-size: 0.8rem;
   padding: 0.15rem 0.4rem;

--- a/app/assets/stylesheets/node_editor.css
+++ b/app/assets/stylesheets/node_editor.css
@@ -2368,11 +2368,34 @@
 }
 
 .mini-board__tile {
+  position: relative;
   width: 40px;
   height: 40px;
   text-align: center;
   vertical-align: middle;
   user-select: none;
+}
+
+.mini-board__tile[data-file-letter="a"]::before,
+.mini-board__tile[data-rank-number="1"]::after {
+  position: absolute;
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 1;
+  color: rgba(40, 32, 24, 0.85);
+  pointer-events: none;
+}
+
+.mini-board__tile[data-file-letter="a"]::before {
+  content: attr(data-rank-number);
+  top: 1px;
+  left: 2px;
+}
+
+.mini-board__tile[data-rank-number="1"]::after {
+  content: attr(data-file-letter);
+  bottom: 0;
+  right: 2px;
 }
 
 .mini-board__tile--light {
@@ -2440,13 +2463,16 @@
 }
 
 .mini-piece--W {
-  color: #f5f0e8;
-  text-shadow: 0 0 2px #1a1410, 0 1px 3px rgba(0, 0, 0, 0.6);
+  color: #f8f4ec;
+  text-shadow:
+    -1px -1px 0 #2a2018,
+     1px -1px 0 #2a2018,
+    -1px  1px 0 #2a2018,
+     1px  1px 0 #2a2018;
 }
 
 .mini-piece--B {
   color: #1a1410;
-  text-shadow: 0 0 2px #f0d9b5, 0 1px 3px rgba(255, 255, 255, 0.35);
 }
 
 .mini-board__nav {

--- a/app/assets/stylesheets/node_editor.css
+++ b/app/assets/stylesheets/node_editor.css
@@ -1261,6 +1261,13 @@
   border-top: none;
 }
 
+.condition-form-radio-row input[type="radio"]:not(:checked) + span,
+.condition-form-scope-toggle input[type="radio"]:not(:checked) + span,
+.condition-form-radio-list input[type="radio"]:not(:checked) + span,
+.condition-form-comparator-toggle input[type="radio"]:not(:checked) + span {
+  color: #6b7280;
+}
+
 .condition-form-radio-row input[type="radio"]:not(:checked) + span:hover,
 .condition-form-scope-toggle input[type="radio"]:not(:checked) + span:hover,
 .condition-form-radio-list input[type="radio"]:not(:checked) + span:hover,
@@ -1273,7 +1280,7 @@
 .condition-form-radio-list input[type="radio"]:checked + span,
 .condition-form-comparator-toggle input[type="radio"]:checked + span {
   background: #A855F7;
-  color: #1a1815;
+  color: #fff;
   font-weight: 700;
 }
 
@@ -1281,8 +1288,12 @@
   pointer-events: none;
 }
 
-.condition-form-comparator-toggle--locked label:not(:first-child) {
+.condition-form-comparator-toggle--locked label:not(:has(input[value="equal_to"])) {
   display: none;
+}
+
+.condition-form-comparator-toggle--locked label:has(input[value="equal_to"]) span {
+  border-top: none;
 }
 
 .condition-form-scope-toggle span {
@@ -1322,6 +1333,14 @@
   flex-wrap: nowrap;
   align-items: flex-start;
   gap: 4px;
+}
+
+/* Center the metric/operator pills + comparator so the middle of the pill
+   group lines up with the comparator. */
+#cond-left-comparison-body .condition-form-comparison-grid,
+#cond-right-comparison-body .condition-form-comparison-grid,
+#cond-census-comparison-body .condition-form-comparison-grid {
+  align-items: center;
 }
 
 .condition-form-comparison-grid--relational select {
@@ -1443,18 +1462,16 @@
 .condition-form-comparison__body {
   margin-top: 10px;
   padding-top: 10px;
-  border-top: 1px solid #3d3a35;
 }
 
-#cond-census-comparison {
-  margin-top: 10px;
-  padding-top: 10px;
-  border-top: 1px solid #3d3a35;
+.condition-form-comparison {
+  margin-bottom: 10px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid #3d3a35;
 }
 
 #cond-census-comparison .condition-form-comparison__body {
   padding-top: 0;
-  border-top: none;
 }
 
 #cond-census-target-filter-row {
@@ -1566,7 +1583,7 @@
 
 .condition-form-position-layout__note {
   grid-column: 1 / -1;
-  margin-top: 0;
+  margin: 0;
 }
 
 
@@ -1578,6 +1595,10 @@
   text-align: center;
 }
 
+.condition-form-formulation {
+  margin-top: 12px;
+}
+
 .condition-form-formulation label {
   display: block;
   margin-bottom: 6px;
@@ -1586,15 +1607,21 @@
 }
 
 .condition-form-formulation__text {
-  padding: 10px 12px;
+  padding: 12px 14px;
   background: #14120f;
   border: 1px solid #3d3a35;
   border-radius: 8px;
-  color: #E5E5E5;
-  font-size: 12px;
+  color: #fff;
+  font-size: 16px;
+  font-weight: 600;
   line-height: 1.45;
   white-space: pre-wrap;
+  text-decoration: underline;
+  text-decoration-color: #d8c160;
+  text-decoration-thickness: 2px;
+  text-underline-offset: 3px;
 }
+
 
 .condition-preview__chunk--spacer {
   font-size: 0;

--- a/app/assets/stylesheets/node_editor.css
+++ b/app/assets/stylesheets/node_editor.css
@@ -70,6 +70,7 @@
   top: 32px;
   z-index: 20;
   display: flex;
+  justify-content: space-between;
   gap: 20px;
   margin-top: 0;
   padding: 10px 20px;
@@ -77,15 +78,32 @@
   border-bottom: 1px solid #3d3a35;
 }
 
-.toolbar-section--push-right {
-  margin-left: auto;
-}
-
 .toolbar-section h3 {
   margin: 0 0 8px 0;
   font-size: 12px;
   color: #A855F7;
   text-transform: uppercase;
+}
+
+.toolbar-section__heading {
+  display: flex;
+  align-items: center;
+  margin-bottom: 8px;
+}
+
+.toolbar-section__heading h3 {
+  margin-bottom: 0;
+}
+
+/* Push the heading-row buttons to the right of the section title. */
+.toolbar-section__heading h3 + button {
+  margin-left: auto;
+}
+
+.toolbar-section__heading .btn-toggle-preview-mode {
+  margin-left: 16px;
+  padding: 3px 8px;
+  font-size: 11px;
 }
 
 .toolbar-section button, .toolbar-section a {
@@ -107,6 +125,10 @@
 .btn-add-node:hover {
   background: #252220;
 }
+
+.btn-add-node[data-type="condition"] { border: 1px solid #A855F7; color: #A855F7; }
+.btn-add-node[data-type="score"]     { border: 1px solid #18b7cf; color: #18b7cf; }
+.btn-add-node[data-type="organizer"] { border: 1px solid #3b82f6; color: #3b82f6; }
 
 .btn-open-templates {
   background: #1a1815;

--- a/app/assets/stylesheets/node_editor.css
+++ b/app/assets/stylesheets/node_editor.css
@@ -1622,7 +1622,6 @@
   text-underline-offset: 3px;
 }
 
-
 .condition-preview__chunk--spacer {
   font-size: 0;
   line-height: 0;

--- a/app/forms/node_form.rb
+++ b/app/forms/node_form.rb
@@ -1,7 +1,7 @@
 class NodeForm
   SUBJECT_LABELS = {
-    'allied' => 'Allied',
-    'enemy' => 'Enemy',
+    'allied' => 'My Pieces',
+    'enemy' => 'Enemy Pieces',
     'moved_piece' => 'Moved Piece',
     'captured_piece' => 'Captured Piece',
     'enemy_moved_piece' => 'Enemy Moved Piece',
@@ -44,6 +44,14 @@ class NodeForm
     'less_than' => '<'
   }.freeze
 
+  COMPARATOR_OPTIONS = [
+    ['greater than', 'greater_than'],
+    ['at least', 'greater_than_or_equal_to'],
+    ['equals', 'equal_to'],
+    ['at most', 'less_than_or_equal_to'],
+    ['less than', 'less_than']
+  ].freeze
+
   COMPARISON_SOURCE_LABELS = {
     'moved_piece' => 'Moved Piece',
     'captured_piece' => 'Captured Piece',
@@ -64,6 +72,14 @@ class NodeForm
 
     def editor_subject_options
       NodeGrammarV2::EDITOR_SUBJECTS.map { |value| [subject_label(value), value] }
+    end
+
+    def relational_subject_options
+      NodeGrammarRules::REGULAR_RELATIONAL_SUBJECTS.map { |value| [subject_label(value), value] }
+    end
+
+    def relational_target_options
+      NodeGrammarRules::REGULAR_RELATIONAL_TARGETS.map { |value| [subject_label(value), value] }
     end
 
     def filter_options
@@ -95,7 +111,9 @@ class NodeForm
     end
 
     def comparison_source_options
-      NodeGrammarV2::COMPARISON_SOURCES.reject { |value| value == NodeGrammarV2::EXACT_COMPARISON_SOURCE }.map { |value| [comparison_source_label(value), value] }
+      ordered = [NodeGrammarV2::PRIOR_BOARD_COMPARISON_SOURCE] +
+                (NodeGrammarV2::COMPARISON_SOURCES - [NodeGrammarV2::EXACT_COMPARISON_SOURCE, NodeGrammarV2::PRIOR_BOARD_COMPARISON_SOURCE])
+      ordered.map { |value| [comparison_source_label(value), value] }
     end
 
     def unary_target_options

--- a/app/javascript/editorV2/EditorActions.js
+++ b/app/javascript/editorV2/EditorActions.js
@@ -85,10 +85,8 @@ class EditorActions {
   togglePreview() {
     if (this.boardStatePreview?.isEnabled && this.boardStatePreview?.mode !== 'idle') {
       this.boardStatePreview.toggle()
-      if (!this.boardStatePreview.isEnabled) { this._showFormulationText() }
     } else if (this.store.getSelectedNodeIds().length > 1) {
       this.boardStatePreview.isEnabled = true
-      this._hideFormulationText()
       this.renderSelectionPreview()
     } else if (this.clickHandler?.getEditingNodeId() && this.clickHandler?.conditionForm) {
       this.activateConditionPreview(this.clickHandler.conditionForm)
@@ -97,20 +95,10 @@ class EditorActions {
 
   activateConditionPreview(conditionForm) {
     this.boardStatePreview?.activate(conditionForm)
-    this._hideFormulationText()
   }
 
   deactivatePreview() {
     this.boardStatePreview?.deactivate()
-    this._showFormulationText()
-  }
-
-  _hideFormulationText() {
-    this.clickHandler?.editorPanel?.querySelector('.condition-form-formulation__text')?.classList.add('hidden')
-  }
-
-  _showFormulationText() {
-    this.clickHandler?.editorPanel?.querySelector('.condition-form-formulation__text')?.classList.remove('hidden')
   }
 
   async save() {

--- a/app/javascript/editorV2/__tests__/BoardStatePreview.test.js
+++ b/app/javascript/editorV2/__tests__/BoardStatePreview.test.js
@@ -179,6 +179,14 @@ describe('BoardStatePreview', () => {
 
       expect(preview.content.querySelector('.board-state-preview__chain')).toBeNull()
     })
+
+    it('does not append a chain in form mode (the sentence is shown in the form instead)', () => {
+      preview.mode = 'form'
+      preview.conditionLabels = [[{ text: 'White pawn advances' }]]
+      preview._appendChain()
+
+      expect(preview.content.querySelector('.board-state-preview__chain')).toBeNull()
+    })
   })
 
   // ── _update ────────────────────────────────────────────────────────────────

--- a/app/javascript/editorV2/__tests__/ConditionForm.test.js
+++ b/app/javascript/editorV2/__tests__/ConditionForm.test.js
@@ -19,7 +19,7 @@ const identityTargetOptions = ['captured_piece', 'enemy_moved_piece']
   .map(value => option(value))
   .join('')
 const censusOperatorOptions = ['count', 'mobility', 'value']
-  .map(value => option(value))
+  .map((value, i) => `<label class="condition-form-checkbox"><input type="radio" name="cond-census-operator" value="${value}"${i === 0 ? ' checked' : ''}><span>${value}</span></label>`)
   .join('')
 const censusTargetOptions = ['exact_number', 'allied', 'enemy', 'moved_piece', 'captured_piece', 'enemy_moved_piece', 'enemy_captured_piece', 'prior_board_state']
   .map(value => option(value))
@@ -45,12 +45,17 @@ function buildPanel() {
         <span>Non-</span>
       </label>
       <select id="cond-left-filter">${option('any')}${option('pawn')}${option('rook')}</select>
-      <select id="cond-left-comparison-metric">${option('count')}</select>
-      <div id="cond-left-comparator">
-        <label class="condition-form-checkbox"><input type="radio" name="cond-left-comparator" value="equal_to" checked><span>=</span></label>
-        <label class="condition-form-checkbox"><input type="radio" name="cond-left-comparator" value="greater_than"><span>></span></label>
-        <label class="condition-form-checkbox"><input type="radio" name="cond-left-comparator" value="less_than"><span><</span></label>
+      <div id="cond-left-comparison-metric">
+        <label class="condition-form-checkbox"><input type="radio" name="cond-left-comparison-metric" value="count" checked><span>Count</span></label>
+        <label class="condition-form-checkbox"><input type="radio" name="cond-left-comparison-metric" value="individual_value"><span>Value</span></label>
       </div>
+      <select id="cond-left-comparator">
+        <option value="equal_to">equal to</option>
+        <option value="greater_than">greater than</option>
+        <option value="less_than">less than</option>
+        <option value="greater_than_or_equal_to">at least</option>
+        <option value="less_than_or_equal_to">at most</option>
+      </select>
       <div id="cond-left-comparison-section" class="condition-form-comparison">
         <button type="button" id="cond-left-comparison-toggle"></button>
         <div id="cond-left-comparison-body" class="hidden"></div>
@@ -71,12 +76,17 @@ function buildPanel() {
         <span>Non-</span>
       </label>
       <select id="cond-right-filter">${option('any')}${option('pawn')}${option('rook')}</select>
-      <select id="cond-right-comparison-metric">${option('count')}</select>
-      <div id="cond-right-comparator">
-        <label class="condition-form-checkbox"><input type="radio" name="cond-right-comparator" value="equal_to" checked><span>=</span></label>
-        <label class="condition-form-checkbox"><input type="radio" name="cond-right-comparator" value="greater_than"><span>></span></label>
-        <label class="condition-form-checkbox"><input type="radio" name="cond-right-comparator" value="less_than"><span><</span></label>
+      <div id="cond-right-comparison-metric">
+        <label class="condition-form-checkbox"><input type="radio" name="cond-right-comparison-metric" value="count" checked><span>Count</span></label>
+        <label class="condition-form-checkbox"><input type="radio" name="cond-right-comparison-metric" value="individual_value"><span>Value</span></label>
       </div>
+      <select id="cond-right-comparator">
+        <option value="equal_to">equal to</option>
+        <option value="greater_than">greater than</option>
+        <option value="less_than">less than</option>
+        <option value="greater_than_or_equal_to">at least</option>
+        <option value="less_than_or_equal_to">at most</option>
+      </select>
       <div id="cond-right-comparison-section" class="condition-form-comparison">
         <button type="button" id="cond-right-comparison-toggle"></button>
         <div id="cond-right-comparison-body" class="hidden"></div>
@@ -108,12 +118,14 @@ function buildPanel() {
       <div id="cond-census-comparison" class="condition-form-comparison">
         <button type="button" id="cond-census-comparison-toggle"></button>
         <div id="cond-census-comparison-body" class="hidden">
-          <select id="cond-census-operator">${censusOperatorOptions}</select>
-          <div id="cond-census-comparator">
-            <label class="condition-form-checkbox"><input type="radio" name="cond-census-comparator" value="equal_to" checked><span>=</span></label>
-            <label class="condition-form-checkbox"><input type="radio" name="cond-census-comparator" value="greater_than"><span>></span></label>
-            <label class="condition-form-checkbox"><input type="radio" name="cond-census-comparator" value="less_than"><span><</span></label>
-          </div>
+          <div id="cond-census-operator">${censusOperatorOptions}</div>
+          <select id="cond-census-comparator">
+            <option value="equal_to">equal to</option>
+            <option value="greater_than">greater than</option>
+            <option value="less_than">less than</option>
+            <option value="greater_than_or_equal_to">at least</option>
+            <option value="less_than_or_equal_to">at most</option>
+          </select>
           <div id="cond-census-target-stack" class="condition-form-comparison-source-stack">
             <select id="cond-census-target">${censusTargetOptions}</select>
             <div id="cond-census-target-filter-row">
@@ -160,6 +172,7 @@ function buildPanel() {
           <div id="cond-census-square-rank">${radioList('cond-census-square-rank')}</div>
         </div>
       </section>
+      <p id="cond-census-rank-note" class="hidden"></p>
     </div>
 
     <div class="condition-form-layout condition-form-identity-layout hidden" id="cond-identity-layout">
@@ -577,6 +590,7 @@ describe('ConditionForm', () => {
 
     expect(panel.querySelector('#cond-census-axis-rank').checked).toBe(true)
     expect(panel.querySelector('#cond-census-region-target').classList.contains('hidden')).toBe(false)
+    expect(panel.querySelector('#cond-census-rank-note').classList.contains('hidden')).toBe(false)
 
     expect(form.buildPayload()).toEqual({
       version: 2,
@@ -614,6 +628,7 @@ describe('ConditionForm', () => {
 
     expect(panel.querySelector('#cond-census-comparison-toggle').textContent).toBe('+ Advanced options')
     expect(panel.querySelector('#cond-census-target').classList.contains('hidden')).toBe(true)
+    expect(panel.querySelector('#cond-census-rank-note').classList.contains('hidden')).toBe(true)
 
     const targetSelect = panel.querySelector('#cond-census-target')
     targetSelect.value = 'prior_board_state'
@@ -794,7 +809,7 @@ describe('ConditionForm', () => {
     expect(form.buildPayload().target).toBe('enemy')
   })
 
-  it('round-trips a non-default relational comparator through the pill', () => {
+  it('round-trips a non-default relational comparator through the dropdown', () => {
     const panel = buildPanel()
     const form = new ConditionForm(panel)
     form.attach()
@@ -813,7 +828,7 @@ describe('ConditionForm', () => {
       targetFilter: 'any'
     })
 
-    expect(panel.querySelector('#cond-left-comparator input[value="greater_than"]').checked).toBe(true)
+    expect(panel.querySelector('#cond-left-comparator').value).toBe('greater_than')
     expect(form.buildPayload().subjectComparator).toBe('greater_than')
   })
 

--- a/app/javascript/editorV2/__tests__/ConditionForm.test.js
+++ b/app/javascript/editorV2/__tests__/ConditionForm.test.js
@@ -6,7 +6,10 @@ function option(value, label = value) {
   return `<option value="${value}">${label}</option>`
 }
 
-const subjectOptions = ['allied', 'enemy', 'moved_piece', 'captured_piece', 'enemy_moved_piece', 'enemy_captured_piece']
+const relationalSubjectOptions = ['moved_piece', 'allied', 'enemy', 'enemy_moved_piece']
+  .map(value => option(value))
+  .join('')
+const censusSubjectOptions = ['moved_piece', 'allied', 'enemy', 'enemy_moved_piece', 'captured_piece', 'enemy_captured_piece']
   .map(value => option(value))
   .join('')
 const relationalOperatorOptions = ['targets', 'shield', 'adjacent']
@@ -21,7 +24,7 @@ const identityTargetOptions = ['captured_piece', 'enemy_moved_piece']
 const censusOperatorOptions = ['count', 'mobility', 'value']
   .map((value, i) => `<label class="condition-form-checkbox"><input type="radio" name="cond-census-operator" value="${value}"${i === 0 ? ' checked' : ''}><span>${value}</span></label>`)
   .join('')
-const censusTargetOptions = ['exact_number', 'allied', 'enemy', 'moved_piece', 'captured_piece', 'enemy_moved_piece', 'enemy_captured_piece', 'prior_board_state']
+const censusTargetOptions = ['exact_number', 'prior_board_state', 'moved_piece', 'allied', 'enemy', 'enemy_moved_piece', 'captured_piece', 'enemy_captured_piece']
   .map(value => option(value))
   .join('')
 function radioList(name) {
@@ -39,7 +42,7 @@ function buildPanel() {
     <button type="button" id="cond-mode-identity">Identity</button>
 
     <div class="condition-form-layout">
-      <select id="cond-left-subject">${subjectOptions}</select>
+      <select id="cond-left-subject">${relationalSubjectOptions}</select>
       <label class="condition-form-checkbox">
         <input id="cond-left-filter-mode" type="checkbox">
         <span>Non-</span>
@@ -70,7 +73,7 @@ function buildPanel() {
 
       <select id="cond-relational-operator">${relationalOperatorOptions}</select>
 
-      <select id="cond-right-subject">${subjectOptions}</select>
+      <select id="cond-right-subject">${relationalSubjectOptions}</select>
       <label class="condition-form-checkbox">
         <input id="cond-right-filter-mode" type="checkbox">
         <span>Non-</span>
@@ -107,7 +110,7 @@ function buildPanel() {
     </div>
 
     <div class="condition-form-layout condition-form-position-layout hidden" id="cond-census-layout">
-      <select id="cond-census-subject">${subjectOptions}</select>
+      <select id="cond-census-subject">${censusSubjectOptions}</select>
       <div id="cond-census-filter-row">
         <label class="condition-form-checkbox">
           <input id="cond-census-filter-mode" type="checkbox">
@@ -337,7 +340,7 @@ describe('ConditionForm', () => {
     expect(rightSubject.querySelector('option[value="enemy_moved_piece"]').disabled).toBe(false)
     expect(rightSubject.querySelector('option[value="allied"]').disabled).toBe(false)
     expect(rightSubject.querySelector('option[value="moved_piece"]').disabled).toBe(false)
-    expect(rightSubject.querySelector('option[value="captured_piece"]').disabled).toBe(true)
+    expect(rightSubject.querySelector('option[value="captured_piece"]')).toBeNull()
   })
 
   it('translates targets operator to defend when subject and target are same team', () => {
@@ -407,7 +410,7 @@ describe('ConditionForm', () => {
     expect(rightSubject.querySelector('option[value="enemy"]').disabled).toBe(false)
     expect(rightSubject.querySelector('option[value="moved_piece"]').disabled).toBe(false)
     expect(rightSubject.querySelector('option[value="enemy_moved_piece"]').disabled).toBe(false)
-    expect(rightSubject.querySelector('option[value="captured_piece"]').disabled).toBe(true)
+    expect(rightSubject.querySelector('option[value="captured_piece"]')).toBeNull()
   })
 
   it('uses rendered grammar config for shield target scoping', () => {

--- a/app/javascript/editorV2/__tests__/EditorActions.test.js
+++ b/app/javascript/editorV2/__tests__/EditorActions.test.js
@@ -611,13 +611,9 @@ describe('EditorActions', () => {
   describe('preview', () => {
     let boardStatePreview
     let editorPanel
-    let formText
 
     beforeEach(() => {
       editorPanel = document.createElement('div')
-      formText = document.createElement('div')
-      formText.className = 'condition-form-formulation__text'
-      editorPanel.appendChild(formText)
       clickHandler.editorPanel = editorPanel
 
       boardStatePreview = {
@@ -639,11 +635,6 @@ describe('EditorActions', () => {
         editorActions.activateConditionPreview(conditionForm)
         expect(boardStatePreview.activate).toHaveBeenCalledWith(conditionForm)
       })
-
-      it('hides the formulation text', () => {
-        editorActions.activateConditionPreview({})
-        expect(formText.classList.contains('hidden')).toBe(true)
-      })
     })
 
     describe('deactivatePreview', () => {
@@ -651,36 +642,17 @@ describe('EditorActions', () => {
         editorActions.deactivatePreview()
         expect(boardStatePreview.deactivate).toHaveBeenCalled()
       })
-
-      it('shows the formulation text', () => {
-        formText.classList.add('hidden')
-        editorActions.deactivatePreview()
-        expect(formText.classList.contains('hidden')).toBe(false)
-      })
     })
 
     describe('togglePreview', () => {
-      it('toggles an active preview off and shows the formulation text', () => {
+      it('toggles an active preview off', () => {
         boardStatePreview.isEnabled = true
         boardStatePreview.mode = 'form'
         boardStatePreview.toggle.mockImplementation(() => { boardStatePreview.isEnabled = false })
-        formText.classList.add('hidden')
 
         editorActions.togglePreview()
 
         expect(boardStatePreview.toggle).toHaveBeenCalled()
-        expect(formText.classList.contains('hidden')).toBe(false)
-      })
-
-      it('does not show formulation text when toggling back on', () => {
-        boardStatePreview.isEnabled = true
-        boardStatePreview.mode = 'form'
-        boardStatePreview.toggle.mockImplementation(() => { boardStatePreview.isEnabled = true })
-        formText.classList.add('hidden')
-
-        editorActions.togglePreview()
-
-        expect(formText.classList.contains('hidden')).toBe(true)
       })
 
       it('enables preview and calls renderSelectionPreview when multiple nodes are selected', () => {
@@ -691,7 +663,6 @@ describe('EditorActions', () => {
         editorActions.togglePreview()
 
         expect(boardStatePreview.isEnabled).toBe(true)
-        expect(formText.classList.contains('hidden')).toBe(true)
         expect(editorActions.renderSelectionPreview).toHaveBeenCalled()
       })
 

--- a/app/javascript/editorV2/__tests__/census_value_pbs.test.js
+++ b/app/javascript/editorV2/__tests__/census_value_pbs.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import Board from 'gameplay/board'
 import generateConditionExamples from '../panels/condition_preview/orchestrator'
 
 function seededRandom(seed = 12345) {
@@ -9,16 +10,17 @@ function seededRandom(seed = 12345) {
   }
 }
 
-// Across a single move, the moving team's own material can only RISE via a pawn
-// promotion (it never loses material on its own turn). So "allied non-king value
-// increased vs prior" is satisfiable only by a promotion, and "allied non-king
-// value decreased" is impossible. These two tests probe whether the example
-// generator (a) produces a promotion for the up-direction and (b) refuses the
-// impossible down-direction rather than emitting a false example.
+// Across a single move the moving team's own material can only RISE via a pawn
+// promotion (it never loses material on its own turn), and the opposing team's
+// material can only FALL via being captured (it never moves on this turn). So
+// each "value vs prior" direction is either forced to a specific move type or is
+// outright impossible. These tests probe whether the generator produces the
+// right move type for the satisfiable directions and refuses the impossible ones
+// rather than emitting a false example.
 describe('census value vs prior_board_state (allied / moving team)', () => {
   const nonKing = { subjectFilter: 'king', subjectFilterMode: 'exclude' }
 
-  it('allied non-king value > prior_board_state yields a promotion example', () => {
+  it('generates a promotion example when allied material must have risen', () => {
     const payload = {
       version: 2, kind: 'census', subject: 'allied', ...nonKing,
       operator: 'value', comparator: 'greater_than', target: 'prior_board_state'
@@ -30,15 +32,12 @@ describe('census value vs prior_board_state (allied / moving team)', () => {
       if (preview.examples.length > 0) { example = preview.examples[0] }
     }
 
-    // No example across 25 seeds => the up-direction has no generation path (the
-    // suspected missing-promotion-mechanism gap).
     expect(example).not.toBeNull()
-    // The only way the moving team's non-king value rises on its own move is a
-    // promotion; a non-promotion example would be a false positive.
+    // The only way the moving team's non-king value rises on its own move is a promotion.
     expect(example.moveObject.promotionPiece).toBeTruthy()
   })
 
-  it('allied non-king value < prior_board_state is unsatisfiable (no example emitted)', () => {
+  it('generates no example when allied material must have fallen — the moving team never loses material on its own move', () => {
     const payload = {
       version: 2, kind: 'census', subject: 'allied', ...nonKing,
       operator: 'value', comparator: 'less_than', target: 'prior_board_state'
@@ -46,8 +45,44 @@ describe('census value vs prior_board_state (allied / moving team)', () => {
 
     for (let seed = 1; seed <= 25; seed += 1) {
       const preview = generateConditionExamples(payload, { random: seededRandom(seed) })
-      // The moving team cannot lose material on its own move, so any emitted
-      // example here is a false positive from the permissive value path.
+      expect(preview.examples.length).toBe(0)
+    }
+  })
+})
+
+describe('census value vs prior_board_state (enemy / opposing team)', () => {
+  const nonKing = { subjectFilter: 'king', subjectFilterMode: 'exclude' }
+
+  it('generates a capture example when enemy material must have fallen', () => {
+    const payload = {
+      version: 2, kind: 'census', subject: 'enemy', ...nonKing,
+      operator: 'value', comparator: 'less_than', target: 'prior_board_state'
+    }
+
+    let capture = null
+    for (let seed = 1; seed <= 25 && !capture; seed += 1) {
+      const preview = generateConditionExamples(payload, { random: seededRandom(seed) })
+      for (const ex of preview.examples) {
+        const moverTeam = ex.priorBoard.teamAt(ex.moveObject.startPosition)
+        // Standard capture: an opposing piece stood on the destination square.
+        if (ex.priorBoard.teamAt(ex.moveObject.endPosition) === Board.opposingTeam(moverTeam)) {
+          capture = ex
+          break
+        }
+      }
+    }
+
+    expect(capture).not.toBeNull()
+  })
+
+  it('generates no example when enemy material must have risen — the opposing team never gains material during the move', () => {
+    const payload = {
+      version: 2, kind: 'census', subject: 'enemy', ...nonKing,
+      operator: 'value', comparator: 'greater_than', target: 'prior_board_state'
+    }
+
+    for (let seed = 1; seed <= 25; seed += 1) {
+      const preview = generateConditionExamples(payload, { random: seededRandom(seed) })
       expect(preview.examples.length).toBe(0)
     }
   })

--- a/app/javascript/editorV2/__tests__/census_value_pbs.test.js
+++ b/app/javascript/editorV2/__tests__/census_value_pbs.test.js
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import generateConditionExamples from '../panels/condition_preview/orchestrator'
+
+function seededRandom(seed = 12345) {
+  let current = seed >>> 0
+  return () => {
+    current = (current * 1664525 + 1013904223) >>> 0
+    return current / 0x100000000
+  }
+}
+
+// Across a single move, the moving team's own material can only RISE via a pawn
+// promotion (it never loses material on its own turn). So "allied non-king value
+// increased vs prior" is satisfiable only by a promotion, and "allied non-king
+// value decreased" is impossible. These two tests probe whether the example
+// generator (a) produces a promotion for the up-direction and (b) refuses the
+// impossible down-direction rather than emitting a false example.
+describe('census value vs prior_board_state (allied / moving team)', () => {
+  const nonKing = { subjectFilter: 'king', subjectFilterMode: 'exclude' }
+
+  it('allied non-king value > prior_board_state yields a promotion example', () => {
+    const payload = {
+      version: 2, kind: 'census', subject: 'allied', ...nonKing,
+      operator: 'value', comparator: 'greater_than', target: 'prior_board_state'
+    }
+
+    let example = null
+    for (let seed = 1; seed <= 25 && !example; seed += 1) {
+      const preview = generateConditionExamples(payload, { random: seededRandom(seed) })
+      if (preview.examples.length > 0) { example = preview.examples[0] }
+    }
+
+    // No example across 25 seeds => the up-direction has no generation path (the
+    // suspected missing-promotion-mechanism gap).
+    expect(example).not.toBeNull()
+    // The only way the moving team's non-king value rises on its own move is a
+    // promotion; a non-promotion example would be a false positive.
+    expect(example.moveObject.promotionPiece).toBeTruthy()
+  })
+
+  it('allied non-king value < prior_board_state is unsatisfiable (no example emitted)', () => {
+    const payload = {
+      version: 2, kind: 'census', subject: 'allied', ...nonKing,
+      operator: 'value', comparator: 'less_than', target: 'prior_board_state'
+    }
+
+    for (let seed = 1; seed <= 25; seed += 1) {
+      const preview = generateConditionExamples(payload, { random: seededRandom(seed) })
+      // The moving team cannot lose material on its own move, so any emitted
+      // example here is a false positive from the permissive value path.
+      expect(preview.examples.length).toBe(0)
+    }
+  })
+})

--- a/app/javascript/editorV2/panels/BoardStatePreview.js
+++ b/app/javascript/editorV2/panels/BoardStatePreview.js
@@ -11,7 +11,7 @@ const BOARD_FADE   = 250
 const HALF_BEAT    = 400
 
 const PIECE_GLYPHS = {
-  WK: '♔', WQ: '♕', WR: '♖', WB: '♗', WN: '♘', WP: '♙',
+  WK: '♚', WQ: '♛', WR: '♜', WB: '♝', WN: '♞', WP: '♟',
   BK: '♚', BQ: '♛', BR: '♜', BB: '♝', BN: '♞', BP: '♟'
 }
 
@@ -29,6 +29,8 @@ function buildMiniBoardEl() {
       const td = document.createElement('td')
       td.className = `mini-board__tile mini-board__tile--${Board.squareColor(index)}`
       td.dataset.index = index
+      td.dataset.fileLetter = 'abcdefgh'[file]
+      td.dataset.rankNumber = rank + 1
       tr.appendChild(td)
     }
     table.appendChild(tr)
@@ -56,6 +58,7 @@ function renderLayout(boardEl, layout, highlights) {
     if (piece && PIECE_GLYPHS[piece]) {
       const span = document.createElement('span')
       span.className = `mini-piece mini-piece--${piece[0]}`
+      span.dataset.piece = piece
       span.textContent = PIECE_GLYPHS[piece]
       tile.appendChild(span)
     }
@@ -67,6 +70,7 @@ function renderPieceIntoTile(tile, piece) {
   if (piece && PIECE_GLYPHS[piece]) {
     const span = document.createElement('span')
     span.className = `mini-piece mini-piece--${piece[0]}`
+    span.dataset.piece = piece
     span.textContent = PIECE_GLYPHS[piece]
     tile.appendChild(span)
   }
@@ -76,10 +80,10 @@ function syncBoardToLayout(boardEl, layout) {
   boardEl.querySelectorAll('[data-index]').forEach(tile => {
     const index = parseInt(tile.dataset.index, 10)
     const expectedPiece = layout[index]
-    const currentPiece = tile.querySelector('.mini-piece')?.textContent || null
-    const expectedGlyph = PIECE_GLYPHS[expectedPiece] || null
+    const currentPiece = tile.querySelector('.mini-piece')?.dataset.piece || null
+    const expectedPieceCode = PIECE_GLYPHS[expectedPiece] ? expectedPiece : null
 
-    if (currentPiece === expectedGlyph) { return }
+    if (currentPiece === expectedPieceCode) { return }
     renderPieceIntoTile(tile, expectedPiece)
   })
 }
@@ -449,6 +453,7 @@ class BoardStatePreview {
   }
 
   _appendChain() {
+    if (this.mode === 'form') { return }
     if (!this.conditionLabels?.length) { return }
     const chain = document.createElement('ol')
     chain.className = 'board-state-preview__chain'

--- a/app/javascript/editorV2/panels/ConditionForm.js
+++ b/app/javascript/editorV2/panels/ConditionForm.js
@@ -97,8 +97,8 @@ class ConditionForm {
     const leftFilterMode = this.editorPanel.querySelector('#cond-left-filter-mode')
     const leftFilter = this.editorPanel.querySelector('#cond-left-filter')
     const leftComparisonMetric = this.editorPanel.querySelector('#cond-left-comparison-metric')
+    const leftComparisonMetricInputs = pillInputs(leftComparisonMetric)
     const leftComparator = this.editorPanel.querySelector('#cond-left-comparator')
-    const leftComparatorInputs = pillInputs(leftComparator)
     const leftComparisonSource = this.editorPanel.querySelector('#cond-left-comparison-source')
     const leftComparisonSourceTotal = this.editorPanel.querySelector('#cond-left-comparison-source-total')
     const relationalOperatorSelect = this.editorPanel.querySelector('#cond-relational-operator')
@@ -106,16 +106,16 @@ class ConditionForm {
     const rightFilterMode = this.editorPanel.querySelector('#cond-right-filter-mode')
     const rightFilter = this.editorPanel.querySelector('#cond-right-filter')
     const rightComparisonMetric = this.editorPanel.querySelector('#cond-right-comparison-metric')
+    const rightComparisonMetricInputs = pillInputs(rightComparisonMetric)
     const rightComparator = this.editorPanel.querySelector('#cond-right-comparator')
-    const rightComparatorInputs = pillInputs(rightComparator)
     const rightComparisonSource = this.editorPanel.querySelector('#cond-right-comparison-source')
     const rightComparisonSourceTotal = this.editorPanel.querySelector('#cond-right-comparison-source-total')
     const censusSubject = this.editorPanel.querySelector('#cond-census-subject')
     const censusFilterMode = this.editorPanel.querySelector('#cond-census-filter-mode')
     const censusFilter = this.editorPanel.querySelector('#cond-census-filter')
     const censusOperator = this.editorPanel.querySelector('#cond-census-operator')
+    const censusOperatorInputs = pillInputs(censusOperator)
     const censusComparator = this.editorPanel.querySelector('#cond-census-comparator')
-    const censusComparatorInputs = pillInputs(censusComparator)
     const censusTarget = this.editorPanel.querySelector('#cond-census-target')
     const censusTargetTotal = this.editorPanel.querySelector('#cond-census-target-total')
     const censusTargetFilter = this.editorPanel.querySelector('#cond-census-target-filter')
@@ -142,8 +142,8 @@ class ConditionForm {
       leftFilterMode,
       leftFilter,
       leftComparisonMetric,
+      leftComparisonMetricInputs,
       leftComparator,
-      leftComparatorInputs,
       leftComparisonSource,
       leftComparisonSourceTotal,
       relationalOperatorSelect,
@@ -151,16 +151,16 @@ class ConditionForm {
       rightFilterMode,
       rightFilter,
       rightComparisonMetric,
+      rightComparisonMetricInputs,
       rightComparator,
-      rightComparatorInputs,
       rightComparisonSource,
       rightComparisonSourceTotal,
       censusSubject,
       censusFilterMode,
       censusFilter,
       censusOperator,
+      censusOperatorInputs,
       censusComparator,
-      censusComparatorInputs,
       censusTarget,
       censusTargetTotal,
       censusTargetFilter,
@@ -214,11 +214,12 @@ class ConditionForm {
       censusScope: this.editorPanel.querySelector('#cond-census-scope'),
       censusSquareInputs: this.editorPanel.querySelector('#cond-census-square-inputs'),
       censusRegionTarget: this.editorPanel.querySelector('#cond-census-region-target'),
+      censusRankNote: this.editorPanel.querySelector('#cond-census-rank-note'),
       all: [
-        leftSubject, leftFilterMode, leftFilter, leftComparisonMetric, ...leftComparatorInputs, leftComparisonSource,
+        leftSubject, leftFilterMode, leftFilter, ...leftComparisonMetricInputs, leftComparator, leftComparisonSource,
         relationalOperatorSelect,
-        rightSubject, rightFilterMode, rightFilter, rightComparisonMetric, ...rightComparatorInputs, rightComparisonSource,
-        censusSubject, censusFilterMode, censusFilter, censusOperator, ...censusComparatorInputs,
+        rightSubject, rightFilterMode, rightFilter, ...rightComparisonMetricInputs, rightComparator, rightComparisonSource,
+        censusSubject, censusFilterMode, censusFilter, ...censusOperatorInputs, censusComparator,
         censusTarget, censusTargetFilter, censusTargetFilterMode,
         censusScopeWhole, censusAxisRank, censusAxisFile, censusAxisSquare, ...censusRegionComparatorInputs,
         ...censusRankInputs, ...censusFileInputs, ...censusSquareFileInputs, ...censusSquareRankInputs,

--- a/app/javascript/editorV2/panels/condition_form/census_mode.js
+++ b/app/javascript/editorV2/panels/condition_form/census_mode.js
@@ -85,8 +85,8 @@ export default class CensusMode {
     cen.regionFileTarget = Number(pillValue(fields.censusFileInputs) || 1)
     cen.regionSquareFile = Number(pillValue(fields.censusSquareFileInputs) || 1)
     cen.regionSquareRank = Number(pillValue(fields.censusSquareRankInputs) || 1)
-    cen.operator = fields.censusOperator?.value || 'count'
-    cen.comparator = pillValue(fields.censusComparatorInputs) || 'greater_than'
+    cen.operator = pillValue(fields.censusOperatorInputs) || 'count'
+    cen.comparator = fields.censusComparator?.value || 'greater_than'
     cen.target = fields.censusTarget?.value || 'exact_number'
     cen.targetFilter = fields.censusTargetFilter?.value || 'any'
     cen.targetFilterMode = fields.censusTargetFilterMode?.checked ? 'exclude' : 'include'
@@ -148,8 +148,8 @@ export default class CensusMode {
     setPillChecked(fields.censusFileInputs, cen.regionFileTarget, true)
     setPillChecked(fields.censusSquareFileInputs, cen.regionSquareFile, true)
     setPillChecked(fields.censusSquareRankInputs, cen.regionSquareRank, true)
-    if (fields.censusOperator) fields.censusOperator.value = cen.operator
-    setPillChecked(fields.censusComparatorInputs, cen.comparator)
+    setPillChecked(fields.censusOperatorInputs, cen.operator)
+    if (fields.censusComparator) fields.censusComparator.value = cen.comparator
     if (fields.censusTarget) fields.censusTarget.value = cen.target
     if (fields.censusTargetTotal) fields.censusTargetTotal.value = cen.targetTotal
     if (fields.censusTargetFilter) fields.censusTargetFilter.value = cen.targetFilter
@@ -159,6 +159,7 @@ export default class CensusMode {
     fields.censusRegionComparator?.classList.toggle('condition-form-comparator-toggle--locked', isSquare)
     fields.censusRegionTarget?.classList.toggle('hidden', false)
     fields.censusRankInput?.classList.toggle('hidden', !region || isSquare || cen.regionAxis === 'file')
+    fields.censusRankNote?.classList.toggle('hidden', !region || isSquare || cen.regionAxis === 'file')
     fields.censusFileInput?.classList.toggle('hidden', !region || isSquare || cen.regionAxis === 'rank')
     fields.censusSquareInputs?.classList.toggle('hidden', region && !isSquare)
     fields.censusSquareInputs?.classList.toggle('condition-form-radio-list--disabled', !region)

--- a/app/javascript/editorV2/panels/condition_form/dom_helpers.js
+++ b/app/javascript/editorV2/panels/condition_form/dom_helpers.js
@@ -23,9 +23,13 @@ export function setPillChecked(inputs, value, numeric = false) {
   })
 }
 
-export function disableOptions(select, disallowedValues) {
-  Array.from(select.options).forEach(option => {
-    option.disabled = disallowedValues.includes(option.value)
+export function disableOptions(control, disallowedValues) {
+  if (!control) { return }
+  const choices = control.options
+    ? Array.from(control.options)
+    : Array.from(control.querySelectorAll('input[type="radio"]'))
+  choices.forEach(choice => {
+    choice.disabled = disallowedValues.includes(choice.value)
   })
 }
 

--- a/app/javascript/editorV2/panels/condition_form/relational_mode.js
+++ b/app/javascript/editorV2/panels/condition_form/relational_mode.js
@@ -90,16 +90,16 @@ export default class RelationalMode {
     rel.left.subject = fields.leftSubject?.value || 'allied'
     rel.left.filterMode = fields.leftFilterMode?.checked ? 'exclude' : 'include'
     rel.left.filter = fields.leftFilter?.value || 'any'
-    rel.left.comparisonMetric = fields.leftComparisonMetric?.value || ''
-    rel.left.comparator = pillValue(fields.leftComparatorInputs) || 'equal_to'
+    rel.left.comparisonMetric = pillValue(fields.leftComparisonMetricInputs) || ''
+    rel.left.comparator = fields.leftComparator?.value || 'equal_to'
     rel.left.comparisonSource = fields.leftComparisonSource?.value || 'exact_number'
     rel.left.comparisonSourceTotal = Number(fields.leftComparisonSourceTotal?.value || 1)
     rel.operator = fields.relationalOperatorSelect?.value || 'targets'
     rel.right.subject = fields.rightSubject?.value || 'enemy'
     rel.right.filterMode = fields.rightFilterMode?.checked ? 'exclude' : 'include'
     rel.right.filter = fields.rightFilter?.value || 'any'
-    rel.right.comparisonMetric = fields.rightComparisonMetric?.value || ''
-    rel.right.comparator = pillValue(fields.rightComparatorInputs) || 'equal_to'
+    rel.right.comparisonMetric = pillValue(fields.rightComparisonMetricInputs) || ''
+    rel.right.comparator = fields.rightComparator?.value || 'equal_to'
     rel.right.comparisonSource = fields.rightComparisonSource?.value || 'exact_number'
     rel.right.comparisonSourceTotal = Number(fields.rightComparisonSourceTotal?.value || 1)
   }
@@ -170,16 +170,16 @@ export default class RelationalMode {
     if (fields.leftSubject) fields.leftSubject.value = rel.left.subject
     if (fields.leftFilterMode) fields.leftFilterMode.checked = leftFilterModeAvailable && rel.left.filterMode === 'exclude'
     if (fields.leftFilter) fields.leftFilter.value = rel.left.filter
-    if (fields.leftComparisonMetric) fields.leftComparisonMetric.value = rel.left.comparisonMetric || 'count'
-    setPillChecked(fields.leftComparatorInputs, rel.left.comparator)
+    setPillChecked(fields.leftComparisonMetricInputs, rel.left.comparisonMetric || 'count')
+    if (fields.leftComparator) fields.leftComparator.value = rel.left.comparator
     if (fields.leftComparisonSource) fields.leftComparisonSource.value = rel.left.comparisonSource
     if (fields.leftComparisonSourceTotal) fields.leftComparisonSourceTotal.value = rel.left.comparisonSourceTotal
 
     if (fields.rightSubject) fields.rightSubject.value = rel.right.subject
     if (fields.rightFilterMode) fields.rightFilterMode.checked = rightFilterModeAvailable && rel.right.filterMode === 'exclude'
     if (fields.rightFilter) fields.rightFilter.value = rel.right.filter
-    if (fields.rightComparisonMetric) fields.rightComparisonMetric.value = rel.right.comparisonMetric || 'count'
-    setPillChecked(fields.rightComparatorInputs, rel.right.comparator)
+    setPillChecked(fields.rightComparisonMetricInputs, rel.right.comparisonMetric || 'count')
+    if (fields.rightComparator) fields.rightComparator.value = rel.right.comparator
     if (fields.rightComparisonSource) fields.rightComparisonSource.value = rel.right.comparisonSource
     if (fields.rightComparisonSourceTotal) fields.rightComparisonSourceTotal.value = rel.right.comparisonSourceTotal
 
@@ -351,17 +351,15 @@ export default class RelationalMode {
   }
 
   setComparisonInputsDisabled(side, fields, disabled) {
-    const metricKey = side === 'left' ? 'leftComparisonMetric' : 'rightComparisonMetric'
+    const metricInputsKey = side === 'left' ? 'leftComparisonMetricInputs' : 'rightComparisonMetricInputs'
     const comparatorKey = side === 'left' ? 'leftComparator' : 'rightComparator'
-    const comparatorInputsKey = side === 'left' ? 'leftComparatorInputs' : 'rightComparatorInputs'
     const sourceKey = side === 'left' ? 'leftComparisonSource' : 'rightComparisonSource'
     const sourceTotalKey = side === 'left' ? 'leftComparisonSourceTotal' : 'rightComparisonSourceTotal'
 
-    fields[metricKey].disabled = disabled
+    fields[metricInputsKey]?.forEach(input => { input.disabled = disabled })
     fields[sourceKey].disabled = disabled
     fields[sourceTotalKey].disabled = disabled
-    fields[comparatorInputsKey]?.forEach(input => { input.disabled = disabled })
-    fields[comparatorKey]?.classList.toggle('condition-form-radio-row--disabled', disabled)
+    fields[comparatorKey].disabled = disabled
   }
 
   disableComparisonSourceOptions(rel, fields) {

--- a/app/javascript/editorV2/panels/condition_preview/shared/king_placement.js
+++ b/app/javascript/editorV2/panels/condition_preview/shared/king_placement.js
@@ -298,7 +298,7 @@ function commitMovedPieceTo(ctx, species, position) {
 // from an L-distance square BK can't capture.
 function placeSmotherMate({ pieces, team, ctx, random }) {
   const enemyTeam = Board.opposingTeam(team)
-  const corners = team === Board.BLACK ? shuffled([56, 63], random) : shuffled([0, 7], random)
+  const corners = shuffled(team === Board.BLACK ? [56, 63] : [0, 7], random)
   for (const cornerPos of corners) {
     if (pieces.has(cornerPos)) { continue }
     if (!isLegalKingSquare({ pieces, pos: cornerPos, team, requireOutOfCheck: false, ctx })) { continue }

--- a/app/javascript/editorV2/panels/condition_preview/shared/king_placement.js
+++ b/app/javascript/editorV2/panels/condition_preview/shared/king_placement.js
@@ -298,7 +298,8 @@ function commitMovedPieceTo(ctx, species, position) {
 // from an L-distance square BK can't capture.
 function placeSmotherMate({ pieces, team, ctx, random }) {
   const enemyTeam = Board.opposingTeam(team)
-  for (const cornerPos of shuffled([0, 7, 56, 63], random)) {
+  const corners = team === Board.BLACK ? shuffled([56, 63], random) : shuffled([0, 7], random)
+  for (const cornerPos of corners) {
     if (pieces.has(cornerPos)) { continue }
     if (!isLegalKingSquare({ pieces, pos: cornerPos, team, requireOutOfCheck: false, ctx })) { continue }
     const escape = adjacentSquares(cornerPos)

--- a/app/javascript/gameplay/__tests__/board_orientation.test.js
+++ b/app/javascript/gameplay/__tests__/board_orientation.test.js
@@ -1,0 +1,50 @@
+import { applyBoardOrientation } from 'gameplay/board_orientation'
+
+function buildArena() {
+  const arena = document.createElement('div')
+  arena.innerHTML = `
+    <div class="board-player-name" data-board-name="top"></div>
+    <div id="W-captures"></div>
+    <table id="chess-board"></table>
+    <div id="B-captures"></div>
+    <div class="board-player-name" data-board-name="bottom"></div>
+  `
+  return arena
+}
+
+describe('applyBoardOrientation', () => {
+  let arena, board, top, bottom
+
+  beforeEach(() => {
+    arena = buildArena()
+    board = arena.querySelector('#chess-board')
+    top = arena.querySelector('[data-board-name="top"]')
+    bottom = arena.querySelector('[data-board-name="bottom"]')
+  })
+
+  it('keeps white on the bottom by default', () => {
+    applyBoardOrientation(arena, { flipped: false, whiteName: 'Alice', blackName: 'Bob' })
+    expect(board.classList.contains('flipped')).toBe(false)
+    expect(top.textContent).toBe('Bob')
+    expect(top.dataset.team).toBe('B')
+    expect(bottom.textContent).toBe('Alice')
+    expect(bottom.dataset.team).toBe('W')
+    expect(board.previousElementSibling.id).toBe('W-captures')
+    expect(board.nextElementSibling.id).toBe('B-captures')
+  })
+
+  it('puts black on the bottom when flipped', () => {
+    applyBoardOrientation(arena, { flipped: true, whiteName: 'Alice', blackName: 'Bob' })
+    expect(board.classList.contains('flipped')).toBe(true)
+    expect(top.textContent).toBe('Alice')
+    expect(top.dataset.team).toBe('W')
+    expect(bottom.textContent).toBe('Bob')
+    expect(bottom.dataset.team).toBe('B')
+    expect(board.previousElementSibling.id).toBe('B-captures')
+    expect(board.nextElementSibling.id).toBe('W-captures')
+  })
+
+  it('does not throw when the arena is absent', () => {
+    expect(() => applyBoardOrientation(null, { flipped: true })).not.toThrow()
+  })
+})

--- a/app/javascript/gameplay/__tests__/game_controller_live_status.test.js
+++ b/app/javascript/gameplay/__tests__/game_controller_live_status.test.js
@@ -9,9 +9,6 @@ function buildRoot() {
   root.dataset.botTeam = Board.BLACK
   root.dataset.botName = 'Clone newBot!'
   root.innerHTML = `
-    <p class="match-show-meta-item"><span data-human-side-label></span></p>
-    <p class="match-show-meta-item"><span data-bot-name-label></span></p>
-    <p class="match-show-meta-item"><span data-bot-side-label></span></p>
     <p class="match-show-meta-item" data-play-status></p>
   `
   return root
@@ -37,16 +34,13 @@ describe('GameController live match status', () => {
     document.body.innerHTML = ''
   })
 
-  it('shows the participants and your turn when the human is to move', () => {
+  it('shows your turn when the human is to move', () => {
     const root = buildRoot()
     document.body.appendChild(root)
     const controller = buildController(root, Board.WHITE)
 
     controller.updateLiveMatchStatus()
 
-    expect(root.querySelector('[data-human-side-label]').textContent).toBe('White')
-    expect(root.querySelector('[data-bot-name-label]').textContent).toBe('Clone newBot!')
-    expect(root.querySelector('[data-bot-side-label]').textContent).toBe('Black')
     expect(root.querySelector('[data-play-status]').textContent).toBe('Your turn.')
     expect(root.querySelector('[data-play-status]').classList.contains('match-live-status-pill--human')).toBe(true)
   })
@@ -70,5 +64,27 @@ describe('GameController live match status', () => {
     controller.updateLiveMatchStatus()
 
     expect(root.querySelector('[data-play-status]').textContent).toBe('Game over.')
+  })
+
+  it('flips the board to the human perspective when the human plays black', () => {
+    const root = buildRoot()
+    root.dataset.humanTeam = Board.BLACK
+    root.dataset.whiteName = 'Alice'
+    root.dataset.blackName = 'Bob'
+    root.insertAdjacentHTML('beforeend', `
+      <div id="arena">
+        <div class="board-player-name" data-board-name="top" data-team="B"></div>
+        <table id="chess-board"></table>
+        <div class="board-player-name" data-board-name="bottom" data-team="W"></div>
+      </div>
+    `)
+    document.body.appendChild(root)
+    const controller = buildController(root, Board.WHITE)
+
+    controller.applyOrientation()
+
+    expect(root.querySelector('#chess-board').classList.contains('flipped')).toBe(true)
+    expect(root.querySelector('[data-board-name="bottom"]').textContent).toBe('Bob')
+    expect(root.querySelector('[data-board-name="bottom"]').dataset.team).toBe('B')
   })
 })

--- a/app/javascript/gameplay/__tests__/match_replay_controller.test.js
+++ b/app/javascript/gameplay/__tests__/match_replay_controller.test.js
@@ -125,4 +125,26 @@ describe('MatchReplayController', () => {
     expect(play.classList.contains('replay-control--hint')).toBe(false)
     expect(forward.classList.contains('replay-control--hint')).toBe(false)
   })
+
+  it('flips the board to the viewer when they own the black bot', () => {
+    const root = buildRoot({ finalLayout: Layout.default(), movementNotation: [] })
+    root.dataset.blackBotOwnerId = '1'
+    root.dataset.whiteName = 'Alice'
+    root.dataset.blackName = 'Bob'
+    document.body.appendChild(root)
+
+    const controller = new MatchReplayController({ rootElement: root })
+    root.insertAdjacentHTML('beforeend', `
+      <div id="arena">
+        <div class="board-player-name" data-board-name="top"></div>
+        <table id="chess-board"></table>
+        <div class="board-player-name" data-board-name="bottom"></div>
+      </div>
+    `)
+    controller.applyOrientation()
+
+    expect(root.querySelector('#chess-board').classList.contains('flipped')).toBe(true)
+    expect(root.querySelector('[data-board-name="bottom"]').textContent).toBe('Bob')
+    expect(root.querySelector('[data-board-name="bottom"]').dataset.team).toBe('B')
+  })
 })

--- a/app/javascript/gameplay/__tests__/match_replay_controller.test.js
+++ b/app/javascript/gameplay/__tests__/match_replay_controller.test.js
@@ -108,4 +108,21 @@ describe('MatchReplayController', () => {
     const botInspection = controller.inspectionContextForBoard(botBoard)
     expect(botInspection.unavailableMessage).toBe("condition trace unavailable for other players' bots")
   })
+
+  it('hints the play and forward buttons until forward or play is used', () => {
+    const root = buildRoot({ finalLayout: Layout.default(), movementNotation: [] })
+    document.body.appendChild(root)
+
+    new MatchReplayController({ rootElement: root })
+    const play = root.querySelector('[data-match-replay-target="play-button"]')
+    const forward = root.querySelector('[data-match-replay-target="forward-button"]')
+
+    expect(play.classList.contains('replay-control--hint')).toBe(true)
+    expect(forward.classList.contains('replay-control--hint')).toBe(true)
+
+    forward.dispatchEvent(new Event('click'))
+
+    expect(play.classList.contains('replay-control--hint')).toBe(false)
+    expect(forward.classList.contains('replay-control--hint')).toBe(false)
+  })
 })

--- a/app/javascript/gameplay/__tests__/view_utils.test.js
+++ b/app/javascript/gameplay/__tests__/view_utils.test.js
@@ -1,0 +1,37 @@
+import { updateTeamAllowedToMove } from 'gameplay/view_utils'
+
+describe('updateTeamAllowedToMove', () => {
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <span id="team-allowed-to-move"></span>
+      <div class="board-player-name" data-team="B"></div>
+      <div class="board-player-name" data-team="W"></div>
+    `
+  })
+
+  const labelFor = team => document.querySelector(`.board-player-name[data-team="${team}"]`)
+  const isActive = team => labelFor(team).classList.contains('board-player-name--active')
+
+  it('still sets the turn-marker text when the span is present (sandbox)', () => {
+    updateTeamAllowedToMove({ allowedToMove: 'W' })
+    expect(document.getElementById('team-allowed-to-move').innerText).toBe('W')
+  })
+
+  it('highlights the name label of the team to move', () => {
+    updateTeamAllowedToMove({ allowedToMove: 'W' })
+    expect(isActive('W')).toBe(true)
+    expect(isActive('B')).toBe(false)
+  })
+
+  it('moves the highlight when the turn changes', () => {
+    updateTeamAllowedToMove({ allowedToMove: 'W' })
+    updateTeamAllowedToMove({ allowedToMove: 'B' })
+    expect(isActive('W')).toBe(false)
+    expect(isActive('B')).toBe(true)
+  })
+
+  it('does not throw when neither span nor labels are present', () => {
+    document.body.innerHTML = ''
+    expect(() => updateTeamAllowedToMove({ allowedToMove: 'W' })).not.toThrow()
+  })
+})

--- a/app/javascript/gameplay/board_orientation.js
+++ b/app/javascript/gameplay/board_orientation.js
@@ -1,0 +1,25 @@
+import Board from "gameplay/board"
+
+export function applyBoardOrientation(arena, { flipped, whiteName, blackName }) {
+  if (!arena) { return }
+  const board = arena.querySelector('#chess-board')
+  board?.classList.toggle('flipped', Boolean(flipped))
+
+  const topLabel = arena.querySelector('[data-board-name="top"]')
+  const bottomLabel = arena.querySelector('[data-board-name="bottom"]')
+  if (topLabel) {
+    topLabel.textContent = flipped ? whiteName : blackName
+    topLabel.dataset.team = flipped ? Board.WHITE : Board.BLACK
+  }
+  if (bottomLabel) {
+    bottomLabel.textContent = flipped ? blackName : whiteName
+    bottomLabel.dataset.team = flipped ? Board.BLACK : Board.WHITE
+  }
+
+  const whiteCaptures = arena.querySelector('#W-captures')
+  const blackCaptures = arena.querySelector('#B-captures')
+  if (board && whiteCaptures && blackCaptures) {
+    board.before(flipped ? blackCaptures : whiteCaptures)
+    board.after(flipped ? whiteCaptures : blackCaptures)
+  }
+}

--- a/app/javascript/gameplay/game_controller.js
+++ b/app/javascript/gameplay/game_controller.js
@@ -1,5 +1,6 @@
 import Board from "gameplay/board"
 import LiveView from "gameplay/live_view"
+import { applyBoardOrientation } from "gameplay/board_orientation"
 import Api	from "gameplay/api"
 import BotRunner from "gameplay/bot_runner"
 import Rules from "gameplay/rules"
@@ -15,6 +16,7 @@ class GameController {
 		this.view = new LiveView(this);
 		this._paused = false
 		this._completionSubmitted = false
+		this.applyOrientation()
 		this.view.displayLayOut({board: this.board, alert: ""})
 		this.view.setTileClickListener()
 		// this.view.setUndoClickListener(this)
@@ -23,6 +25,15 @@ class GameController {
 		this.configurePlayBots()
 		this.updateLiveMatchStatus()
 		if(this._whiteBot && !this._paused){ this.queryNextBotMove()}
+	}
+
+	applyOrientation(){
+		const humanPlaysBlack = this.playConfig?.humanTeam === Board.BLACK
+		applyBoardOrientation(this.rootElement?.querySelector('#arena'), {
+			flipped: humanPlaysBlack,
+			whiteName: this.rootElement?.dataset.whiteName,
+			blackName: this.rootElement?.dataset.blackName
+		})
 	}
 
 	buildPlayConfig(){
@@ -226,23 +237,7 @@ class GameController {
 
 	updateLiveMatchStatus(){
 		if (!this.playConfig) { return }
-		this.updateParticipantLabels()
 		this.updateTurnStatus()
-	}
-
-	updateParticipantLabels(){
-		const humanSide = this.rootElement?.querySelector('[data-human-side-label]')
-		const botName = this.rootElement?.querySelector('[data-bot-name-label]')
-		const botSide = this.rootElement?.querySelector('[data-bot-side-label]')
-		if (humanSide) {
-			humanSide.textContent = this.teamLabel(this.playConfig.humanTeam)
-		}
-		if (botName) {
-			botName.textContent = this.playConfig.botName || 'Bot'
-		}
-		if (botSide) {
-			botSide.textContent = this.teamLabel(this.playConfig.botTeam)
-		}
 	}
 
 	updateTurnStatus(){
@@ -259,9 +254,6 @@ class GameController {
 		this.updatePlayStatus("Bot's turn.", 'bot')
 	}
 
-	teamLabel(team){
-		return team === Board.WHITE ? 'White' : 'Black'
-	}
 }
 
 export default GameController

--- a/app/javascript/gameplay/match_replay_controller.js
+++ b/app/javascript/gameplay/match_replay_controller.js
@@ -4,6 +4,7 @@ import NotationResolver from "gameplay/notation_resolver"
 import ReplayMoveInspector from "gameplay/replay_move_inspector"
 import ReplayView, { buildReplayBoard } from "gameplay/replay_view"
 import { cloneRecentMoveContext } from "gameplay/recent_move_context"
+import { applyBoardOrientation } from "gameplay/board_orientation"
 import Sound from "gameplay/sound"
 
 class MatchReplayController {
@@ -23,10 +24,10 @@ class MatchReplayController {
     this.resultElement = rootElement.querySelector('[data-match-replay-target="result"]')
     this.boardElement = rootElement.querySelector('#chess-board')
     this.speedButtons = rootElement.querySelectorAll('[data-match-replay-target="speed-button"]')
-    this.playButton?.addEventListener('click', () => this.togglePlayback(1))
+    this.playButton?.addEventListener('click', () => { this.clearControlHints(); this.togglePlayback(1) })
     this.reverseButton?.addEventListener('click', () => this.togglePlayback(-1))
     this.backButton?.addEventListener('click', this.stepBackwardOnce.bind(this))
-    this.forwardButton?.addEventListener('click', this.stepForwardOnce.bind(this))
+    this.forwardButton?.addEventListener('click', () => { this.clearControlHints(); this.stepForwardOnce() })
     this.startButton?.addEventListener('click', this.jumpToStart.bind(this))
     this.topMovesToggle?.addEventListener('click', this.toggleTopMoveHighlights.bind(this))
     this.notationElement?.addEventListener('click', this.jumpToNotationMove.bind(this))
@@ -35,6 +36,8 @@ class MatchReplayController {
     this.speedButtons.forEach(button => {
       button.addEventListener('click', () => this.setSpeed(Number(button.dataset.speedMultiplier)))
     })
+    this.playButton?.classList.add('replay-control--hint')
+    this.forwardButton?.classList.add('replay-control--hint')
 
     this.intervalId = null
     this.isPlaying = false
@@ -60,7 +63,25 @@ class MatchReplayController {
     this.selectedStartPosition = null
     this.inspectedMoveKey = null
     this.muteTopMoveHighlights = false
+    this.applyOrientation()
     this.renderCurrentFrame()
+  }
+
+  clearControlHints() {
+    this.playButton?.classList.remove('replay-control--hint')
+    this.forwardButton?.classList.remove('replay-control--hint')
+  }
+
+  applyOrientation() {
+    const viewerOwnsBlackBot =
+      Number.isInteger(this.currentUserId) &&
+      this.blackBotOwnerId !== null &&
+      this.currentUserId === this.blackBotOwnerId
+    applyBoardOrientation(this.rootElement.querySelector('#arena'), {
+      flipped: viewerOwnsBlackBot,
+      whiteName: this.rootElement.dataset.whiteName,
+      blackName: this.rootElement.dataset.blackName
+    })
   }
 
   parseCompiledProgramSnapshot(snapshotJson) {

--- a/app/javascript/gameplay/view_utils.js
+++ b/app/javascript/gameplay/view_utils.js
@@ -71,8 +71,10 @@ export function renderBoardPieces(board) {
 
 export function updateTeamAllowedToMove(board) {
   const span = document.getElementById("team-allowed-to-move")
-  if (!span) { return }
-  span.innerText = board.allowedToMove
+  if (span) { span.innerText = board.allowedToMove }
+  document.querySelectorAll(".board-player-name").forEach(label => {
+    label.classList.toggle("board-player-name--active", label.dataset.team === board.allowedToMove)
+  })
 }
 
 export function updateCaptures(board) {

--- a/app/models/node_grammar_rules.rb
+++ b/app/models/node_grammar_rules.rb
@@ -9,16 +9,16 @@ class NodeGrammarRules
   }.freeze
 
   REGULAR_RELATIONAL_SUBJECTS = %w[
+    moved_piece
     allied
     enemy
-    moved_piece
     enemy_moved_piece
   ].freeze
 
   REGULAR_RELATIONAL_TARGETS = %w[
+    moved_piece
     allied
     enemy
-    moved_piece
     enemy_moved_piece
   ].freeze
 
@@ -122,7 +122,9 @@ class NodeGrammarRules
         'positionSubjects' => NodeGrammarV2::POSITION_SUBJECTS,
         'census' => {
           'regionSubjects' => NodeGrammarV2::POSITION_SUBJECTS,
-          'wholeBoardSubjects' => NodeGrammarV2::EDITOR_SUBJECTS,
+          # TEMPORARY: captured pieces live in census whole-board until they
+          # move to identity. Drop OFF_BOARD_SUBJECTS here once relocated.
+          'wholeBoardSubjects' => NodeGrammarV2::POSITION_SUBJECTS + NodeGrammarV2::OFF_BOARD_SUBJECTS,
           'operators' => NodeGrammarV2::POSITION_OPERATORS,
           'axes' => NodeGrammarV2::POSITION_AXES,
           'wholeBoardTargets' => NodeGrammarV2::UNARY_TARGETS

--- a/app/models/node_grammar_v2.rb
+++ b/app/models/node_grammar_v2.rb
@@ -1,10 +1,10 @@
   class NodeGrammarV2
     SUBJECTS = %w[
+      moved_piece
       allied
       enemy
-      moved_piece
-      captured_piece
       enemy_moved_piece
+      captured_piece
       enemy_captured_piece
     ].freeze
 
@@ -18,7 +18,7 @@
 
     UNARY_OPERATORS = %w[count mobility value].freeze
     SPECIAL_UNARY_TARGETS = %w[exact_number prior_board_state].freeze
-    UNARY_TARGETS = (%w[exact_number] + SUBJECTS + %w[prior_board_state]).freeze
+    UNARY_TARGETS = (SPECIAL_UNARY_TARGETS + SUBJECTS).freeze
 
     POSITION_SUBJECTS = %w[allied enemy moved_piece enemy_moved_piece].freeze
     POSITION_OPERATORS = %w[count mobility value].freeze

--- a/app/views/bots/edit.html.erb
+++ b/app/views/bots/edit.html.erb
@@ -15,28 +15,32 @@
 
   <div class="editor-toolbar">
     <div class="toolbar-section">
-      <h3>Add Node</h3>
+      <div class="toolbar-section__heading">
+        <h3>Add Node</h3>
+        <button
+          type="button"
+          class="btn-guide"
+          data-action="click->bot-intro#open"
+          aria-controls="bot-intro-modal"
+          aria-haspopup="dialog">How it works</button>
+        <button type="button" class="btn-open-templates">Templates</button>
+      </div>
       <button type="button" class="btn-add-node" data-type="condition">+ Condition</button>
       <button type="button" class="btn-add-node" data-type="score">+ Score</button>
       <button type="button" class="btn-add-node" data-type="organizer">+ Organizer</button>
-      <button type="button" class="btn-open-templates">Templates</button>
-    </div>
-    
-    <div class="toolbar-section">
-      <h3>Tool</h3>
-      <button type="button" class="btn-delete-node" disabled title="Delete selected node (Delete/Backspace)">Delete</button>
-      <button
-        type="button"
-        class="btn-guide"
-        data-action="click->bot-intro#open"
-        aria-controls="bot-intro-modal"
-        aria-haspopup="dialog">How it works</button>
     </div>
 
     <div class="toolbar-section">
-      <h3>View</h3>
-      <button type="button" class="btn-toggle-preview-mode" aria-pressed="true"
-        title="Show condition previews as plain-language sentences or terse chunks (reopen a panel to apply)">Sentences: on</button>
+      <h3>Tool</h3>
+      <button type="button" class="btn-delete-node" disabled title="Delete selected node (Delete/Backspace)">Delete</button>
+    </div>
+
+    <div class="toolbar-section">
+      <div class="toolbar-section__heading">
+        <h3>View</h3>
+        <button type="button" class="btn-toggle-preview-mode" aria-pressed="true"
+          title="Show condition previews as plain-language sentences or terse chunks (reopen a panel to apply)">Sentences: on</button>
+      </div>
       <button type="button" id="zoom-out" class="btn-zoom">-</button>
       <span id="zoom-level">100%</span>
       <button type="button" id="zoom-in" class="btn-zoom">+</button>
@@ -52,7 +56,7 @@
       </button>
     </div>
 
-    <div class="toolbar-section toolbar-section--push-right toolbar-right-group">
+    <div class="toolbar-section toolbar-right-group">
       <div class="toolbar-right-group__top">
         <%= link_to 'compile bot',
             compile_bot_path(@bot),

--- a/app/views/bots/nodes/_editor.html.erb
+++ b/app/views/bots/nodes/_editor.html.erb
@@ -34,11 +34,7 @@
                   <% end %>
                 </div>
 
-                <select id="cond-left-comparator">
-                  <% NodeForm::COMPARATOR_OPTIONS.each do |label, value| %>
-                    <option value="<%= value %>"><%= label %></option>
-                  <% end %>
-                </select>
+                <select id="cond-left-comparator"><%= options_for_select(NodeForm::COMPARATOR_OPTIONS) %></select>
 
                 <div class="condition-form-comparison-source-stack" id="cond-left-comparison-source-stack">
                   <select id="cond-left-comparison-source">
@@ -106,11 +102,7 @@
                     <% end %>
                   </div>
 
-                  <select id="cond-right-comparator">
-                    <% NodeForm::COMPARATOR_OPTIONS.each do |label, value| %>
-                      <option value="<%= value %>"><%= label %></option>
-                    <% end %>
-                  </select>
+                  <select id="cond-right-comparator"><%= options_for_select(NodeForm::COMPARATOR_OPTIONS) %></select>
 
                   <div class="condition-form-comparison-source-stack" id="cond-right-comparison-source-stack">
                     <select id="cond-right-comparison-source">
@@ -173,11 +165,7 @@
                   <% end %>
                 </div>
 
-                <select id="cond-census-comparator">
-                  <% NodeForm::COMPARATOR_OPTIONS.each do |label, value| %>
-                    <option value="<%= value %>"><%= label %></option>
-                  <% end %>
-                </select>
+                <select id="cond-census-comparator"><%= options_for_select(NodeForm::COMPARATOR_OPTIONS) %></select>
 
                 <div class="condition-form-comparison-source-stack" id="cond-census-target-stack">
                   <select id="cond-census-target">

--- a/app/views/bots/nodes/_editor.html.erb
+++ b/app/views/bots/nodes/_editor.html.erb
@@ -20,9 +20,43 @@
             <span class="condition-form-side__label">Subject</span>
           </div>
 
+          <div class="condition-form-comparison" id="cond-left-comparison-section">
+            <button type="button" class="condition-form-comparison__toggle" id="cond-left-comparison-toggle"></button>
+
+            <div class="condition-form-comparison__body hidden" id="cond-left-comparison-body">
+              <div class="condition-form-comparison-grid condition-form-comparison-grid--relational">
+                <div class="condition-form-radio-row" id="cond-left-comparison-metric">
+                  <% NodeForm.comparison_metric_options.each_with_index do |(label, value), i| %>
+                    <label class="condition-form-checkbox">
+                      <input type="radio" name="cond-left-comparison-metric" value="<%= value %>" <%= 'checked' if i.zero? %>>
+                      <span><%= label %></span>
+                    </label>
+                  <% end %>
+                </div>
+
+                <select id="cond-left-comparator">
+                  <% NodeForm::COMPARATOR_OPTIONS.each do |label, value| %>
+                    <option value="<%= value %>"><%= label %></option>
+                  <% end %>
+                </select>
+
+                <div class="condition-form-comparison-source-stack" id="cond-left-comparison-source-stack">
+                  <select id="cond-left-comparison-source">
+                    <option value="exact_number">Integer</option>
+                    <% NodeForm.comparison_source_options.each do |label, value| %>
+                      <option value="<%= value %>"><%= label %></option>
+                    <% end %>
+                  </select>
+                  <input id="cond-left-comparison-source-total" type="number" min="0" step="1">
+                </div>
+              </div>
+              <p class="condition-form-note hidden" id="cond-left-aggregate-note">Aggregate value unavailable while target uses aggregate value.</p>
+            </div>
+          </div>
+
           <div class="condition-form-field">
             <select id="cond-left-subject">
-              <% NodeForm.editor_subject_options.each do |label, value| %>
+              <% NodeForm.relational_subject_options.each do |label, value| %>
                 <option value="<%= value %>"><%= label %></option>
               <% end %>
             </select>
@@ -39,40 +73,6 @@
                   <option value="<%= value %>"><%= label %></option>
                 <% end %>
               </select>
-            </div>
-          </div>
-
-          <div class="condition-form-comparison" id="cond-left-comparison-section">
-            <button type="button" class="condition-form-comparison__toggle" id="cond-left-comparison-toggle"></button>
-
-            <div class="condition-form-comparison__body hidden" id="cond-left-comparison-body">
-              <div class="condition-form-comparison-grid condition-form-comparison-grid--relational">
-                <select id="cond-left-comparison-metric">
-                  <% NodeForm.comparison_metric_options.each do |label, value| %>
-                    <option value="<%= value %>"><%= label %></option>
-                  <% end %>
-                </select>
-
-                <div class="condition-form-radio-row" id="cond-left-comparator">
-                  <% [['equal_to', '='], ['greater_than', '>'], ['less_than', '<'], ['greater_than_or_equal_to', '≥'], ['less_than_or_equal_to', '≤']].each_with_index do |(value, glyph), i| %>
-                    <label class="condition-form-checkbox">
-                      <input type="radio" name="cond-left-comparator" value="<%= value %>" <%= 'checked' if i.zero? %>>
-                      <span><%= glyph %></span>
-                    </label>
-                  <% end %>
-                </div>
-
-                <div class="condition-form-comparison-source-stack" id="cond-left-comparison-source-stack">
-                  <select id="cond-left-comparison-source">
-                    <option value="exact_number">Integer</option>
-                    <% NodeForm.comparison_source_options.each do |label, value| %>
-                      <option value="<%= value %>"><%= label %></option>
-                    <% end %>
-                  </select>
-                  <input id="cond-left-comparison-source-total" type="number" min="0" step="1">
-                </div>
-              </div>
-              <p class="condition-form-note hidden" id="cond-left-aggregate-note">Aggregate value unavailable while target uses aggregate value.</p>
             </div>
           </div>
         </section>
@@ -92,9 +92,43 @@
           </div>
 
           <div id="cond-right-relational-fields">
+            <div class="condition-form-comparison">
+              <button type="button" class="condition-form-comparison__toggle" id="cond-right-comparison-toggle"></button>
+
+              <div class="condition-form-comparison__body hidden" id="cond-right-comparison-body">
+                <div class="condition-form-comparison-grid condition-form-comparison-grid--relational">
+                  <div class="condition-form-radio-row" id="cond-right-comparison-metric">
+                    <% NodeForm.comparison_metric_options.each_with_index do |(label, value), i| %>
+                      <label class="condition-form-checkbox">
+                        <input type="radio" name="cond-right-comparison-metric" value="<%= value %>" <%= 'checked' if i.zero? %>>
+                        <span><%= label %></span>
+                      </label>
+                    <% end %>
+                  </div>
+
+                  <select id="cond-right-comparator">
+                    <% NodeForm::COMPARATOR_OPTIONS.each do |label, value| %>
+                      <option value="<%= value %>"><%= label %></option>
+                    <% end %>
+                  </select>
+
+                  <div class="condition-form-comparison-source-stack" id="cond-right-comparison-source-stack">
+                    <select id="cond-right-comparison-source">
+                      <option value="exact_number">Integer</option>
+                      <% NodeForm.comparison_source_options.each do |label, value| %>
+                        <option value="<%= value %>"><%= label %></option>
+                      <% end %>
+                    </select>
+                    <input id="cond-right-comparison-source-total" type="number" min="0" step="1">
+                  </div>
+                </div>
+                <p class="condition-form-note hidden" id="cond-right-aggregate-note">Aggregate value unavailable while subject uses aggregate value.</p>
+              </div>
+            </div>
+
             <div class="condition-form-field">
               <select id="cond-right-subject">
-                <% NodeForm.editor_subject_options.each do |label, value| %>
+                <% NodeForm.relational_target_options.each do |label, value| %>
                   <option value="<%= value %>"><%= label %></option>
                 <% end %>
               </select>
@@ -115,40 +149,6 @@
             </div>
 
             <p class="condition-form-note hidden" id="cond-relational-target-note">Shield requires a same-team target.</p>
-
-            <div class="condition-form-comparison">
-              <button type="button" class="condition-form-comparison__toggle" id="cond-right-comparison-toggle"></button>
-
-              <div class="condition-form-comparison__body hidden" id="cond-right-comparison-body">
-                <div class="condition-form-comparison-grid condition-form-comparison-grid--relational">
-                  <select id="cond-right-comparison-metric">
-                    <% NodeForm.comparison_metric_options.each do |label, value| %>
-                      <option value="<%= value %>"><%= label %></option>
-                    <% end %>
-                  </select>
-
-                  <div class="condition-form-radio-row" id="cond-right-comparator">
-                    <% [['equal_to', '='], ['greater_than', '>'], ['less_than', '<'], ['greater_than_or_equal_to', '≥'], ['less_than_or_equal_to', '≤']].each_with_index do |(value, glyph), i| %>
-                      <label class="condition-form-checkbox">
-                        <input type="radio" name="cond-right-comparator" value="<%= value %>" <%= 'checked' if i.zero? %>>
-                        <span><%= glyph %></span>
-                      </label>
-                    <% end %>
-                  </div>
-
-                  <div class="condition-form-comparison-source-stack" id="cond-right-comparison-source-stack">
-                    <select id="cond-right-comparison-source">
-                      <option value="exact_number">Integer</option>
-                      <% NodeForm.comparison_source_options.each do |label, value| %>
-                        <option value="<%= value %>"><%= label %></option>
-                      <% end %>
-                    </select>
-                    <input id="cond-right-comparison-source-total" type="number" min="0" step="1">
-                  </div>
-                </div>
-                <p class="condition-form-note hidden" id="cond-right-aggregate-note">Aggregate value unavailable while subject uses aggregate value.</p>
-              </div>
-            </div>
           </div>
         </section>
       </div>
@@ -159,47 +159,25 @@
             <span class="condition-form-side__label">Subject</span>
           </div>
 
-          <div class="condition-form-field">
-            <select id="cond-census-subject">
-              <% NodeForm.editor_subject_options.each do |label, value| %>
-                <option value="<%= value %>"><%= label %></option>
-              <% end %>
-            </select>
-          </div>
-
-          <div class="condition-form-field" id="cond-census-filter-row">
-            <div class="condition-form-inline-pair">
-              <label class="condition-form-checkbox">
-                <input id="cond-census-filter-mode" type="checkbox">
-                <span>Non-</span>
-              </label>
-              <select id="cond-census-filter">
-                <% NodeForm.filter_options.each do |label, value| %>
-                  <option value="<%= value %>"><%= label %></option>
-                <% end %>
-              </select>
-            </div>
-          </div>
-
           <div class="condition-form-comparison" id="cond-census-comparison">
             <button type="button" class="condition-form-comparison__toggle" id="cond-census-comparison-toggle"></button>
 
             <div class="condition-form-comparison__body hidden" id="cond-census-comparison-body">
               <div class="condition-form-comparison-grid condition-form-comparison-grid--relational">
-                <select id="cond-census-operator">
-                  <% NodeForm.condition_form_position_operator_options.each do |label, value| %>
-                    <option value="<%= value %>"><%= label %></option>
-                  <% end %>
-                </select>
-
-                <div class="condition-form-radio-row" id="cond-census-comparator">
-                  <% [['equal_to', '='], ['greater_than', '>'], ['less_than', '<'], ['greater_than_or_equal_to', '≥'], ['less_than_or_equal_to', '≤']].each_with_index do |(value, glyph), i| %>
+                <div class="condition-form-radio-row" id="cond-census-operator">
+                  <% NodeForm.condition_form_position_operator_options.each_with_index do |(label, value), i| %>
                     <label class="condition-form-checkbox">
-                      <input type="radio" name="cond-census-comparator" value="<%= value %>" <%= 'checked' if i.zero? %>>
-                      <span><%= glyph %></span>
+                      <input type="radio" name="cond-census-operator" value="<%= value %>" <%= 'checked' if i.zero? %>>
+                      <span><%= label %></span>
                     </label>
                   <% end %>
                 </div>
+
+                <select id="cond-census-comparator">
+                  <% NodeForm::COMPARATOR_OPTIONS.each do |label, value| %>
+                    <option value="<%= value %>"><%= label %></option>
+                  <% end %>
+                </select>
 
                 <div class="condition-form-comparison-source-stack" id="cond-census-target-stack">
                   <select id="cond-census-target">
@@ -225,6 +203,28 @@
               </div>
             </div>
           </div>
+
+          <div class="condition-form-field">
+            <select id="cond-census-subject">
+              <% NodeForm.editor_subject_options.each do |label, value| %>
+                <option value="<%= value %>"><%= label %></option>
+              <% end %>
+            </select>
+          </div>
+
+          <div class="condition-form-field" id="cond-census-filter-row">
+            <div class="condition-form-inline-pair">
+              <label class="condition-form-checkbox">
+                <input id="cond-census-filter-mode" type="checkbox">
+                <span>Non-</span>
+              </label>
+              <select id="cond-census-filter">
+                <% NodeForm.filter_options.each do |label, value| %>
+                  <option value="<%= value %>"><%= label %></option>
+                <% end %>
+              </select>
+            </div>
+          </div>
         </section>
 
         <section class="condition-form-operator">
@@ -233,7 +233,7 @@
           <div class="condition-form-scope-toggle" id="cond-census-scope">
             <label class="condition-form-checkbox">
               <input type="radio" name="cond-census-scope" id="cond-census-scope-whole" value="whole">
-              <span>Whole<br>board</span>
+              <span>Anywhere</span>
             </label>
             <label class="condition-form-checkbox">
               <input type="radio" name="cond-census-scope" id="cond-census-axis-rank" value="rank" checked>
@@ -251,24 +251,24 @@
 
           <div class="condition-form-comparator-toggle" id="cond-census-region-comparator">
             <label class="condition-form-checkbox">
-              <input type="radio" name="cond-census-region-comparator" value="equal_to" checked>
-              <span>=</span>
-            </label>
-            <label class="condition-form-checkbox">
               <input type="radio" name="cond-census-region-comparator" value="greater_than">
               <span>></span>
-            </label>
-            <label class="condition-form-checkbox">
-              <input type="radio" name="cond-census-region-comparator" value="less_than">
-              <span><</span>
             </label>
             <label class="condition-form-checkbox">
               <input type="radio" name="cond-census-region-comparator" value="greater_than_or_equal_to">
               <span>≥</span>
             </label>
             <label class="condition-form-checkbox">
+              <input type="radio" name="cond-census-region-comparator" value="equal_to" checked>
+              <span>=</span>
+            </label>
+            <label class="condition-form-checkbox">
               <input type="radio" name="cond-census-region-comparator" value="less_than_or_equal_to">
               <span>≤</span>
+            </label>
+            <label class="condition-form-checkbox">
+              <input type="radio" name="cond-census-region-comparator" value="less_than">
+              <span><</span>
             </label>
           </div>
           </div>
@@ -319,7 +319,7 @@
           </div>
         </section>
 
-        <p class="condition-form-note condition-form-position-layout__note">Rank is relative to your side (rank 1 = your back rank).</p>
+        <p class="condition-form-note condition-form-position-layout__note hidden" id="cond-census-rank-note">Rank 1 is your back rank, whether you are white or black.</p>
       </div>
 
       <div class="condition-form-layout condition-form-identity-layout hidden" id="cond-identity-layout">
@@ -356,7 +356,6 @@
       </div>
 
       <div class="condition-form-formulation">
-        <p></p>
         <div class="condition-form-formulation__text" id="cond-formulation-preview"></div>
       </div>
 

--- a/app/views/matches/_match_summary.html.erb
+++ b/app/views/matches/_match_summary.html.erb
@@ -1,7 +1,5 @@
 <div class="match-show-meta">
   <p class="match-show-title">Match <%= match.id %></p>
   <p class="match-show-meta-item"><strong>Status:</strong> <%= match.status %></p>
-  <p class="match-show-meta-item"><strong>White:</strong> <%= match.player_display_name_for(:white) %></p>
-  <p class="match-show-meta-item"><strong>Black:</strong> <%= match.player_display_name_for(:black) %></p>
   <%= render 'matches/rematch_controls', rematch_options: rematch_options %>
 </div>

--- a/app/views/matches/_rematch_controls.html.erb
+++ b/app/views/matches/_rematch_controls.html.erb
@@ -2,7 +2,7 @@
   <%= form_with url: human_vs_bot_matches_path, scope: :match, method: :post, local: true do |form| %>
     <%= form.hidden_field :bot_id, value: rematch_options.human_vs_bot_params[:bot_id] %>
     <%= form.hidden_field :human_color, value: rematch_options.human_vs_bot_params[:human_color] %>
-    <%= form.submit 'Play Again' %>
+    <%= form.submit 'Play Again', class: 'btn-rematch' %>
   <% end %>
 <% elsif rematch_options.human_vs_bot_unavailable_message.present? %>
   <p class="match-show-meta-item"><%= rematch_options.human_vs_bot_unavailable_message %></p>
@@ -10,6 +10,6 @@
   <%= form_with url: bot_vs_bot_matches_path, scope: :match, method: :post, local: true do |form| %>
     <%= form.hidden_field :own_bot_id, value: rematch_options.bot_vs_bot_params[:own_bot_id] %>
     <%= form.hidden_field :opponent_bot_id, value: rematch_options.bot_vs_bot_params[:opponent_bot_id] %>
-    <%= form.submit 'Rematch' %>
+    <%= form.submit 'Rematch', class: 'btn-rematch' %>
   <% end %>
 <% end %>

--- a/app/views/matches/live.html.erb
+++ b/app/views/matches/live.html.erb
@@ -11,6 +11,8 @@
   data-human-team="<%= human_team %>"
   data-bot-team="<%= bot_team %>"
   data-bot-name="<%= @match.player_display_name_for(bot_color) %>"
+  data-white-name="<%= @match.player_display_name_for(:white) %>"
+  data-black-name="<%= @match.player_display_name_for(:black) %>"
   data-complete-url="<%= complete_human_vs_bot_match_path(@match) %>"
   data-replay-url="<%= match_path(@match) %>"
   data-bot-compiled-program="<%= json_escape(bot_snapshot.to_json) %>"
@@ -18,22 +20,10 @@
   <div class="match-live-layout">
     <div class="match-show-meta match-live-sidebar">
       <p class="match-show-title">Match <%= @match.id %></p>
-      <p class="match-show-meta-item"><strong>Human:</strong> <span data-human-side-label><%= human_team == 'W' ? 'White' : 'Black' %></span></p>
-      <p class="match-show-meta-item">
-        <strong>Bot:</strong>
-        <span data-bot-name-label><%= @match.player_display_name_for(bot_color) %></span>
-        (<span data-bot-side-label><%= bot_color == :white ? 'White' : 'Black' %></span>)
-      </p>
       <p class="match-show-meta-item match-live-status-pill" data-play-status>Bot's turn.</p>
     </div>
 
-    <div id="arena">
-      <div id="notifications"></div>
-      <div id="turn-marker"><span id="team-allowed-to-move">white</span>'s turn</div>
-      <div id="W-captures" class="captures"><br><br><br></div>
-      <%= render partial: 'shared/chess_board' %>
-      <div id="B-captures" class="captures"><br><br><br></div>
-    </div>
+    <%= render 'shared/match_arena', match: @match %>
   </div>
 
   <button id="undo-button">undo</button>

--- a/app/views/matches/show.html.erb
+++ b/app/views/matches/show.html.erb
@@ -11,13 +11,7 @@
         <% if @match.error_message.present? %>
           <p class="match-show-error"><strong>Error:</strong> <%= @match.error_message %></p>
         <% end %>
-        <div id="arena">
-          <div id="notifications"></div>
-          <div id="turn-marker"><span id="team-allowed-to-move">W</span>'s turn</div>
-          <div id="W-captures" class="captures"><br><br><br></div>
-          <%= render partial: 'shared/chess_board' %>
-          <div id="B-captures" class="captures"><br><br><br></div>
-        </div>
+        <%= render 'shared/match_arena', match: @match %>
       </div>
 
       <div class="bot-trace-panel replay-stack replay-shell">
@@ -27,6 +21,8 @@
   <% elsif @match.failed? %>
     <div class="game-page">
       <%= render 'matches/match_summary', match: @match, rematch_options: @rematch_options %>
+      <p class="match-show-meta-item"><strong>White:</strong> <%= @match.player_display_name_for(:white) %></p>
+      <p class="match-show-meta-item"><strong>Black:</strong> <%= @match.player_display_name_for(:black) %></p>
       <p>Match generation failed.</p>
       <% if @match.error_message.present? %>
         <p class="match-show-error"><strong>Error:</strong> <%= @match.error_message %></p>
@@ -40,6 +36,8 @@
       data-movement-notation="<%= json_escape(@match.movement_notation.to_json) %>"
       data-result="<%= @match.result %>"
       data-current-user-id="<%= current_user.id %>"
+      data-white-name="<%= @match.player_display_name_for(:white) %>"
+      data-black-name="<%= @match.player_display_name_for(:black) %>"
       data-white-bot-owner-id="<%= @match.white_tournament_entry&.bot_owner_id || (@match.white_player_type == 'Bot' ? @match.white_player&.user_id : '') %>"
       data-black-bot-owner-id="<%= @match.black_tournament_entry&.bot_owner_id || (@match.black_player_type == 'Bot' ? @match.black_player&.user_id : '') %>"
       data-white-compiled-program-snapshot="<%= json_escape(@match.compiled_program_snapshot_for(:white).to_json) %>"
@@ -73,13 +71,7 @@
           </div>
           <p data-match-replay-target="warning" hidden></p>
         </div>
-        <div id="arena">
-          <div id="notifications"></div>
-          <div id="turn-marker"><span id="team-allowed-to-move">W</span>'s turn</div>
-          <div id="W-captures" class="captures"><br><br><br></div>
-          <%= render partial: 'shared/chess_board' %>
-          <div id="B-captures" class="captures"><br><br><br></div>
-        </div>
+        <%= render 'shared/match_arena', match: @match %>
       </div>
 
       <div class="match-replay-notation-column replay-scroll-y">

--- a/app/views/shared/_match_arena.html.erb
+++ b/app/views/shared/_match_arena.html.erb
@@ -1,0 +1,8 @@
+<div id="arena">
+  <div id="notifications"></div>
+  <div class="board-player-name" data-board-name="top"><%= match.player_display_name_for(:black) %></div>
+  <div id="W-captures" class="captures"><br><br><br></div>
+  <%= render partial: 'shared/chess_board' %>
+  <div id="B-captures" class="captures"><br><br><br></div>
+  <div class="board-player-name" data-board-name="bottom"><%= match.player_display_name_for(:white) %></div>
+</div>

--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -7,3 +7,4 @@ bundle exec rails assets:precompile
 bundle exec rails assets:clean
 bundle exec rails db:migrate
 bundle exec rails db:seed
+bundle exec rails conditions:census_value_any_to_non_king

--- a/lib/tasks/census_value_any_to_non_king.rake
+++ b/lib/tasks/census_value_any_to_non_king.rake
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+namespace :conditions do
+  desc 'Convert group census value conditions from "any" to non-king (filter: king, ' \
+       'mode: exclude). Targets allied/enemy value+any census conditions only — their ' \
+       '"any" set includes the king, whose Infinity value poisons the aggregate. ' \
+       'Singular-actor conditions (moved_piece/captured_piece/enemy_moved_piece/' \
+       'enemy_captured_piece) are intentionally left untouched: they are either ' \
+       'never-king or correctly king-valued under king=Infinity. Idempotent. ' \
+       'Set DRY_RUN=1 to preview without writing.'
+  task census_value_any_to_non_king: :environment do
+    dry_run = ENV['DRY_RUN'].present?
+    group_subjects = %w[allied enemy]
+
+    candidates = Node.where(node_type: 'condition')
+                     .where("data->>'kind' = 'census'")
+                     .where("data->>'operator' = 'value'")
+                     .where("data->>'subjectFilter' = 'any'")
+                     .where("data->>'subject' IN (?)", group_subjects)
+
+    puts "Found #{candidates.size} group census value+any condition(s)#{dry_run ? ' (dry run)' : ''}."
+
+    converted = 0
+    candidates.find_each do |node|
+      puts "  node #{node.id} (bot #{node.bot_id}): #{node.data['subject']} value any -> non-king"
+      next if dry_run
+
+      node.data = node.data.merge('subjectFilter' => 'king', 'subjectFilterMode' => 'exclude')
+      node.save!
+      converted += 1
+    end
+
+    puts dry_run ? 'Dry run — no changes written.' : "Converted #{converted} condition(s)."
+  end
+end


### PR DESCRIPTION
UI pass over the match pages and bot editor, plus three fixes.

  - **Match arena:** shared `_match_arena` partial; board flips to the viewer's
    perspective (names beside it, active player highlighted, captures + labels follow).
  - **Editor toolbar:** heading rows for How it works/Templates/Sentences; add-node
    buttons bordered in their node colors.
  - **Condition form:** My Pieces/Enemy Pieces relabel + consistent ordering;
    plain-English comparator selects; metric/operator pills; "Anywhere" scope; result
    sentence enlarged and always shown.
  - **Mini-board:** filled glyphs (color fix) + file/rank labels.
  - **Fixes:** smother-mate king placed in its own back-rank corner.

  Tests added for orientation, replay flip, and control hints; full JS suite green

also rake task to update old value any conditions to behave correctly with new king=infinity