### PR TITLE
grammar gating (backend + preview) & condition form overhaul

### DIFF
--- a/app/assets/stylesheets/node_editor.css
+++ b/app/assets/stylesheets/node_editor.css
@@ -1092,7 +1092,7 @@
   background: #14120f;
   border: 1px solid #3d3a35;
   border-radius: 10px;
-  padding: 2px 14px 14px;
+  padding: 2px 8px 14px;
 }
 
 .condition-form-side__header {
@@ -1142,6 +1142,13 @@
 .condition-form-field ~ .condition-form-comparison,
 .condition-form-comparison + .condition-form-field {
   margin-top: 6px;
+}
+
+#cond-left-filter-row,
+#cond-right-filter-row,
+#cond-census-filter-row,
+#cond-captures-filter-row {
+  margin-top: 0;
 }
 
 .condition-form-side select,
@@ -1196,13 +1203,28 @@
 }
 
 .condition-form-inline-pair {
-  grid-template-columns: 4.1rem minmax(0, 1fr);
-  gap: 0.08rem;
+  grid-template-columns: auto minmax(0, 1fr);
+  gap: 0;
+  align-items: center;
 }
 
-#cond-position-square-inputs {
-  grid-template-columns: 1fr 1fr;
-  gap: 8px;
+.condition-form-inline-pair .condition-form-checkbox {
+  padding-right: 0;
+}
+
+.condition-form-side .condition-form-inline-pair select {
+  width: 80%;
+}
+
+#cond-left-comparison-metric .condition-form-checkbox span,
+#cond-right-comparison-metric .condition-form-checkbox span,
+#cond-census-operator .condition-form-checkbox span {
+  padding-left: 5px;
+  padding-right: 5px;
+}
+
+#cond-captures-operator .condition-form-checkbox span {
+  padding: 8px 5px;
 }
 
 .condition-form-radio-row,
@@ -1317,11 +1339,27 @@
   pointer-events: none;
 }
 
-.condition-form-positions-row {
+.condition-form-square-inputs.condition-form-radio-list--disabled .condition-form-radio-list input[type="radio"]:checked + span {
+  background: transparent;
+  color: #6b7280;
+  font-weight: normal;
+}
+
+.condition-form-positions-row,
+.condition-form-operator-row {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
   gap: 1rem;
+}
+
+.condition-form-operator-row {
+  gap: 0.25rem;
+}
+
+.condition-form-captures-layout .condition-form-operator {
+  padding-left: 8px;
+  padding-right: 8px;
 }
 
 .condition-form-inline-triple {
@@ -1362,10 +1400,22 @@
 .condition-form-comparison-grid--relational .condition-form-comparison-source-stack {
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 0;
   flex: 1 1 auto;
   min-width: 0;
   max-width: 14rem;
+}
+
+/* Combined integer box stays at the dropdown's footprint: the number eats into
+   the select's width rather than widening the box. */
+.condition-form-comparison-grid--relational .condition-form-comparison-source-stack:has(> select:not(.hidden)):has(> input[type="number"]:not(.hidden)) {
+  flex: 0 1 7.5rem;
+  max-width: 7.5rem;
+}
+
+.condition-form-comparison-grid--relational .condition-form-comparison-source-stack:has(> select:not(.hidden)):has(> input[type="number"]:not(.hidden)) > input[type="number"] {
+  flex: 0 0 2.75rem;
+  width: 2.75rem;
 }
 
 .condition-form-comparison-grid--relational .condition-form-comparison-source-stack select {
@@ -1389,38 +1439,52 @@
   align-self: flex-start;
 }
 
-.condition-form-comparison-grid--unary {
-  grid-template-columns: 4.75rem minmax(10.5rem, 1fr);
-  align-items: start;
-}
-
 .condition-form-comparison-source-stack {
   display: grid;
-  gap: 8px;
+  gap: 0;
   grid-column: 1 / -1;
 }
 
-.condition-form-comparison-source-stack--inline-number {
-  grid-template-columns: minmax(0, 1fr) minmax(3.85rem, 4.25rem);
-  align-items: center;
-  gap: 6px;
-}
-
-.condition-form-comparison-source-stack--inline-number input[type="number"] {
-  width: 100%;
-  box-sizing: border-box;
-  padding: 7px 8px;
-  margin: 0;
-  background: #2d2a25;
+/* Integer comparison: the source dropdown and the number read as one bordered
+   field. Fires only when both the dropdown and the number are showing. */
+.condition-form-comparison-source-stack:has(> select:not(.hidden)):has(> input[type="number"]:not(.hidden)) {
+  display: flex;
+  flex-direction: row;
+  align-items: stretch;
   border: 1px solid #1a1815;
   border-radius: 6px;
-  color: #E5E5E5;
-  font-size: 12px;
-  line-height: normal;
-  appearance: auto;
+  background: #2d2a25;
+  overflow: hidden;
+}
+
+.condition-form-comparison-source-stack:has(> select:not(.hidden)):has(> input[type="number"]:not(.hidden)) > select {
+  flex: 1 1 auto;
+  width: auto;
+  min-width: 0;
+  align-self: auto;
+  border: none;
+  background-color: transparent;
+  border-radius: 0;
+}
+
+.condition-form-comparison-source-stack:has(> select:not(.hidden)):has(> input[type="number"]:not(.hidden)) > input[type="number"] {
+  flex: 0 0 3.5rem;
+  width: 3.5rem;
+  align-self: auto;
+  border: none;
+  border-left: 1px solid #1a1815;
+  background: transparent;
+  border-radius: 0;
   text-align: center;
-  font-weight: 400;
-  font-variant-numeric: tabular-nums;
+}
+
+.condition-form-comparison-source-stack:has(> select:not(.hidden)):has(> input[type="number"]:not(.hidden)):focus-within {
+  border-color: rgba(168, 85, 247, 0.55);
+}
+
+.condition-form-comparison-source-stack:has(> select:not(.hidden)):has(> input[type="number"]:not(.hidden)) > select:focus,
+.condition-form-comparison-source-stack:has(> select:not(.hidden)):has(> input[type="number"]:not(.hidden)) > input[type="number"]:focus {
+  outline: none;
 }
 
 .condition-form-checkbox {
@@ -1442,26 +1506,13 @@
   margin: 0;
 }
 
-.condition-form-comparison__toggle {
-  width: 100%;
-  padding: 5px 8px;
-  background: #1d1916;
-  border: 1px dashed #5a5650;
-  border-radius: 8px;
-  color: #D1D5DB;
-  font-size: 12px;
-  text-align: left;
-  cursor: pointer;
-}
-
-.condition-form-comparison__toggle:disabled {
-  opacity: 0.55;
-  cursor: not-allowed;
-}
-
 .condition-form-comparison__body {
-  margin-top: 10px;
-  padding-top: 10px;
+  padding-top: 6px;
+}
+
+.condition-form-comparison__body--locked .condition-form-comparison-grid {
+  opacity: 0.4;
+  pointer-events: none;
 }
 
 .condition-form-comparison {
@@ -1474,22 +1525,6 @@
   padding-top: 0;
 }
 
-#cond-census-target-filter-row {
-  grid-template-columns: auto minmax(0, 1fr);
-  gap: 0;
-  align-items: center;
-}
-
-#cond-census-target-filter-row .condition-form-checkbox {
-  padding-right: 0;
-  align-self: stretch;
-  align-items: center;
-}
-
-#cond-census-target-filter-row .condition-form-checkbox input {
-  margin: 0;
-}
-
 #cond-census-filter-row .condition-form-inline-pair {
   grid-template-columns: auto minmax(0, 1fr);
   gap: 0;
@@ -1499,12 +1534,6 @@
 #cond-census-filter-row .condition-form-checkbox {
   padding-right: 0;
 }
-
-#cond-census-target-filter {
-  padding-top: 6px;
-  padding-bottom: 6px;
-}
-
 
 .condition-form-result-mode {
   display: inline-flex;
@@ -1586,14 +1615,6 @@
   margin: 0;
 }
 
-
-#cond-position-target-total {
-  width: 3rem;
-  min-width: 0;
-  box-sizing: border-box;
-  padding: 7px 4px;
-  text-align: center;
-}
 
 .condition-form-formulation {
   margin-top: 12px;

--- a/app/forms/node_form.rb
+++ b/app/forms/node_form.rb
@@ -9,7 +9,7 @@ class NodeForm
   }.freeze
 
   FILTER_LABELS = {
-    'any' => 'Any piece',
+    'any' => 'Any piece type',
     'king' => 'King',
     'queen' => 'Queen',
     'rook' => 'Rook',

--- a/app/javascript/bot_execution/actors.js
+++ b/app/javascript/bot_execution/actors.js
@@ -1,4 +1,6 @@
-// Canonical definitions of actor sets used across bot execution and analysis.
+// Actor sets used across bot execution and analysis. The singular sets mirror
+// app/models/node_grammar_v2.rb (SINGULAR_SUBJECTS / RELATIONAL_SINGULAR_SUBJECTS);
+// spec/models/actors_js_sync_spec.rb guards the mirror.
 
 // Singular move-event actors — count is always 0 or 1 (one piece per role).
 // Distinct from group actors (allied, enemy) which can have many pieces.

--- a/app/javascript/bot_execution/candidate_move_analysis_v2.js
+++ b/app/javascript/bot_execution/candidate_move_analysis_v2.js
@@ -214,7 +214,7 @@ class CandidateMoveAnalysisV2 {
     const endPosition = this.moveObject.endPosition
     const movedPieceType = this.board.pieceTypeAt(startPosition)
     if (this.board.teamAt(endPosition) !== Board.EMPTY) { return endPosition }
-    const changedFiles = Board.file(startPosition) !== Board.file(endPosition)
+    const changedFiles = Board.fileLabel(startPosition) !== Board.fileLabel(endPosition)
     if (movedPieceType === Board.PAWN && changedFiles) {
       return this.movedPieceTeam() === Board.WHITE
         ? endPosition - 8

--- a/app/javascript/bot_execution/position_analysis.js
+++ b/app/javascript/bot_execution/position_analysis.js
@@ -1,5 +1,5 @@
 import Board from "gameplay/board"
-import { materialValue, relativeRank, relativeToAbsolutePosition } from "gameplay/board_query_utils"
+import { materialValue, relativeRankLabel, relativeToAbsolutePosition } from "gameplay/board_query_utils"
 import profileCollector from "gameplay/profile_collector"
 import { relationalActorPositions } from "bot_execution/actor_positions"
 import { aggregateOrNull, compareValues } from "bot_execution/utils"
@@ -35,7 +35,7 @@ export function positionMetricTotal(analysis, { positions, operator, boardScope 
 function positionSatisfied(position, team, { positionAxis, positionComparator, positionTarget }) {
   switch (positionAxis) {
     case "rank": {
-      const rank = relativeRank(position, team)
+      const rank = relativeRankLabel(position, team)
       return compareValues(rank, positionComparator, positionTarget)
     }
     case "file": {

--- a/app/javascript/editorV2/__tests__/ConditionExampleGenerator.test.js
+++ b/app/javascript/editorV2/__tests__/ConditionExampleGenerator.test.js
@@ -461,19 +461,6 @@ describe('ConditionExampleGenerator', () => {
     expect(preview.examples.length).toBeGreaterThan(0)
   })
 
-  it('flags contradiction when a singular actor has count > 1', () => {
-    const payload = {
-      version: 2, kind: 'relational',
-      subject: 'moved_piece', subjectFilter: 'any', operator: 'attack',
-      target: 'enemy', targetFilter: 'any',
-      subjectComparisonMetric: 'count', subjectComparator: 'equal_to',
-      subjectComparisonSource: 'exact_number', subjectComparisonSourceTotal: 2
-    }
-    const preview = generateConditionExamples(payload, { random: seededRandom(1106) })
-    expect(preview.status).toBe('contradictory')
-    expect(preview.reason).toMatch(/singular actor/i)
-  })
-
   // Dormant: detectSingularActorWithAggregateValue is unregistered from
   // CONTRADICTION_DETECTORS while aggregate_value is grammar-gated. Re-enable
   // the detector and this test together.
@@ -514,54 +501,6 @@ describe('ConditionExampleGenerator', () => {
     const preview = generateConditionExamples(payload, { random: seededRandom(1110) })
     expect(preview.status).toBe('contradictory')
     expect(preview.reason).toMatch(/filter matches no pieces with the required value/i)
-  })
-
-  it('flags contradiction when a pawn is required on an illegal rank', () => {
-    const payload = {
-      version: 2, kind: 'census', target: 'exact_number',
-      subject: 'allied', subjectFilter: 'pawn', operator: 'count',
-      positionAxis: 'rank', positionComparator: 'equal_to', positionTarget: 0,
-      comparator: 'greater_than_or_equal_to', targetTotal: 1
-    }
-    const preview = generateConditionExamples(payload, { random: seededRandom(1111) })
-    expect(preview.status).toBe('contradictory')
-    expect(preview.reason).toMatch(/pawns cannot be on rank 1/i)
-  })
-
-  it('flags contradiction when a directional rank constraint resolves to only an illegal pawn rank', () => {
-    const payload = {
-      version: 2, kind: 'census', target: 'exact_number',
-      subject: 'allied', subjectFilter: 'pawn', operator: 'count',
-      positionAxis: 'rank', positionComparator: 'less_than', positionTarget: 1,
-      comparator: 'greater_than_or_equal_to', targetTotal: 1
-    }
-    const preview = generateConditionExamples(payload, { random: seededRandom(1112) })
-    expect(preview.status).toBe('contradictory')
-    expect(preview.reason).toMatch(/pawns cannot be on rank 1/i)
-  })
-
-  it('flags contradiction when a unary singular actor has count > 1', () => {
-    const payload = {
-      version: 2, kind: 'census',
-      subject: 'moved_piece', subjectFilter: 'any',
-      operator: 'count', comparator: 'equal_to',
-      target: 'exact_number', targetTotal: 2
-    }
-    const preview = generateConditionExamples(payload, { random: seededRandom(1113) })
-    expect(preview.status).toBe('contradictory')
-    expect(preview.reason).toMatch(/singular actor.*cannot have count > 1/i)
-  })
-
-  it('flags contradiction when moved_piece is required to have count = 0', () => {
-    const payload = {
-      version: 2, kind: 'census',
-      subject: 'moved_piece', subjectFilter: 'any',
-      operator: 'count', comparator: 'equal_to',
-      target: 'exact_number', targetTotal: 0
-    }
-    const preview = generateConditionExamples(payload, { random: seededRandom(1114) })
-    expect(preview.status).toBe('contradictory')
-    expect(preview.reason).toMatch(/moved_piece must exist/i)
   })
 
   it('uses forward generation for allied any mobility > prior_board_state via group-mobility-increase pattern', () => {

--- a/app/javascript/editorV2/__tests__/ConditionForm.test.js
+++ b/app/javascript/editorV2/__tests__/ConditionForm.test.js
@@ -63,8 +63,8 @@ function buildPanel() {
         <option value="less_than_or_equal_to">at most</option>
       </select>
       <div id="cond-left-comparison-section" class="condition-form-comparison">
-        <button type="button" id="cond-left-comparison-toggle"></button>
-        <div id="cond-left-comparison-body" class="hidden"></div>
+        <div id="cond-left-comparison-body"></div>
+        <p id="cond-left-comparison-locked-note" class="hidden"></p>
       </div>
       <div id="cond-left-comparison-source-stack" class="condition-form-comparison-source-stack">
         <select id="cond-left-comparison-source">
@@ -94,8 +94,8 @@ function buildPanel() {
         <option value="less_than_or_equal_to">at most</option>
       </select>
       <div id="cond-right-comparison-section" class="condition-form-comparison">
-        <button type="button" id="cond-right-comparison-toggle"></button>
-        <div id="cond-right-comparison-body" class="hidden"></div>
+        <div id="cond-right-comparison-body"></div>
+        <p id="cond-right-comparison-locked-note" class="hidden"></p>
       </div>
       <div id="cond-right-comparison-source-stack" class="condition-form-comparison-source-stack">
         <select id="cond-right-comparison-source">
@@ -122,8 +122,7 @@ function buildPanel() {
         <select id="cond-census-filter">${option('any')}${option('pawn')}${option('rook')}</select>
       </div>
       <div id="cond-census-comparison" class="condition-form-comparison">
-        <button type="button" id="cond-census-comparison-toggle"></button>
-        <div id="cond-census-comparison-body" class="hidden">
+        <div id="cond-census-comparison-body">
           <div id="cond-census-operator">${censusOperatorOptions}</div>
           <select id="cond-census-comparator">
             <option value="equal_to">equal to</option>
@@ -134,13 +133,6 @@ function buildPanel() {
           </select>
           <div id="cond-census-target-stack" class="condition-form-comparison-source-stack">
             <select id="cond-census-target">${censusTargetOptions}</select>
-            <div id="cond-census-target-filter-row">
-              <label class="condition-form-checkbox">
-                <input id="cond-census-target-filter-mode" type="checkbox">
-                <span>Non-</span>
-              </label>
-              <select id="cond-census-target-filter">${option('any')}${option('pawn')}${option('rook')}</select>
-            </div>
             <input id="cond-census-target-total" type="number">
           </div>
         </div>
@@ -245,8 +237,6 @@ describe('ConditionForm', () => {
     expect(panel.querySelector('#cond-left-comparison-source').classList.contains('hidden')).toBe(false)
     expect(panel.querySelector('#cond-left-comparison-source-total').classList.contains('hidden')).toBe(false)
     expect(panel.querySelector('#cond-right-comparison-source-total').classList.contains('hidden')).toBe(false)
-    expect(panel.querySelector('#cond-left-comparison-source-stack').classList.contains('condition-form-comparison-source-stack--inline-number')).toBe(true)
-    expect(panel.querySelector('#cond-right-comparison-source-stack').classList.contains('condition-form-comparison-source-stack--inline-number')).toBe(true)
 
     const rightSource = panel.querySelector('#cond-right-comparison-source')
     rightSource.value = 'prior_board_state'
@@ -255,7 +245,9 @@ describe('ConditionForm', () => {
     expect(panel.querySelector('#cond-left-comparison-source-total').classList.contains('hidden')).toBe(false)
     expect(panel.querySelector('#cond-right-comparison-source-total').classList.contains('hidden')).toBe(true)
     expect(panel.querySelector('#cond-right-comparison-source').classList.contains('hidden')).toBe(false)
-    expect(panel.querySelector('#cond-right-comparison-source-stack').classList.contains('condition-form-comparison-source-stack--inline-number')).toBe(false)
+
+    expect(panel.querySelector('#cond-left-comparison-body').classList.contains('condition-form-comparison__body--locked')).toBe(true)
+    expect(panel.querySelector('#cond-left-comparison-locked-note').classList.contains('hidden')).toBe(false)
   })
 
   it('hides the numeric selector when the left source is symbolic and leaves the right side alone', () => {
@@ -284,8 +276,6 @@ describe('ConditionForm', () => {
     expect(panel.querySelector('#cond-left-comparison-source-total').classList.contains('hidden')).toBe(true)
     expect(panel.querySelector('#cond-right-comparison-source-total').classList.contains('hidden')).toBe(false)
     expect(panel.querySelector('#cond-left-comparison-source').classList.contains('hidden')).toBe(false)
-    expect(panel.querySelector('#cond-left-comparison-source-stack').classList.contains('condition-form-comparison-source-stack--inline-number')).toBe(false)
-    expect(panel.querySelector('#cond-right-comparison-source-stack').classList.contains('condition-form-comparison-source-stack--inline-number')).toBe(true)
   })
 
   it('hides and clears the subject non toggle when the subject filter is any', () => {
@@ -474,7 +464,7 @@ describe('ConditionForm', () => {
     expect(form.buildPayload().target).toBe('enemy')
   })
 
-  it('loads a whole-board census and builds an actor-target payload with filters', () => {
+  it('loads a whole-board value census and drops any target piece-type filter', () => {
     const panel = buildPanel()
     const form = new ConditionForm(panel)
     form.attach()
@@ -498,7 +488,6 @@ describe('ConditionForm', () => {
     expect(squareInputs.classList.contains('condition-form-radio-list--disabled')).toBe(true)
     expect(panel.querySelector('#cond-census-square-rank input').disabled).toBe(true)
     expect(panel.querySelector('#cond-census-target-total').classList.contains('hidden')).toBe(true)
-    expect(panel.querySelector('#cond-census-target-filter-row').classList.contains('hidden')).toBe(false)
 
     const payload = form.buildPayload()
     expect(payload).toMatchObject({
@@ -509,9 +498,9 @@ describe('ConditionForm', () => {
       operator: 'value',
       comparator: 'greater_than',
       target: 'enemy',
-      targetFilter: 'rook',
-      targetFilterMode: 'exclude'
+      targetFilter: 'any'
     })
+    expect(payload).not.toHaveProperty('targetFilterMode')
     expect(payload).not.toHaveProperty('positionAxis')
     expect(payload).not.toHaveProperty('positionComparator')
     expect(payload).not.toHaveProperty('positionTarget')
@@ -547,38 +536,7 @@ describe('ConditionForm', () => {
     })
   })
 
-  it('hides and clears the whole-board target non toggle when the target filter is any', () => {
-    const panel = buildPanel()
-    const form = new ConditionForm(panel)
-    form.attach()
-
-    form.populate({
-      version: 2,
-      kind: 'census',
-      subject: 'allied',
-      subjectFilter: 'any',
-      operator: 'value',
-      comparator: 'greater_than',
-      target: 'enemy',
-      targetFilter: 'rook',
-      targetFilterMode: 'exclude'
-    })
-
-    const targetFilterMode = panel.querySelector('#cond-census-target-filter-mode')
-    const control = targetFilterMode.closest('.condition-form-checkbox')
-    expect(targetFilterMode.checked).toBe(true)
-    expect(control.classList.contains('condition-form-checkbox--unavailable')).toBe(false)
-
-    const targetFilter = panel.querySelector('#cond-census-target-filter')
-    targetFilter.value = 'any'
-    targetFilter.dispatchEvent(new Event('change', { bubbles: true }))
-
-    expect(targetFilterMode.checked).toBe(false)
-    expect(control.classList.contains('condition-form-checkbox--unavailable')).toBe(true)
-    expect(form.buildPayload()).not.toHaveProperty('targetFilterMode')
-  })
-
-  it('disallows captured-piece whole-board census targets for mobility', () => {
+  it('limits whole-board mobility targets to integer and prior board state', () => {
     const panel = buildPanel()
     const form = new ConditionForm(panel)
     form.attach()
@@ -590,15 +548,15 @@ describe('ConditionForm', () => {
       subjectFilter: 'any',
       operator: 'mobility',
       comparator: 'greater_than',
-      target: 'captured_piece',
-      targetFilter: 'any'
+      target: 'enemy'
     })
 
     const targetSelect = panel.querySelector('#cond-census-target')
     expect(form.buildPayload().target).toBe('exact_number')
+    expect(targetSelect.querySelector('option[value="enemy"]').disabled).toBe(true)
     expect(targetSelect.querySelector('option[value="captured_piece"]').disabled).toBe(true)
-    expect(targetSelect.querySelector('option[value="enemy_captured_piece"]').disabled).toBe(true)
-    expect(targetSelect.querySelector('option[value="enemy"]').disabled).toBe(false)
+    expect(targetSelect.querySelector('option[value="exact_number"]').disabled).toBe(false)
+    expect(targetSelect.querySelector('option[value="prior_board_state"]').disabled).toBe(false)
   })
 
   it('loads a region census and emits spatial keys with an exact_number target', () => {
@@ -639,7 +597,7 @@ describe('ConditionForm', () => {
     })
   })
 
-  it('keeps a Simple region census on exact_number and hides the target select', () => {
+  it('shows the region census target select and switches count to prior_board_state', () => {
     const panel = buildPanel()
     const form = new ConditionForm(panel)
     form.attach()
@@ -658,8 +616,7 @@ describe('ConditionForm', () => {
       targetTotal: 0
     })
 
-    expect(panel.querySelector('#cond-census-comparison-toggle').textContent).toBe('+ Advanced options')
-    expect(panel.querySelector('#cond-census-target').classList.contains('hidden')).toBe(true)
+    expect(panel.querySelector('#cond-census-target').classList.contains('hidden')).toBe(false)
     expect(panel.querySelector('#cond-census-rank-note').classList.contains('hidden')).toBe(true)
 
     const targetSelect = panel.querySelector('#cond-census-target')
@@ -670,9 +627,9 @@ describe('ConditionForm', () => {
       kind: 'census',
       positionAxis: 'file',
       positionTarget: 3,
-      target: 'exact_number',
-      targetTotal: 0
+      target: 'prior_board_state'
     })
+    expect(form.buildPayload()).not.toHaveProperty('targetTotal')
   })
 
   it('preserves relational state when switching to the census tab and back', () => {
@@ -727,7 +684,7 @@ describe('ConditionForm', () => {
     expect(payload.targetTotal).toBe(3)
   })
 
-  it('defaults whole-board to Simple (no target select) and reveals it via Advanced', () => {
+  it('shows the whole-board target select with no advanced toggle', () => {
     const panel = buildPanel()
     const form = new ConditionForm(panel)
     form.attach()
@@ -743,48 +700,13 @@ describe('ConditionForm', () => {
       targetTotal: 2
     })
 
-    const toggle = panel.querySelector('#cond-census-comparison-toggle')
     expect(panel.querySelector('#cond-census-scope-whole').checked).toBe(true)
-    expect(panel.querySelector('#cond-census-comparison-body').classList.contains('hidden')).toBe(false)
-    expect(toggle.classList.contains('hidden')).toBe(false)
-    expect(toggle.textContent).toBe('+ Advanced options')
-    expect(panel.querySelector('#cond-census-target').classList.contains('hidden')).toBe(true)
+    expect(panel.querySelector('#cond-census-comparison-toggle')).toBeNull()
+    expect(panel.querySelector('#cond-census-target').classList.contains('hidden')).toBe(false)
     expect(form.buildPayload()).toMatchObject({ kind: 'census', target: 'exact_number', targetTotal: 2 })
-
-    toggle.dispatchEvent(new Event('click'))
-
-    expect(toggle.textContent).toBe('Simplify')
-    expect(panel.querySelector('#cond-census-target').classList.contains('hidden')).toBe(false)
   })
 
-  it('keeps the Advanced toggle available in region scope', () => {
-    const panel = buildPanel()
-    const form = new ConditionForm(panel)
-    form.attach()
-
-    form.populate({
-      version: 2,
-      kind: 'census',
-      subject: 'allied',
-      subjectFilter: 'any',
-      positionAxis: 'rank',
-      positionComparator: 'equal_to',
-      positionTarget: 5,
-      operator: 'count',
-      comparator: 'greater_than',
-      target: 'exact_number',
-      targetTotal: 0
-    })
-
-    const toggle = panel.querySelector('#cond-census-comparison-toggle')
-    expect(toggle.classList.contains('hidden')).toBe(false)
-    expect(panel.querySelector('#cond-census-target').classList.contains('hidden')).toBe(true)
-
-    toggle.dispatchEvent(new Event('click'))
-    expect(panel.querySelector('#cond-census-target').classList.contains('hidden')).toBe(false)
-  })
-
-  it('loads a region prior_board_state census straight into Advanced and round-trips spatial keys', () => {
+  it('loads a region prior_board_state census and round-trips spatial keys', () => {
     const panel = buildPanel()
     const form = new ConditionForm(panel)
     form.attach()
@@ -803,7 +725,6 @@ describe('ConditionForm', () => {
       target: 'prior_board_state'
     })
 
-    expect(panel.querySelector('#cond-census-comparison-toggle').textContent).toBe('Simplify')
     expect(panel.querySelector('#cond-census-target').classList.contains('hidden')).toBe(false)
     expect(form.buildPayload()).toEqual({
       version: 2,
@@ -820,7 +741,7 @@ describe('ConditionForm', () => {
     })
   })
 
-  it('loads an actor-target whole-board census straight into Advanced', () => {
+  it('loads an actor-target whole-board value census', () => {
     const panel = buildPanel()
     const form = new ConditionForm(panel)
     form.attach()
@@ -836,7 +757,6 @@ describe('ConditionForm', () => {
       targetFilter: 'rook'
     })
 
-    expect(panel.querySelector('#cond-census-comparison-toggle').textContent).toBe('Simplify')
     expect(panel.querySelector('#cond-census-target').classList.contains('hidden')).toBe(false)
     expect(form.buildPayload().target).toBe('enemy')
   })
@@ -864,29 +784,7 @@ describe('ConditionForm', () => {
     expect(form.buildPayload().subjectComparator).toBe('greater_than')
   })
 
-  it('relabels the relational comparison toggle to "+ comparison (advanced)"', () => {
-    const panel = buildPanel()
-    const form = new ConditionForm(panel)
-    form.attach()
-
-    form.populate({
-      version: 2,
-      kind: 'relational',
-      subject: 'allied',
-      subjectFilter: 'any',
-      operator: 'attack',
-      target: 'enemy',
-      targetFilter: 'any'
-    })
-
-    const toggle = panel.querySelector('#cond-left-comparison-toggle')
-    expect(toggle.textContent).toBe('+ comparison (advanced)')
-
-    toggle.dispatchEvent(new Event('click'))
-    expect(toggle.textContent).toBe('Hide comparison')
-  })
-
-  it('a collapsed relational comparison emits no comparison fields', () => {
+  it('a relational with no explicit comparison emits no comparison fields', () => {
     const panel = buildPanel()
     const form = new ConditionForm(panel)
     form.attach()

--- a/app/javascript/editorV2/panels/ConditionForm.js
+++ b/app/javascript/editorV2/panels/ConditionForm.js
@@ -46,12 +46,9 @@ class ConditionForm {
     }
     this.state = this.defaultState()
     this.boundHandleFieldChange = this.handleFieldChange.bind(this)
-    this.boundHandleLeftComparisonToggle = this.toggleLeftComparison.bind(this)
-    this.boundHandleRightComparisonToggle = this.toggleRightComparison.bind(this)
     this.boundHandleModeRelational = () => this.handleModeChange('relational')
     this.boundHandleModeCensus = () => this.handleModeChange('census')
     this.boundHandleModeCaptures = () => this.handleModeChange('captures')
-    this.boundHandleCensusComparisonToggle = this.toggleCensusComparison.bind(this)
   }
 
   defaultState() {
@@ -77,24 +74,18 @@ class ConditionForm {
     const fields = this.fields()
     fields.all.forEach(field => field?.addEventListener('change', this.boundHandleFieldChange))
     fields.numberInputs.forEach(field => field?.addEventListener('input', this.boundHandleFieldChange))
-    fields.leftComparisonToggle?.addEventListener('click', this.boundHandleLeftComparisonToggle)
-    fields.rightComparisonToggle?.addEventListener('click', this.boundHandleRightComparisonToggle)
     fields.modeRelationalBtn?.addEventListener('click', this.boundHandleModeRelational)
     fields.modeCensusBtn?.addEventListener('click', this.boundHandleModeCensus)
     fields.modeCapturesBtn?.addEventListener('click', this.boundHandleModeCaptures)
-    fields.censusComparisonToggle?.addEventListener('click', this.boundHandleCensusComparisonToggle)
   }
 
   detach() {
     const fields = this.fields()
     fields.all.forEach(field => field?.removeEventListener('change', this.boundHandleFieldChange))
     fields.numberInputs.forEach(field => field?.removeEventListener('input', this.boundHandleFieldChange))
-    fields.leftComparisonToggle?.removeEventListener('click', this.boundHandleLeftComparisonToggle)
-    fields.rightComparisonToggle?.removeEventListener('click', this.boundHandleRightComparisonToggle)
     fields.modeRelationalBtn?.removeEventListener('click', this.boundHandleModeRelational)
     fields.modeCensusBtn?.removeEventListener('click', this.boundHandleModeCensus)
     fields.modeCapturesBtn?.removeEventListener('click', this.boundHandleModeCaptures)
-    fields.censusComparisonToggle?.removeEventListener('click', this.boundHandleCensusComparisonToggle)
   }
 
   fields() {
@@ -123,8 +114,6 @@ class ConditionForm {
     const censusComparator = this.editorPanel.querySelector('#cond-census-comparator')
     const censusTarget = this.editorPanel.querySelector('#cond-census-target')
     const censusTargetTotal = this.editorPanel.querySelector('#cond-census-target-total')
-    const censusTargetFilter = this.editorPanel.querySelector('#cond-census-target-filter')
-    const censusTargetFilterMode = this.editorPanel.querySelector('#cond-census-target-filter-mode')
     const censusScopeWhole = this.editorPanel.querySelector('#cond-census-scope-whole')
     const censusAxisRank = this.editorPanel.querySelector('#cond-census-axis-rank')
     const censusAxisFile = this.editorPanel.querySelector('#cond-census-axis-file')
@@ -141,6 +130,7 @@ class ConditionForm {
     const capturesOperator = this.editorPanel.querySelector('#cond-captures-operator')
     const capturesOperatorInputs = pillInputs(capturesOperator)
     const capturesComparator = this.editorPanel.querySelector('#cond-captures-comparator')
+    const capturesComparatorInputs = pillInputs(capturesComparator)
     const capturesTarget = this.editorPanel.querySelector('#cond-captures-target')
     const capturesTargetFilter = this.editorPanel.querySelector('#cond-captures-target-filter')
     const capturesTargetFilterMode = this.editorPanel.querySelector('#cond-captures-target-filter-mode')
@@ -176,8 +166,6 @@ class ConditionForm {
       censusComparator,
       censusTarget,
       censusTargetTotal,
-      censusTargetFilter,
-      censusTargetFilterMode,
       censusScopeWhole,
       censusAxisRank,
       censusAxisFile,
@@ -198,17 +186,16 @@ class ConditionForm {
       capturesOperator,
       capturesOperatorInputs,
       capturesComparator,
+      capturesComparatorInputs,
       capturesTarget,
       capturesTargetFilter,
       capturesTargetFilterMode,
       capturesTargetTotal,
-      leftComparisonToggle: this.editorPanel.querySelector('#cond-left-comparison-toggle'),
       leftComparisonBody: this.editorPanel.querySelector('#cond-left-comparison-body'),
-      leftComparisonSourceStack: this.editorPanel.querySelector('#cond-left-comparison-source-stack'),
+      leftComparisonLockedNote: this.editorPanel.querySelector('#cond-left-comparison-locked-note'),
       leftFilterModeControl: leftFilterMode?.closest('.condition-form-checkbox'),
-      rightComparisonToggle: this.editorPanel.querySelector('#cond-right-comparison-toggle'),
       rightComparisonBody: this.editorPanel.querySelector('#cond-right-comparison-body'),
-      rightComparisonSourceStack: this.editorPanel.querySelector('#cond-right-comparison-source-stack'),
+      rightComparisonLockedNote: this.editorPanel.querySelector('#cond-right-comparison-locked-note'),
       rightFilterModeControl: rightFilterMode?.closest('.condition-form-checkbox'),
       rightCardLabel: this.editorPanel.querySelector('#cond-right-card-label'),
       rightRelationalFields: this.editorPanel.querySelector('#cond-right-relational-fields'),
@@ -233,11 +220,6 @@ class ConditionForm {
       capturesEnemyNote: this.editorPanel.querySelector('#cond-captures-enemy-note'),
       censusFilterRow: this.editorPanel.querySelector('#cond-census-filter-row'),
       censusFilterModeControl: censusFilterMode?.closest('.condition-form-checkbox'),
-      censusComparisonToggle: this.editorPanel.querySelector('#cond-census-comparison-toggle'),
-      censusComparisonBody: this.editorPanel.querySelector('#cond-census-comparison-body'),
-      censusTargetStack: this.editorPanel.querySelector('#cond-census-target-stack'),
-      censusTargetFilterRow: this.editorPanel.querySelector('#cond-census-target-filter-row'),
-      censusTargetFilterModeControl: censusTargetFilterMode?.closest('.condition-form-checkbox'),
       censusScope: this.editorPanel.querySelector('#cond-census-scope'),
       censusSquareInputs: this.editorPanel.querySelector('#cond-census-square-inputs'),
       censusRegionTarget: this.editorPanel.querySelector('#cond-census-region-target'),
@@ -247,10 +229,10 @@ class ConditionForm {
         relationalOperatorSelect,
         rightSubject, rightFilterMode, rightFilter, ...rightComparisonMetricInputs, rightComparator, rightComparisonSource,
         censusSubject, censusFilterMode, censusFilter, ...censusOperatorInputs, censusComparator,
-        censusTarget, censusTargetFilter, censusTargetFilterMode,
+        censusTarget,
         censusScopeWhole, censusAxisRank, censusAxisFile, censusAxisSquare, ...censusRegionComparatorInputs,
         ...censusRankInputs, ...censusFileInputs, ...censusSquareFileInputs, ...censusSquareRankInputs,
-        capturesSubject, capturesFilterMode, capturesFilter, ...capturesOperatorInputs, capturesComparator,
+        capturesSubject, capturesFilterMode, capturesFilter, ...capturesOperatorInputs, ...capturesComparatorInputs,
         capturesTarget, capturesTargetFilter, capturesTargetFilterMode
       ],
       numberInputs: [
@@ -325,23 +307,6 @@ class ConditionForm {
     }
 
     if (this.onStateChange) { this.onStateChange(this.buildPayload()) }
-  }
-
-  toggleLeftComparison() {
-    if (this.state.mode !== 'relational') { return }
-    if (this.modes.relational.toggleComparison('left', this.state.relational)) { this.render() }
-  }
-
-  toggleCensusComparison() {
-    if (this.state.mode !== 'census') { return }
-    this.modes.census.toggleAdvanced(this.state.census)
-    this.modes.census.applyCompatibilityRules(this.state.census)
-    this.render()
-  }
-
-  toggleRightComparison() {
-    if (this.state.mode !== 'relational') { return }
-    if (this.modes.relational.toggleComparison('right', this.state.relational)) { this.render() }
   }
 
   handleModeChange(mode) {

--- a/app/javascript/editorV2/panels/condition_form/captures_mode.js
+++ b/app/javascript/editorV2/panels/condition_form/captures_mode.js
@@ -57,7 +57,7 @@ export default class CapturesMode {
     cap.filterMode = fields.capturesFilterMode?.checked ? 'exclude' : 'include'
     cap.filter = fields.capturesFilter?.value || 'any'
     cap.operator = pillValue(fields.capturesOperatorInputs) || 'exists'
-    cap.comparator = fields.capturesComparator?.value || 'equal_to'
+    cap.comparator = pillValue(fields.capturesComparatorInputs) || 'equal_to'
     cap.target = fields.capturesTarget?.value || 'exact_number'
     cap.targetFilter = fields.capturesTargetFilter?.value || 'any'
     cap.targetFilterMode = fields.capturesTargetFilterMode?.checked ? 'exclude' : 'include'
@@ -126,7 +126,7 @@ export default class CapturesMode {
     if (fields.capturesFilter) fields.capturesFilter.value = cap.filter
     if (fields.capturesFilterMode) fields.capturesFilterMode.checked = filterModeAvailable && cap.filterMode === 'exclude'
     setPillChecked(fields.capturesOperatorInputs, cap.operator)
-    if (fields.capturesComparator) fields.capturesComparator.value = cap.comparator
+    setPillChecked(fields.capturesComparatorInputs, cap.comparator)
     if (fields.capturesTarget) fields.capturesTarget.value = cap.target
     if (fields.capturesTargetTotal) fields.capturesTargetTotal.value = cap.targetTotal
     if (fields.capturesTargetFilter) fields.capturesTargetFilter.value = cap.targetFilter

--- a/app/javascript/editorV2/panels/condition_form/census_mode.js
+++ b/app/javascript/editorV2/panels/condition_form/census_mode.js
@@ -16,12 +16,9 @@ const DEFAULT_CENSUS_STATE = {
   regionFileTarget: 1,
   regionSquareFile: 1,
   regionSquareRank: 1,
-  advanced: false,
   operator: 'count',
   comparator: 'greater_than',
   target: 'exact_number',
-  targetFilter: 'any',
-  targetFilterMode: 'include',
   targetTotal: 0
 }
 
@@ -55,12 +52,9 @@ export default class CensusMode {
       regionFileTarget: nodeData.positionAxis === 'file' ? (nodeData.positionTarget || 1) : 1,
       regionSquareFile: squareFile,
       regionSquareRank: squareRank,
-      advanced: Boolean(nodeData.target) && nodeData.target !== 'exact_number',
       operator: nodeData.operator || 'count',
       comparator: nodeData.comparator || 'greater_than',
       target: nodeData.target || 'exact_number',
-      targetFilter: nodeData.targetFilter || 'any',
-      targetFilterMode: nodeData.targetFilterMode || 'include',
       targetTotal: typeof nodeData.targetTotal === 'number' ? nodeData.targetTotal : 0
     }
   }
@@ -89,8 +83,6 @@ export default class CensusMode {
     cen.operator = pillValue(fields.censusOperatorInputs) || 'count'
     cen.comparator = fields.censusComparator?.value || 'greater_than'
     cen.target = fields.censusTarget?.value || 'exact_number'
-    cen.targetFilter = fields.censusTargetFilter?.value || 'any'
-    cen.targetFilterMode = fields.censusTargetFilterMode?.checked ? 'exclude' : 'include'
     cen.targetTotal = Number(fields.censusTargetTotal?.value || 0)
   }
 
@@ -102,8 +94,8 @@ export default class CensusMode {
       operator: cen.operator,
       comparator: cen.comparator,
       target: cen.target,
-      targetFilter: cen.targetFilter,
-      targetFilterMode: cen.targetFilterMode,
+      targetFilter: 'any',
+      targetFilterMode: 'include',
       targetTotal: cen.targetTotal
     })
     if (cen.scope === 'region') {
@@ -114,16 +106,10 @@ export default class CensusMode {
     return payload
   }
 
-  toggleAdvanced(cen) {
-    cen.advanced = !cen.advanced
-  }
-
   render(cen, fields) {
     const region = cen.scope === 'region'
     const isSquare = region && cen.regionAxis === 'square'
     const filterModeAvailable = cen.left.filter !== 'any'
-    const targetUsesActor = this.targetUsesActor(cen)
-    const targetFilterModeAvailable = targetUsesActor && cen.targetFilter !== 'any'
 
     if (fields.censusSubject) fields.censusSubject.value = cen.left.subject
     if (fields.censusFilterMode) fields.censusFilterMode.checked = filterModeAvailable && cen.left.filterMode === 'exclude'
@@ -144,8 +130,6 @@ export default class CensusMode {
     if (fields.censusComparator) fields.censusComparator.value = cen.comparator
     if (fields.censusTarget) fields.censusTarget.value = cen.target
     if (fields.censusTargetTotal) fields.censusTargetTotal.value = cen.targetTotal
-    if (fields.censusTargetFilter) fields.censusTargetFilter.value = cen.targetFilter
-    if (fields.censusTargetFilterMode) fields.censusTargetFilterMode.checked = targetFilterModeAvailable && cen.targetFilterMode === 'exclude'
 
     fields.censusRegionComparator?.classList.toggle('hidden', !region)
     fields.censusRegionComparator?.classList.toggle('condition-form-comparator-toggle--locked', isSquare)
@@ -158,19 +142,9 @@ export default class CensusMode {
     const squareTargetInputs = [...(fields.censusSquareFileInputs || []), ...(fields.censusSquareRankInputs || [])]
     squareTargetInputs.forEach(input => { input.disabled = !region })
 
-    fields.censusTarget?.classList.toggle('hidden', !cen.advanced)
     fields.censusTargetTotal?.classList.toggle('hidden', cen.target !== 'exact_number')
-    fields.censusTargetFilterRow?.classList.toggle('hidden', !targetUsesActor)
-    fields.censusTargetStack?.classList.toggle('condition-form-comparison-source-stack--inline-number', cen.target === 'exact_number')
-
-    fields.censusComparisonBody?.classList.toggle('hidden', false)
-    fields.censusComparisonToggle?.classList.toggle('hidden', false)
-    if (fields.censusComparisonToggle) {
-      fields.censusComparisonToggle.textContent = cen.advanced ? 'Simplify' : '+ Advanced options'
-    }
 
     fields.censusFilterModeControl?.classList.toggle('condition-form-checkbox--unavailable', !filterModeAvailable)
-    fields.censusTargetFilterModeControl?.classList.toggle('condition-form-checkbox--unavailable', !targetFilterModeAvailable)
 
     showAllOptions(fields.censusSubject)
     showAllOptions(fields.censusTarget)
@@ -191,24 +165,11 @@ export default class CensusMode {
     if (cen.scope === 'region' && cen.regionAxis === 'square') {
       cen.regionComparator = 'equal_to'
     }
-    if (!cen.advanced) {
+    const allowedTargets = this.allowedTargetsForOperator(cen.operator)
+    if (!allowedTargets.includes(cen.target)) {
       cen.target = 'exact_number'
-      cen.targetFilter = 'any'
-      cen.targetFilterMode = 'include'
-    } else {
-      const allowedTargets = this.allowedTargetsForOperator(cen.operator)
-      if (!allowedTargets.includes(cen.target)) {
-        cen.target = 'exact_number'
-        cen.targetFilter = 'any'
-        cen.targetFilterMode = 'include'
-      }
     }
-    this.applyFilterModeCompatibilityRules(cen)
-  }
-
-  applyFilterModeCompatibilityRules(cen) {
     if (cen.left.filter === 'any') { cen.left.filterMode = 'include' }
-    if (cen.targetFilter === 'any') { cen.targetFilterMode = 'include' }
   }
 
   resolvedRegionTarget(cen) {
@@ -233,14 +194,13 @@ export default class CensusMode {
     return census.wholeBoardSubjects || this.editorSubjects()
   }
 
-  targetUsesActor(cen) {
-    return cen.advanced && !['exact_number', 'prior_board_state'].includes(cen.target)
-  }
-
   allowedTargetsForOperator(operator) {
+    if (operator !== 'value') {
+      return ['exact_number', 'prior_board_state']
+    }
     return [
       'exact_number',
-      ...this.editorSubjects().filter(subject => this.allowedOperatorsForSubject(subject).includes(operator)),
+      ...this.editorSubjects().filter(subject => this.allowedOperatorsForSubject(subject).includes('value')),
       'prior_board_state'
     ]
   }

--- a/app/javascript/editorV2/panels/condition_form/relational_mode.js
+++ b/app/javascript/editorV2/panels/condition_form/relational_mode.js
@@ -2,30 +2,17 @@ import {
   disableOptions, enableAllOptions, showAllOptions, pillValue, setPillChecked
 } from 'editorV2/panels/condition_form/dom_helpers'
 
+const NEUTRAL_COMPARISON = {
+  comparisonMetric: 'count',
+  comparator: 'greater_than_or_equal_to',
+  comparisonSource: 'exact_number',
+  comparisonSourceTotal: 1
+}
+
 const DEFAULT_RELATIONAL_STATE = {
-  left: {
-    subject: 'allied',
-    filter: 'any',
-    filterMode: 'include',
-    comparisonMetric: '',
-    comparator: 'equal_to',
-    comparisonSource: 'exact_number',
-    comparisonSourceTotal: 1
-  },
+  left: { subject: 'allied', filter: 'any', filterMode: 'include', ...NEUTRAL_COMPARISON },
   operator: 'targets',
-  right: {
-    subject: 'enemy',
-    filter: 'any',
-    filterMode: 'include',
-    comparisonMetric: '',
-    comparator: 'equal_to',
-    comparisonSource: 'exact_number',
-    comparisonSourceTotal: 1
-  },
-  ui: {
-    leftComparisonOpen: false,
-    rightComparisonOpen: false
-  }
+  right: { subject: 'enemy', filter: 'any', filterMode: 'include', ...NEUTRAL_COMPARISON }
 }
 
 // Relational condition mode. State-only: the orchestrator owns DOM events and
@@ -59,11 +46,7 @@ export default class RelationalMode {
         comparator: nodeData.targetComparator,
         comparisonSource: nodeData.targetComparisonSource,
         comparisonSourceTotal: nodeData.targetComparisonSourceTotal
-      }),
-      ui: {
-        leftComparisonOpen: Boolean(nodeData.subjectComparisonMetric),
-        rightComparisonOpen: Boolean(nodeData.targetComparisonMetric)
-      }
+      })
     }
   }
 
@@ -74,15 +57,15 @@ export default class RelationalMode {
   }
 
   sideState({ subject, filter, filterMode, comparisonMetric, comparator, comparisonSource, comparisonSourceTotal }) {
-    const source = comparisonSource || 'exact_number'
+    const source = comparisonSource || NEUTRAL_COMPARISON.comparisonSource
     return {
       subject: subject || 'allied',
       filter: filter || 'any',
       filterMode: filterMode || 'include',
-      comparisonMetric: comparisonMetric || '',
-      comparator: comparator || 'equal_to',
+      comparisonMetric: comparisonMetric || NEUTRAL_COMPARISON.comparisonMetric,
+      comparator: comparator || NEUTRAL_COMPARISON.comparator,
       comparisonSource: source,
-      comparisonSourceTotal: source === 'exact_number' && typeof comparisonSourceTotal === 'number' ? comparisonSourceTotal : 1
+      comparisonSourceTotal: source === 'exact_number' && typeof comparisonSourceTotal === 'number' ? comparisonSourceTotal : NEUTRAL_COMPARISON.comparisonSourceTotal
     }
   }
 
@@ -90,7 +73,7 @@ export default class RelationalMode {
     rel.left.subject = fields.leftSubject?.value || 'allied'
     rel.left.filterMode = fields.leftFilterMode?.checked ? 'exclude' : 'include'
     rel.left.filter = fields.leftFilter?.value || 'any'
-    rel.left.comparisonMetric = pillValue(fields.leftComparisonMetricInputs) || ''
+    rel.left.comparisonMetric = pillValue(fields.leftComparisonMetricInputs) || 'count'
     rel.left.comparator = fields.leftComparator?.value || 'equal_to'
     rel.left.comparisonSource = fields.leftComparisonSource?.value || 'exact_number'
     rel.left.comparisonSourceTotal = Number(fields.leftComparisonSourceTotal?.value || 1)
@@ -98,7 +81,7 @@ export default class RelationalMode {
     rel.right.subject = fields.rightSubject?.value || 'enemy'
     rel.right.filterMode = fields.rightFilterMode?.checked ? 'exclude' : 'include'
     rel.right.filter = fields.rightFilter?.value || 'any'
-    rel.right.comparisonMetric = pillValue(fields.rightComparisonMetricInputs) || ''
+    rel.right.comparisonMetric = pillValue(fields.rightComparisonMetricInputs) || 'count'
     rel.right.comparator = fields.rightComparator?.value || 'equal_to'
     rel.right.comparisonSource = fields.rightComparisonSource?.value || 'exact_number'
     rel.right.comparisonSourceTotal = Number(fields.rightComparisonSourceTotal?.value || 1)
@@ -123,7 +106,7 @@ export default class RelationalMode {
       payload.targetFilterMode = rel.right.filterMode
     }
 
-    if (rel.ui.leftComparisonOpen && rel.left.comparisonMetric) {
+    if (!this.isNeutralComparison(rel.left)) {
       payload.subjectComparisonMetric = rel.left.comparisonMetric
       payload.subjectComparator = rel.left.comparator
       payload.subjectComparisonSource = rel.left.comparisonSource
@@ -132,7 +115,7 @@ export default class RelationalMode {
       }
     }
 
-    if (rel.ui.rightComparisonOpen && rel.right.comparisonMetric) {
+    if (!this.isNeutralComparison(rel.right)) {
       payload.targetComparisonMetric = rel.right.comparisonMetric
       payload.targetComparator = rel.right.comparator
       payload.targetComparisonSource = rel.right.comparisonSource
@@ -144,33 +127,21 @@ export default class RelationalMode {
     return payload
   }
 
-  toggleComparison(side, rel) {
-    if (this.comparisonLocked(rel, side)) { return false }
-    const sideState = rel[side]
-    const uiKey = side === 'left' ? 'leftComparisonOpen' : 'rightComparisonOpen'
-
-    if (!rel.ui[uiKey] && !sideState.comparisonMetric) {
-      sideState.comparisonMetric = 'count'
-      sideState.comparator = 'equal_to'
-      sideState.comparisonSource = 'exact_number'
-      sideState.comparisonSourceTotal ||= 1
-    }
-
-    rel.ui[uiKey] = !rel.ui[uiKey]
-    return true
+  isNeutralComparison(sideState) {
+    return Object.entries(NEUTRAL_COMPARISON).every(([key, value]) => sideState[key] === value)
   }
 
   render(rel, fields) {
-    const leftComparisonActive = rel.ui.leftComparisonOpen
-    const rightComparisonActive = rel.ui.rightComparisonOpen
     const leftFilterModeAvailable = rel.left.filter !== 'any'
     const rightFilterModeAvailable = rel.right.filter !== 'any'
+    const leftLocked = this.comparisonLocked(rel, 'left')
+    const rightLocked = this.comparisonLocked(rel, 'right')
 
     if (fields.relationalOperatorSelect) fields.relationalOperatorSelect.value = rel.operator
     if (fields.leftSubject) fields.leftSubject.value = rel.left.subject
     if (fields.leftFilterMode) fields.leftFilterMode.checked = leftFilterModeAvailable && rel.left.filterMode === 'exclude'
     if (fields.leftFilter) fields.leftFilter.value = rel.left.filter
-    setPillChecked(fields.leftComparisonMetricInputs, rel.left.comparisonMetric || 'count')
+    setPillChecked(fields.leftComparisonMetricInputs, rel.left.comparisonMetric)
     if (fields.leftComparator) fields.leftComparator.value = rel.left.comparator
     if (fields.leftComparisonSource) fields.leftComparisonSource.value = rel.left.comparisonSource
     if (fields.leftComparisonSourceTotal) fields.leftComparisonSourceTotal.value = rel.left.comparisonSourceTotal
@@ -178,33 +149,23 @@ export default class RelationalMode {
     if (fields.rightSubject) fields.rightSubject.value = rel.right.subject
     if (fields.rightFilterMode) fields.rightFilterMode.checked = rightFilterModeAvailable && rel.right.filterMode === 'exclude'
     if (fields.rightFilter) fields.rightFilter.value = rel.right.filter
-    setPillChecked(fields.rightComparisonMetricInputs, rel.right.comparisonMetric || 'count')
+    setPillChecked(fields.rightComparisonMetricInputs, rel.right.comparisonMetric)
     if (fields.rightComparator) fields.rightComparator.value = rel.right.comparator
     if (fields.rightComparisonSource) fields.rightComparisonSource.value = rel.right.comparisonSource
     if (fields.rightComparisonSourceTotal) fields.rightComparisonSourceTotal.value = rel.right.comparisonSourceTotal
 
-    fields.leftComparisonBody.classList.toggle('hidden', !rel.ui.leftComparisonOpen)
-    fields.rightComparisonBody.classList.toggle('hidden', !rel.ui.rightComparisonOpen)
     fields.leftComparisonSourceTotal?.classList.toggle('hidden', rel.left.comparisonSource !== 'exact_number')
     fields.rightComparisonSourceTotal?.classList.toggle('hidden', rel.right.comparisonSource !== 'exact_number')
-    fields.leftComparisonSourceStack?.classList.toggle('condition-form-comparison-source-stack--inline-number', rel.left.comparisonSource === 'exact_number')
-    fields.rightComparisonSourceStack?.classList.toggle('condition-form-comparison-source-stack--inline-number', rel.right.comparisonSource === 'exact_number')
 
     fields.leftFilterRow.classList.toggle('hidden', false)
     fields.rightFilterRow.classList.toggle('hidden', false)
     fields.leftFilterModeControl?.classList.toggle('condition-form-checkbox--unavailable', !leftFilterModeAvailable)
     fields.rightFilterModeControl?.classList.toggle('condition-form-checkbox--unavailable', !rightFilterModeAvailable)
-    fields.rightComparisonToggle.closest('.condition-form-comparison').classList.toggle('hidden', false)
 
-    const leftLocked = this.comparisonLocked(rel, 'left')
-    const rightLocked = this.comparisonLocked(rel, 'right')
-    fields.leftComparisonToggle.disabled = leftLocked
-    fields.rightComparisonToggle.disabled = rightLocked
-    fields.leftComparisonToggle.textContent = leftLocked ? this.comparisonUnavailableText(rel, 'left') : (rel.ui.leftComparisonOpen ? 'Hide comparison' : '+ comparison (advanced)')
-    fields.rightComparisonToggle.textContent = rightLocked ? this.comparisonUnavailableText(rel, 'right') : (rel.ui.rightComparisonOpen ? 'Hide comparison' : '+ comparison (advanced)')
-
-    this.setComparisonInputsDisabled('left', fields, !leftComparisonActive)
-    this.setComparisonInputsDisabled('right', fields, !rightComparisonActive)
+    fields.leftComparisonLockedNote?.classList.toggle('hidden', !leftLocked)
+    fields.rightComparisonLockedNote?.classList.toggle('hidden', !rightLocked)
+    fields.leftComparisonBody?.classList.toggle('condition-form-comparison__body--locked', leftLocked)
+    fields.rightComparisonBody?.classList.toggle('condition-form-comparison__body--locked', rightLocked)
 
     showAllOptions(fields.leftSubject)
     showAllOptions(fields.rightSubject)
@@ -232,13 +193,11 @@ export default class RelationalMode {
     }
 
     if (this.leftUsesPriorBoardState(rel)) {
-      this.clearComparator(rel, 'right')
-      rel.ui.rightComparisonOpen = false
+      this.resetComparison(rel, 'right')
     }
 
     if (this.rightUsesPriorBoardState(rel)) {
-      this.clearComparator(rel, 'left')
-      rel.ui.leftComparisonOpen = false
+      this.resetComparison(rel, 'left')
     }
 
     if (this.leftUsesAggregateValue(rel) && rel.right.comparisonMetric === 'aggregate_value') {
@@ -264,42 +223,28 @@ export default class RelationalMode {
     if (rel.right.filter === 'any') { rel.right.filterMode = 'include' }
   }
 
-  clearComparator(rel, side) {
-    const sideState = rel[side]
-    sideState.comparisonMetric = ''
-    sideState.comparator = 'equal_to'
-    sideState.comparisonSource = 'exact_number'
-    sideState.comparisonSourceTotal = 1
+  resetComparison(rel, side) {
+    Object.assign(rel[side], NEUTRAL_COMPARISON)
   }
 
   leftUsesPriorBoardState(rel) {
-    return rel.ui.leftComparisonOpen && rel.left.comparisonSource === 'prior_board_state'
+    return rel.left.comparisonSource === 'prior_board_state'
   }
 
   rightUsesPriorBoardState(rel) {
-    return rel.ui.rightComparisonOpen && rel.right.comparisonSource === 'prior_board_state'
+    return rel.right.comparisonSource === 'prior_board_state'
   }
 
   leftUsesAggregateValue(rel) {
-    return rel.ui.leftComparisonOpen && rel.left.comparisonMetric === 'aggregate_value'
+    return rel.left.comparisonMetric === 'aggregate_value'
   }
 
   rightUsesAggregateValue(rel) {
-    return rel.ui.rightComparisonOpen && rel.right.comparisonMetric === 'aggregate_value'
+    return rel.right.comparisonMetric === 'aggregate_value'
   }
 
   comparisonLocked(rel, side) {
     return side === 'left' ? this.rightUsesPriorBoardState(rel) : this.leftUsesPriorBoardState(rel)
-  }
-
-  comparisonUnavailableText(rel, side) {
-    if (side === 'left' && this.rightUsesPriorBoardState(rel)) {
-      return '+ comparison unavailable while target uses prior'
-    }
-    if (side === 'right' && this.leftUsesPriorBoardState(rel)) {
-      return '+ comparison unavailable while subject uses prior'
-    }
-    return '+ comparison unavailable'
   }
 
   regularSubjects() {
@@ -348,18 +293,6 @@ export default class RelationalMode {
       return ['exact_number', 'prior_board_state', 'moved_piece', 'captured_piece', 'enemy_moved_piece', 'enemy_captured_piece']
     }
     return ['exact_number', 'prior_board_state']
-  }
-
-  setComparisonInputsDisabled(side, fields, disabled) {
-    const metricInputsKey = side === 'left' ? 'leftComparisonMetricInputs' : 'rightComparisonMetricInputs'
-    const comparatorKey = side === 'left' ? 'leftComparator' : 'rightComparator'
-    const sourceKey = side === 'left' ? 'leftComparisonSource' : 'rightComparisonSource'
-    const sourceTotalKey = side === 'left' ? 'leftComparisonSourceTotal' : 'rightComparisonSourceTotal'
-
-    fields[metricInputsKey]?.forEach(input => { input.disabled = disabled })
-    fields[sourceKey].disabled = disabled
-    fields[sourceTotalKey].disabled = disabled
-    fields[comparatorKey].disabled = disabled
   }
 
   disableComparisonSourceOptions(rel, fields) {

--- a/app/javascript/editorV2/panels/condition_preview/forward_proposition/narrow_moved_piece_for_region.js
+++ b/app/javascript/editorV2/panels/condition_preview/forward_proposition/narrow_moved_piece_for_region.js
@@ -1,5 +1,5 @@
 import Board from 'gameplay/board'
-import { relativeRank } from 'gameplay/board_query_utils'
+import { relativeRankLabel } from 'gameplay/board_query_utils'
 import { intersectRegions } from 'editorV2/panels/condition_preview/forward_proposition/region'
 
 // Region census is only satisfiable via moved_piece: entering the region as a
@@ -28,7 +28,7 @@ function captureRegion(region, moved, captured) {
   if (epEligible(moved, captured)) {
     const forward = moved.team === Board.BLACK ? 8 : -8
     for (const sq of region.squares) {
-      if (relativeRank(sq, moved.team) !== 5) { continue }
+      if (relativeRankLabel(sq, moved.team) !== 5) { continue }
       const landing = sq + forward
       if (landing >= 0 && landing <= 63) { squares.add(landing) }
     }

--- a/app/javascript/editorV2/panels/condition_preview/plans/__tests__/contradictions.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/plans/__tests__/contradictions.test.js
@@ -1,0 +1,212 @@
+import { describe, it, expect } from 'vitest'
+import { buildCombinedPlan } from 'editorV2/panels/condition_preview/plans/plan'
+
+// Fast detector coverage: buildCombinedPlan runs detectContradiction without
+// the generation pipeline. Mirrors the single-condition rules in Ruby
+// Nodes::ConditionSatisfiability.
+function result(payload) {
+  return buildCombinedPlan([payload])
+}
+
+function census(overrides = {}) {
+  return {
+    version: 2, kind: 'census',
+    subject: 'allied', subjectFilter: 'any',
+    operator: 'count', comparator: 'equal_to',
+    target: 'exact_number', targetTotal: 1,
+    ...overrides
+  }
+}
+
+function relational(overrides = {}) {
+  return {
+    version: 2, kind: 'relational',
+    subject: 'moved_piece', subjectFilter: 'any',
+    operator: 'attack', target: 'enemy', targetFilter: 'any',
+    ...overrides
+  }
+}
+
+describe('plan contradictions', () => {
+  describe('at-most-one count ceiling', () => {
+    it('flags a singular census count of 2', () => {
+      expect(result(census({ subject: 'moved_piece', targetTotal: 2 })).reason).toMatch(/at most once/i)
+    })
+
+    it('flags a captured-piece census count greater than 1', () => {
+      expect(result(census({ subject: 'captured_piece', comparator: 'greater_than', targetTotal: 1 })).reason).toMatch(/at most once/i)
+    })
+
+    it('flags a king-filtered census count of 2', () => {
+      expect(result(census({ subjectFilter: 'king', subjectFilterMode: 'include', targetTotal: 2 })).reason).toMatch(/at most once/i)
+    })
+
+    it('flags a singular relational subject count of 2', () => {
+      expect(result(relational({
+        subjectComparisonMetric: 'count', subjectComparator: 'equal_to',
+        subjectComparisonSource: 'exact_number', subjectComparisonSourceTotal: 2
+      })).reason).toMatch(/at most once/i)
+    })
+
+    it('flags a singular relational target count of 2', () => {
+      expect(result(relational({
+        target: 'enemy_moved_piece',
+        targetComparisonMetric: 'count', targetComparator: 'equal_to',
+        targetComparisonSource: 'exact_number', targetComparisonSourceTotal: 2
+      })).reason).toMatch(/at most once/i)
+    })
+
+    it('flags a relational singular count > 1 (operand 1)', () => {
+      expect(result(relational({
+        subjectComparisonMetric: 'count', subjectComparator: 'greater_than',
+        subjectComparisonSource: 'exact_number', subjectComparisonSourceTotal: 1
+      })).reason).toMatch(/at most once/i)
+    })
+
+    it('allows a singular count of 1', () => {
+      expect(result(census({ subject: 'moved_piece', targetTotal: 1 })).status).not.toBe('contradictory')
+    })
+
+    it('allows a group count above 1', () => {
+      expect(result(census({ subject: 'allied', comparator: 'greater_than', targetTotal: 5 })).status).not.toBe('contradictory')
+    })
+
+    it('allows a vacuous singular upper bound (count < 5)', () => {
+      expect(result(census({ subject: 'moved_piece', comparator: 'less_than', targetTotal: 5 })).status).not.toBe('contradictory')
+    })
+  })
+
+  describe('pawn rank legality', () => {
+    function pawn(overrides = {}) {
+      return census({
+        subjectFilter: 'pawn', subjectFilterMode: 'include',
+        comparator: 'greater_than', targetTotal: 0,
+        positionAxis: 'rank', positionComparator: 'equal_to', positionTarget: 5,
+        ...overrides
+      })
+    }
+
+    it('flags a pawn on rank 1', () => {
+      expect(result(pawn({ positionTarget: 1 })).reason).toMatch(/rank 1 or 8/i)
+    })
+
+    it('flags a pawn on rank 8', () => {
+      expect(result(pawn({ positionTarget: 8 })).reason).toMatch(/rank 1 or 8/i)
+    })
+
+    it('flags a pawn pinned to rank 1 by a range comparator', () => {
+      expect(result(pawn({ positionComparator: 'less_than_or_equal_to', positionTarget: 1 })).reason).toMatch(/rank 1 or 8/i)
+    })
+
+    it('flags a pawn on a square that sits on rank 1', () => {
+      expect(result(pawn({ positionAxis: 'square', positionComparator: 'equal_to', positionTarget: 3 })).reason).toMatch(/rank 1 or 8/i)
+    })
+
+    it('flags a moved_piece pawn on its home rank (2)', () => {
+      expect(result(pawn({ subject: 'moved_piece', positionTarget: 2 })).reason).toMatch(/starting rank/i)
+    })
+
+    it('flags an enemy_moved_piece pawn on its home rank (7)', () => {
+      expect(result(pawn({ subject: 'enemy_moved_piece', positionTarget: 7 })).reason).toMatch(/starting rank/i)
+    })
+
+    it('allows a pawn on rank 5', () => {
+      expect(result(pawn({ positionTarget: 5 })).status).not.toBe('contradictory')
+    })
+
+    it('allows a pawn on rank 2 for a non-moved subject', () => {
+      expect(result(pawn({ subject: 'allied', positionTarget: 2 })).status).not.toBe('contradictory')
+    })
+
+    it('ignores an excluded pawn filter', () => {
+      expect(result(pawn({ subjectFilterMode: 'exclude', positionTarget: 1 })).status).not.toBe('contradictory')
+    })
+
+    it('ignores the file axis', () => {
+      expect(result(pawn({ positionAxis: 'file', positionComparator: 'equal_to', positionTarget: 1 })).status).not.toBe('contradictory')
+    })
+  })
+
+  describe('allied team cannot be fully immobile', () => {
+    function mob(overrides = {}) {
+      return census({ subject: 'allied', subjectFilter: 'any', operator: 'mobility', comparator: 'equal_to', targetTotal: 0, ...overrides })
+    }
+
+    it('flags allied any mobility = 0', () => {
+      expect(result(mob()).reason).toMatch(/allied mobility/i)
+    })
+
+    it('allows allied any mobility = 0 within a region', () => {
+      expect(result(mob({ positionAxis: 'rank', positionComparator: 'equal_to', positionTarget: 5 })).status).not.toBe('contradictory')
+    })
+
+    it('allows enemy any mobility = 0', () => {
+      expect(result(mob({ subject: 'enemy' })).status).not.toBe('contradictory')
+    })
+
+    it('allows allied filtered mobility = 0', () => {
+      expect(result(mob({ subjectFilter: 'queen', subjectFilterMode: 'include' })).status).not.toBe('contradictory')
+    })
+  })
+
+  describe('count cannot exceed the prior board state', () => {
+    function growth(overrides = {}) {
+      return census({ subject: 'allied', subjectFilter: 'any', operator: 'count', comparator: 'greater_than', target: 'prior_board_state', ...overrides })
+    }
+
+    it('flags allied any count > PBS', () => {
+      expect(result(growth()).reason).toMatch(/prior board state/i)
+    })
+
+    it('flags enemy any count > PBS', () => {
+      expect(result(growth({ subject: 'enemy' })).reason).toMatch(/prior board state/i)
+    })
+
+    it('allows count > PBS within a region', () => {
+      expect(result(growth({ positionAxis: 'rank', positionComparator: 'equal_to', positionTarget: 5 })).status).not.toBe('contradictory')
+    })
+
+    it('allows a filtered count > PBS', () => {
+      expect(result(growth({ subjectFilter: 'queen', subjectFilterMode: 'include' })).status).not.toBe('contradictory')
+    })
+  })
+
+  describe('the moved piece must exist', () => {
+    function moved(overrides = {}) {
+      return census({ subject: 'moved_piece', subjectFilter: 'any', operator: 'count', comparator: 'equal_to', targetTotal: 0, ...overrides })
+    }
+
+    it('flags moved_piece any count = 0 whole-board', () => {
+      expect(result(moved()).reason).toMatch(/moved piece must exist/i)
+    })
+
+    it('allows moved_piece any count = 0 within a region', () => {
+      expect(result(moved({ positionAxis: 'rank', positionComparator: 'equal_to', positionTarget: 5 })).status).not.toBe('contradictory')
+    })
+
+    it('allows a filtered moved_piece count = 0', () => {
+      expect(result(moved({ subjectFilter: 'queen', subjectFilterMode: 'include' })).status).not.toBe('contradictory')
+    })
+
+    it('allows enemy_moved_piece any count = 0', () => {
+      expect(result(moved({ subject: 'enemy_moved_piece' })).status).not.toBe('contradictory')
+    })
+  })
+
+  describe('comparison below zero', () => {
+    it('flags census mobility < 0', () => {
+      expect(result(census({ subject: 'moved_piece', operator: 'mobility', comparator: 'less_than', targetTotal: 0 })).reason).toMatch(/below 0/i)
+    })
+
+    it('flags relational count < 0', () => {
+      expect(result(relational({
+        subjectComparisonMetric: 'count', subjectComparator: 'less_than',
+        subjectComparisonSource: 'exact_number', subjectComparisonSourceTotal: 0
+      })).reason).toMatch(/below 0/i)
+    })
+
+    it('allows a count of 0', () => {
+      expect(result(census({ subject: 'allied', operator: 'count', comparator: 'equal_to', targetTotal: 0 })).status).not.toBe('contradictory')
+    })
+  })
+})

--- a/app/javascript/editorV2/panels/condition_preview/plans/__tests__/contradictions.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/plans/__tests__/contradictions.test.js
@@ -41,6 +41,10 @@ describe('plan contradictions', () => {
       expect(result(census({ subjectFilter: 'king', subjectFilterMode: 'include', targetTotal: 2 })).reason).toMatch(/at most once/i)
     })
 
+    it('allows a king-exclude group count above 1', () => {
+      expect(result(census({ subjectFilter: 'king', subjectFilterMode: 'exclude', comparator: 'greater_than', targetTotal: 1 })).status).not.toBe('contradictory')
+    })
+
     it('flags a singular relational subject count of 2', () => {
       expect(result(relational({
         subjectComparisonMetric: 'count', subjectComparator: 'equal_to',

--- a/app/javascript/editorV2/panels/condition_preview/plans/plan.js
+++ b/app/javascript/editorV2/panels/condition_preview/plans/plan.js
@@ -78,31 +78,150 @@ function detectConflictingRequiredPositions({ plans }) {
   return null
 }
 
-function detectIllegalPawnRanks({ plans }) {
-  for (const { square, filter } of positionRequirementsFromPlans(plans)) {
-    if (filter === 'pawn') {
-      const rank = Board.rankIndex(square)
-      if (rank === 0 || rank === 7) {
-        return `A condition requires a pawn on ${Board.gridCalculator(square)}, which is never a legal pawn position.`
+// Single-condition detectors, mirroring Ruby Nodes::ConditionSatisfiability
+// (condition_satisfiability.rb) — keep in sync. One intentional drift: 
+// Ruby also declines vacuous comparisons (e.g. singular count < 5) the generator can satisfy.
+
+const BASE_PAWN_RANKS = Object.freeze([2, 3, 4, 5, 6, 7])
+const PAWN_HOME_RANK = Object.freeze({ moved_piece: 2, enemy_moved_piece: 7 })
+const ALL_RANKS = Object.freeze([1, 2, 3, 4, 5, 6, 7, 8])
+
+function atMostOneSet(actor, filter) {
+  return SINGULAR_ACTORS.has(actor) || filter === 'king'
+}
+
+function requiresMoreThanOne(comparator, total) {
+  return (comparator === 'equal_to' && total > 1) ||
+    (comparator === 'greater_than' && total >= 1) ||
+    (comparator === 'greater_than_or_equal_to' && total > 1)
+}
+
+function assertsZero(comparator, total) {
+  return (comparator === 'equal_to' && total === 0) ||
+    (comparator === 'less_than' && total === 1) ||
+    (comparator === 'less_than_or_equal_to' && total === 0)
+}
+
+function rankComparatorMatches(comparator, rank, target) {
+  switch (comparator) {
+    case 'equal_to': return rank === target
+    case 'greater_than': return rank > target
+    case 'greater_than_or_equal_to': return rank >= target
+    case 'less_than': return rank < target
+    case 'less_than_or_equal_to': return rank <= target
+    default: return false
+  }
+}
+
+function legalPawnRanks(subject) {
+  const home = PAWN_HOME_RANK[subject]
+  return home ? BASE_PAWN_RANKS.filter(rank => rank !== home) : BASE_PAWN_RANKS
+}
+
+function admittedPawnRanks(plan) {
+  if (plan.positionAxis === 'square') {
+    return [Board.rankIndex(plan.positionTarget) + 1]
+  }
+  return ALL_RANKS.filter(rank => rankComparatorMatches(plan.positionComparator, rank, plan.positionTarget))
+}
+
+function measureComparisons(plan) {
+  if (plan.kind === 'census') {
+    if (plan.target !== 'exact_number') { return [] }
+    return [{
+      metric: plan.operator, comparator: plan.comparator, total: Number(plan.targetTotal ?? 0),
+      actor: plan.subject, filter: plan.subjectFilter
+    }]
+  }
+  if (plan.kind === 'relational') {
+    return (plan.comparisonDescriptors ?? [])
+      .filter(descriptor => descriptor.source === 'exact_number')
+      .map(descriptor => ({
+        metric: descriptor.metric, comparator: descriptor.comparator, total: Number(descriptor.total ?? 0),
+        actor: descriptor.side === 'subject' ? plan.subject : plan.target,
+        filter: descriptor.side === 'subject' ? plan.subjectFilter : plan.targetFilter
+      }))
+  }
+  return []
+}
+
+function detectComparisonBelowZero({ plans }) {
+  for (const plan of plans) {
+    for (const comparison of measureComparisons(plan)) {
+      if (comparison.comparator === 'less_than' && comparison.total === 0) {
+        return 'Count, mobility, and value are never below 0; this condition can never be satisfied.'
       }
     }
   }
   return null
 }
 
-function detectSingularActorWithImpossibleCount({ plans }) {
+function detectImpossibleSingularCount({ plans }) {
   for (const plan of plans) {
-    if (plan.kind !== 'relational') { continue }
-    const descriptors = plan.comparisonDescriptors ?? []
-    for (const descriptor of descriptors) {
-      if (descriptor.metric !== 'count') { continue }
-      if (descriptor.source !== 'exact_number') { continue }
-      const total = Number(descriptor.total ?? 0)
-      const actor = descriptor.side === 'subject' ? plan.subject : plan.target
-      if (!SINGULAR_ACTORS.has(actor)) { continue }
-      if (total > 1) {
-        return `A singular actor (${actor}) cannot have count ${total}; its count is at most 1.`
+    for (const comparison of measureComparisons(plan)) {
+      if (comparison.metric === 'count'
+          && atMostOneSet(comparison.actor, comparison.filter)
+          && requiresMoreThanOne(comparison.comparator, comparison.total)) {
+        return 'This piece can appear at most once, so its count cannot exceed 1; this condition can never be satisfied.'
       }
+    }
+  }
+  return null
+}
+
+function detectImpossiblePawnRank({ plans }) {
+  for (const plan of plans) {
+    if (plan.kind !== 'census') { continue }
+    if (plan.subjectFilter !== 'pawn' || plan.subjectFilterMode === 'exclude') { continue }
+    if (plan.positionAxis !== 'rank' && plan.positionAxis !== 'square') { continue }
+    const admitted = admittedPawnRanks(plan)
+    if (admitted.length === 0) { continue }
+    if (admitted.every(rank => !BASE_PAWN_RANKS.includes(rank))) {
+      return 'Pawns can never be on rank 1 or 8; this condition can never be satisfied.'
+    }
+    if (admitted.every(rank => !legalPawnRanks(plan.subject).includes(rank))) {
+      return 'A pawn that just moved cannot still be on its starting rank; this condition can never be satisfied.'
+    }
+  }
+  return null
+}
+
+function detectAlliedFullyImmobile({ plans }) {
+  for (const plan of plans) {
+    if (plan.kind !== 'census') { continue }
+    if (plan.operator !== 'mobility') { continue }
+    if (plan.subject !== 'allied' || plan.subjectFilter !== 'any') { continue }
+    if (plan.positionAxis != null) { continue }
+    if (plan.target !== 'exact_number') { continue }
+    if (assertsZero(plan.comparator, Number(plan.targetTotal ?? 0))) {
+      return 'The moving team always has a legal move, so allied mobility cannot be 0; this condition can never be satisfied.'
+    }
+  }
+  return null
+}
+
+function detectCountExceedsPriorBoard({ plans }) {
+  for (const plan of plans) {
+    if (plan.kind !== 'census') { continue }
+    if (plan.operator !== 'count') { continue }
+    if (plan.subjectFilter !== 'any') { continue }
+    if (plan.positionAxis != null) { continue }
+    if (plan.comparator !== 'greater_than') { continue }
+    if (plan.target !== 'prior_board_state') { continue }
+    return 'A team never gains pieces during a turn, so its count cannot exceed the prior board state; this condition can never be satisfied.'
+  }
+  return null
+}
+
+function detectMovedPieceMustExist({ plans }) {
+  for (const plan of plans) {
+    if (plan.kind !== 'census') { continue }
+    if (plan.subject !== 'moved_piece' || plan.subjectFilter !== 'any') { continue }
+    if (plan.operator !== 'count') { continue }
+    if (plan.positionAxis != null) { continue }
+    if (plan.target !== 'exact_number') { continue }
+    if (assertsZero(plan.comparator, Number(plan.targetTotal ?? 0))) {
+      return 'The moved piece must exist (a move occurred); this condition can never be satisfied.'
     }
   }
   return null
@@ -127,40 +246,6 @@ function detectFilterMatchesNoSpecies({ plans }) {
   return null
 }
 
-const ALL_RELATIVE_RANKS = Object.freeze([0, 1, 2, 3, 4, 5, 6, 7])
-const ILLEGAL_PAWN_RANKS = Object.freeze(new Set([0, 7]))
-
-function rankSatisfiesComparator(rank, comparator, target) {
-  switch (comparator) {
-    case 'equal_to':                 return rank === target
-    case 'greater_than':             return rank > target
-    case 'greater_than_or_equal_to': return rank >= target
-    case 'less_than':                return rank < target
-    case 'less_than_or_equal_to':    return rank <= target
-    default:                         return false
-  }
-}
-
-function detectImpossiblePawnPosition({ plans }) {
-  for (const plan of plans) {
-    if (plan.kind !== 'census') { continue }
-    if (plan.subjectFilter !== 'pawn') { continue }
-    if (plan.positionAxis !== 'rank') { continue }
-    const matching = ALL_RELATIVE_RANKS.filter(r =>
-      rankSatisfiesComparator(r, plan.positionComparator, plan.positionTarget)
-    )
-    // Empty matching set is a different impossibility (out-of-range comparator/target);
-    // leave that for upstream/other detectors. We fire only when the satisfying ranks
-    // exist but every one of them is a pawn-illegal rank.
-    if (matching.length === 0) { continue }
-    if (matching.every(r => ILLEGAL_PAWN_RANKS.has(r))) {
-      const ranksText = matching.map(r => r + 1).join(' or ')
-      return `Pawns cannot be on rank ${ranksText} relative to the moving team; this condition can never be satisfied.`
-    }
-  }
-  return null
-}
-
 function detectSingularActorWithAggregateValue({ plans }) {
   for (const plan of plans) {
     if (plan.kind !== 'relational') { continue }
@@ -176,53 +261,16 @@ function detectSingularActorWithAggregateValue({ plans }) {
   return null
 }
 
-function detectSingularActorWithImpossibleUnaryCount({ plans }) {
-  for (const plan of plans) {
-    if (plan.kind !== 'census') { continue }
-    if (!SINGULAR_ACTORS.has(plan.subject)) { continue }
-    if (plan.operator !== 'count') { continue }
-    if (plan.target !== 'exact_number') { continue }
-    const total = Number(plan.targetTotal ?? 0)
-    const requiresMoreThanOne =
-      (plan.comparator === 'equal_to' && total > 1) ||
-      (plan.comparator === 'greater_than' && total >= 1) ||
-      (plan.comparator === 'greater_than_or_equal_to' && total > 1)
-    if (requiresMoreThanOne) {
-      return `A singular actor (${plan.subject}) cannot have count > 1; its count is at most 1.`
-    }
-  }
-  return null
-}
-
-function detectMovedPieceWithCountZero({ plans }) {
-  for (const plan of plans) {
-    if (plan.kind !== 'census') { continue }
-    if (plan.subject !== 'moved_piece') { continue }
-    if (plan.operator !== 'count') { continue }
-    // Region-restricted census moved_piece count = 0 is satisfiable (piece exists outside the region)
-    if (plan.positionAxis != null) { continue }
-    if (plan.target !== 'exact_number') { continue }
-    const total = Number(plan.targetTotal ?? 0)
-    const requiresZero =
-      (plan.comparator === 'equal_to' && total === 0) ||
-      (plan.comparator === 'less_than' && total <= 1) ||
-      (plan.comparator === 'less_than_or_equal_to' && total === 0)
-    if (requiresZero) {
-      return 'moved_piece must exist (a move occurred), but a condition requires its count to be zero.'
-    }
-  }
-  return null
-}
-
 const CONTRADICTION_DETECTORS = [
+  detectComparisonBelowZero,
+  detectImpossibleSingularCount,
+  detectImpossiblePawnRank,
+  detectAlliedFullyImmobile,
+  detectCountExceedsPriorBoard,
+  detectMovedPieceMustExist,
   detectIncompatibleMoveKinds,
   detectImpossibleMovedPieceSpecies,
   detectConflictingRequiredPositions,
-  detectIllegalPawnRanks,
-  detectImpossiblePawnPosition,
-  detectSingularActorWithImpossibleCount,
-  detectSingularActorWithImpossibleUnaryCount,
-  detectMovedPieceWithCountZero,
   detectFilterMatchesNoSpecies
 ]
 

--- a/app/javascript/editorV2/panels/condition_preview/plans/plan.js
+++ b/app/javascript/editorV2/panels/condition_preview/plans/plan.js
@@ -79,15 +79,15 @@ function detectConflictingRequiredPositions({ plans }) {
 }
 
 // Single-condition detectors, mirroring Ruby Nodes::ConditionSatisfiability
-// (condition_satisfiability.rb) — keep in sync. One intentional drift: 
-// Ruby also declines vacuous comparisons (e.g. singular count < 5) the generator can satisfy.
+// (condition_satisfiability.rb) — keep in sync. Ruby also declines two cases the
+// generator/form already handle: vacuous comparisons (e.g. singular count < 5) and negatives.
 
 const BASE_PAWN_RANKS = Object.freeze([2, 3, 4, 5, 6, 7])
 const PAWN_HOME_RANK = Object.freeze({ moved_piece: 2, enemy_moved_piece: 7 })
 const ALL_RANKS = Object.freeze([1, 2, 3, 4, 5, 6, 7, 8])
 
-function atMostOneSet(actor, filter) {
-  return SINGULAR_ACTORS.has(actor) || filter === 'king'
+function atMostOneSet(actor, filter, filterMode) {
+  return SINGULAR_ACTORS.has(actor) || (filter === 'king' && filterMode !== 'exclude')
 }
 
 function requiresMoreThanOne(comparator, total) {
@@ -130,7 +130,7 @@ function measureComparisons(plan) {
     if (plan.target !== 'exact_number') { return [] }
     return [{
       metric: plan.operator, comparator: plan.comparator, total: Number(plan.targetTotal ?? 0),
-      actor: plan.subject, filter: plan.subjectFilter
+      actor: plan.subject, filter: plan.subjectFilter, filterMode: plan.subjectFilterMode
     }]
   }
   if (plan.kind === 'relational') {
@@ -139,7 +139,8 @@ function measureComparisons(plan) {
       .map(descriptor => ({
         metric: descriptor.metric, comparator: descriptor.comparator, total: Number(descriptor.total ?? 0),
         actor: descriptor.side === 'subject' ? plan.subject : plan.target,
-        filter: descriptor.side === 'subject' ? plan.subjectFilter : plan.targetFilter
+        filter: descriptor.side === 'subject' ? plan.subjectFilter : plan.targetFilter,
+        filterMode: descriptor.side === 'subject' ? plan.subjectFilterMode : plan.targetFilterMode
       }))
   }
   return []
@@ -160,7 +161,7 @@ function detectImpossibleSingularCount({ plans }) {
   for (const plan of plans) {
     for (const comparison of measureComparisons(plan)) {
       if (comparison.metric === 'count'
-          && atMostOneSet(comparison.actor, comparison.filter)
+          && atMostOneSet(comparison.actor, comparison.filter, comparison.filterMode)
           && requiresMoreThanOne(comparison.comparator, comparison.total)) {
         return 'This piece can appear at most once, so its count cannot exceed 1; this condition can never be satisfied.'
       }

--- a/app/javascript/editorV2/panels/condition_preview/shared/geometry_utils.js
+++ b/app/javascript/editorV2/panels/condition_preview/shared/geometry_utils.js
@@ -1,5 +1,5 @@
 import Board from 'gameplay/board'
-import { nextPositionOnRay, knightControlledSquares, kingControlledSquares, ROOK_RAY_STEPS, BISHOP_RAY_STEPS, QUEEN_RAY_STEPS, relativeRank, relativeToAbsolutePosition } from 'gameplay/board_query_utils'
+import { nextPositionOnRay, knightControlledSquares, kingControlledSquares, ROOK_RAY_STEPS, BISHOP_RAY_STEPS, QUEEN_RAY_STEPS, relativeRankLabel, relativeToAbsolutePosition } from 'gameplay/board_query_utils'
 
 export { QUEEN_RAY_STEPS as RAY_STEPS }
 
@@ -169,7 +169,7 @@ export function qualifyingSquares(positionAxis, positionComparator, positionTarg
   const result = []
   for (let pos = 0; pos < 64; pos += 1) {
     if (positionAxis === 'rank') {
-      if (satisfiesComparator(positionComparator, relativeRank(pos, team), positionTarget)) { result.push(pos) }
+      if (satisfiesComparator(positionComparator, relativeRankLabel(pos, team), positionTarget)) { result.push(pos) }
     } else if (positionAxis === 'file') {
       if (satisfiesComparator(positionComparator, Board.fileIndex(pos) + 1, positionTarget)) { result.push(pos) }
     } else if (positionAxis === 'square') {

--- a/app/javascript/gameplay/board.js
+++ b/app/javascript/gameplay/board.js
@@ -145,11 +145,11 @@ class Board {
     return position % 8
   }
 
-  static rank(position){
+  static rankLabel(position){
     return Board.rankIndex(position) + 1
   }
 
-  static file(position){
+  static fileLabel(position){
     let files = "abcdefgh";
     return files[Board.fileIndex(position)]
   }
@@ -506,12 +506,12 @@ class Board {
     let competingStarts = this.competingMoveStarts(moveObject)
     if( competingStarts.length === 0 ){ return pieceNotation }
 
-    let startFile = Board.file(moveObject.startPosition),
-      startRank = Board.rank(moveObject.startPosition),
-      fileMatches = competingStarts.filter(position => Board.file(position) === startFile)
+    let startFile = Board.fileLabel(moveObject.startPosition),
+      startRank = Board.rankLabel(moveObject.startPosition),
+      fileMatches = competingStarts.filter(position => Board.fileLabel(position) === startFile)
     if( fileMatches.length === 0 ){ return pieceNotation + startFile }
 
-    let rankMatches = competingStarts.filter(position => Board.rank(position) === startRank)
+    let rankMatches = competingStarts.filter(position => Board.rankLabel(position) === startRank)
     if( rankMatches.length === 0 ){ return pieceNotation + startRank }
 
     return pieceNotation + Board.gridCalculator(moveObject.startPosition)

--- a/app/javascript/gameplay/board_query_utils.js
+++ b/app/javascript/gameplay/board_query_utils.js
@@ -674,8 +674,8 @@ export function cachedControlledSquares({ board, attackerPosition, cache = null,
     })
 }
 
-export function relativeRank(position, team) {
-    return team === Board.WHITE ? Board.rank(position) : 9 - Board.rank(position)
+export function relativeRankLabel(position, team) {
+    return team === Board.WHITE ? Board.rankLabel(position) : 9 - Board.rankLabel(position)
 }
 
 export function relativeToAbsolutePosition(relativeIndex, team) {

--- a/app/javascript/gameplay/candidate_move_analysis.js
+++ b/app/javascript/gameplay/candidate_move_analysis.js
@@ -473,7 +473,7 @@ class CandidateMoveAnalysis {
     const endPosition = this.moveObject.endPosition
     const movedPieceType = this.board.pieceTypeAt(startPosition)
     if (this.board.teamAt(endPosition) !== Board.EMPTY) { return endPosition }
-    const changedFiles = Board.file(startPosition) !== Board.file(endPosition)
+    const changedFiles = Board.fileLabel(startPosition) !== Board.fileLabel(endPosition)
     if (movedPieceType === Board.PAWN && changedFiles) {
       return this.movedPieceTeam() === Board.WHITE ? endPosition - 8 : endPosition + 8 
     }

--- a/app/javascript/gameplay/moves_calculator.js
+++ b/app/javascript/gameplay/moves_calculator.js
@@ -86,7 +86,7 @@ class MovesCalculator {
 
   promotionPiecesFor(endPosition) {
     if (this.pieceType !== Board.PAWN) { return [null] }
-    if (Board.rank(endPosition) !== 1 && Board.rank(endPosition) !== 8) { return [null] }
+    if (Board.rankLabel(endPosition) !== 1 && Board.rankLabel(endPosition) !== 8) { return [null] }
 
     return [Board.QUEEN, Board.ROOK, Board.BISHOP, Board.NIGHT]
   }
@@ -388,8 +388,8 @@ class MovesCalculator {
                 doubleStepCheck: Board.isSeventhRank(startPosition) && board._twoSpacesDownIsEmpty(startPosition) && board._oneSpaceDownIsEmpty(startPosition),
                 leftAttackMove: MovesCalculator.genericMovements({increment: MovesCalculator.forwardSlashDownIncrement}),
                 rightAttackMove: MovesCalculator.genericMovements({increment: MovesCalculator.backSlashDownIncrement}),
-                rightEnPassantCheck: Board.rank(startPosition) === 4 && board._whitePawnAt(startPosition + 1) && board.whitePawnDoubleSteppedTo(startPosition + 1),//board.whitePawnDoubleSteppedFrom(startPosition - 15),
-                leftEnPassantCheck: Board.rank(startPosition) === 4 && board._whitePawnAt(startPosition - 1) && board.whitePawnDoubleSteppedTo(startPosition - 1)// board.whitePawnDoubleSteppedFrom(startPosition - 17),
+                rightEnPassantCheck: Board.rankLabel(startPosition) === 4 && board._whitePawnAt(startPosition + 1) && board.whitePawnDoubleSteppedTo(startPosition + 1),//board.whitePawnDoubleSteppedFrom(startPosition - 15),
+                leftEnPassantCheck: Board.rankLabel(startPosition) === 4 && board._whitePawnAt(startPosition - 1) && board.whitePawnDoubleSteppedTo(startPosition - 1)// board.whitePawnDoubleSteppedFrom(startPosition - 17),
               },
               W: {
                 startRank: 2,
@@ -398,8 +398,8 @@ class MovesCalculator {
                 doubleStepCheck: Board.isSecondRank(startPosition) && board._twoSpacesUpIsEmpty( startPosition ) && board._oneSpaceUpIsEmpty(startPosition),
                 leftAttackMove: MovesCalculator.genericMovements({increment: MovesCalculator.backSlashUpIncrement}),
                 rightAttackMove: MovesCalculator.genericMovements({increment: MovesCalculator.forwardSlashUpIncrement}),
-                leftEnPassantCheck: Board.rank(startPosition) === 5 && board._blackPawnAt(startPosition - 1) && board.blackPawnDoubleSteppedTo(startPosition - 1),//board.blackPawnDoubleSteppedFrom(startPosition + 15),
-                rightEnPassantCheck: Board.rank(startPosition) === 5 && board._blackPawnAt(startPosition + 1) && board.blackPawnDoubleSteppedTo(startPosition + 1)//board.blackPawnDoubleSteppedFrom(startPosition + 17),
+                leftEnPassantCheck: Board.rankLabel(startPosition) === 5 && board._blackPawnAt(startPosition - 1) && board.blackPawnDoubleSteppedTo(startPosition - 1),//board.blackPawnDoubleSteppedFrom(startPosition + 15),
+                rightEnPassantCheck: Board.rankLabel(startPosition) === 5 && board._blackPawnAt(startPosition + 1) && board.blackPawnDoubleSteppedTo(startPosition + 1)//board.blackPawnDoubleSteppedFrom(startPosition + 17),
               }
             },
             pawnVars = colorVars[teamString]
@@ -423,7 +423,7 @@ class MovesCalculator {
               const movementType = pawnVars.leftAttackMove
               movementType.rangeLimit = 1
               movementType.startPosition = startPosition
-              movementType.pieceNotation = Board.file(startPosition)
+              movementType.pieceNotation = Board.fileLabel(startPosition)
               movementTypes.push(movementType)
             }
           }
@@ -433,7 +433,7 @@ class MovesCalculator {
               const movementType = pawnVars.rightAttackMove
               movementType.rangeLimit = 1
               movementType.startPosition = startPosition
-              movementType.pieceNotation = Board.file(startPosition)
+              movementType.pieceNotation = Board.fileLabel(startPosition)
               movementTypes.push(movementType)
             }
           }
@@ -441,7 +441,7 @@ class MovesCalculator {
             let movementType = pawnVars.rightAttackMove
             movementType.rangeLimit = 1
             movementType.startPosition = startPosition
-            movementType.pieceNotation = Board.file(startPosition)// + "x"
+            movementType.pieceNotation = Board.fileLabel(startPosition)// + "x"
             movementType.captureNotation = "x" //might be quicker to assign a single hash at once
             movementType.additionalActions = function(startPosition){
               this._capture(startPosition + 1)
@@ -454,7 +454,7 @@ class MovesCalculator {
             let movementType = pawnVars.leftAttackMove
             movementType.rangeLimit = 1
             movementType.startPosition = startPosition
-            movementType.pieceNotation = Board.file(startPosition)// + "x"
+            movementType.pieceNotation = Board.fileLabel(startPosition)// + "x"
             movementType.captureNotation = "x" //might be quicker to assign a single hash at once
             movementType.additionalActions = function(startPosition){
               this._capture(startPosition - 1)

--- a/app/models/node_grammar_v2.rb
+++ b/app/models/node_grammar_v2.rb
@@ -10,6 +10,11 @@
 
     EDITOR_SUBJECTS = SUBJECTS
 
+    # Mirrored in app/javascript/bot_execution/actors.js; kept in sync by
+    # spec/models/actors_js_sync_spec.rb.
+    SINGULAR_SUBJECTS = (SUBJECTS - %w[allied enemy]).freeze
+    RELATIONAL_SINGULAR_SUBJECTS = %w[moved_piece enemy_moved_piece].freeze
+
     FILTERS = %w[any king queen rook bishop knight pawn major minor].freeze
     CONCRETE_FILTERS = %w[king queen rook bishop knight pawn major minor].freeze
     FILTER_MODES = %w[include exclude].freeze

--- a/app/models/nodes/condition_satisfiability.rb
+++ b/app/models/nodes/condition_satisfiability.rb
@@ -1,0 +1,188 @@
+module Nodes
+  # Single-condition satisfiability, enforced at persistence. The live editor
+  # preview mirrors these as generation detectors in
+  # app/javascript/editorV2/panels/condition_preview/plans/plan.js — the two
+  # are parallel sources of truth and must be kept in sync.
+  class ConditionSatisfiability
+    BASE_PAWN_RANKS = (2..7).to_a.freeze
+    HOME_RANK_BY_SUBJECT = { 'moved_piece' => 2, 'enemy_moved_piece' => 7 }.freeze
+
+    REASONS = {
+      negative_operand: "A count, mobility, or value comparison can't use a negative number.",
+      below_zero: "Count, mobility, and value are never below zero, so 'less than 0' can never be true.",
+      single_count_ceiling: "This piece can appear at most once (its count is always 0 or 1), so this comparison is either impossible or always true.",
+      pawn_rank: "Pawns can never be on rank 1 or 8 — they promote on the final rank. To check for promotion, compare the count of the promoted piece to the prior board state (e.g. allied queens, count greater than prior board state).",
+      moved_pawn_home: "A pawn that just moved can't still be on its starting rank.",
+      allied_stuck: "The moving team always has at least one legal move, so allied mobility can't be 0. Add a piece filter to ask about a specific piece's mobility.",
+      count_growth: "A team never gains pieces during a turn, so its total count can't be greater than the prior board state.",
+      moved_piece_exists: "The moved piece must exist (a move occurred), so its count can't be 0."
+    }.freeze
+
+    class << self
+      def reasons(data)
+        new(data).reasons
+      end
+    end
+
+    def initialize(data)
+      @data = data || {}
+    end
+
+    def reasons
+      case data['kind']
+      when 'relational' then relational_reasons
+      when 'census' then census_reasons
+      else []
+      end
+    end
+
+    private
+
+    attr_reader :data
+
+    def relational_reasons
+      %w[subject target].flat_map { |side| side_comparator_reasons(side) }.uniq
+    end
+
+    def side_comparator_reasons(side)
+      return [] if data["#{side}ComparisonMetric"].blank?
+      return [] unless data["#{side}ComparisonSource"] == NodeGrammarV2::EXACT_COMPARISON_SOURCE
+
+      total = data["#{side}ComparisonSourceTotal"]
+      return [] unless total.is_a?(Numeric)
+
+      measure_reasons(
+        metric: data["#{side}ComparisonMetric"],
+        comparator: data["#{side}Comparator"],
+        total:,
+        actor: data[side],
+        filter: data["#{side}Filter"],
+        filter_mode: data["#{side}FilterMode"]
+      )
+    end
+
+    def census_reasons
+      [
+        census_measure_reasons,
+        census_mobility_reasons,
+        census_count_growth_reasons,
+        census_moved_piece_reasons,
+        census_pawn_rank_reasons
+      ].flatten.uniq
+    end
+
+    def census_measure_reasons
+      return [] unless data['target'] == NodeGrammarV2::EXACT_COMPARISON_SOURCE
+
+      total = data['targetTotal']
+      return [] unless total.is_a?(Numeric)
+
+      measure_reasons(
+        metric: data['operator'],
+        comparator: data['comparator'],
+        total:,
+        actor: data['subject'],
+        filter: data['subjectFilter'],
+        filter_mode: data['subjectFilterMode']
+      )
+    end
+
+    def census_mobility_reasons
+      return [] unless data['operator'] == 'mobility'
+      return [] unless data['subject'] == 'allied' && data['subjectFilter'] == 'any'
+      return [] if data['positionAxis'].present?
+      return [] unless data['target'] == NodeGrammarV2::EXACT_COMPARISON_SOURCE
+      return [] unless asserts_zero?(data['comparator'], data['targetTotal'])
+
+      [REASONS[:allied_stuck]]
+    end
+
+    def census_count_growth_reasons
+      return [] unless data['operator'] == 'count'
+      return [] unless data['subjectFilter'] == 'any'
+      return [] if data['positionAxis'].present?
+      return [] unless data['comparator'] == 'greater_than'
+      return [] unless data['target'] == NodeGrammarV2::PRIOR_BOARD_COMPARISON_SOURCE
+
+      [REASONS[:count_growth]]
+    end
+
+    def census_moved_piece_reasons
+      return [] unless data['subject'] == 'moved_piece' && data['subjectFilter'] == 'any'
+      return [] unless data['operator'] == 'count'
+      return [] if data['positionAxis'].present?
+      return [] unless data['target'] == NodeGrammarV2::EXACT_COMPARISON_SOURCE
+      return [] unless asserts_zero?(data['comparator'], data['targetTotal'])
+
+      [REASONS[:moved_piece_exists]]
+    end
+
+    def census_pawn_rank_reasons
+      return [] unless data['subjectFilter'] == 'pawn' && data['subjectFilterMode'] != 'exclude'
+      return [] unless %w[rank square].include?(data['positionAxis'])
+
+      admitted = admitted_ranks
+      return [] if admitted.empty?
+
+      if (admitted & BASE_PAWN_RANKS).empty?
+        [REASONS[:pawn_rank]]
+      elsif (admitted & legal_pawn_ranks(data['subject'])).empty?
+        [REASONS[:moved_pawn_home]]
+      else
+        []
+      end
+    end
+
+    def measure_reasons(metric:, comparator:, total:, actor:, filter:, filter_mode:)
+      out = []
+      out << REASONS[:negative_operand] if total.negative?
+      out << REASONS[:below_zero] if comparator == 'less_than' && total.zero?
+      if metric == 'count' && at_most_one_set?(actor, filter, filter_mode) && exceeds_one?(comparator, total)
+        out << REASONS[:single_count_ceiling]
+      end
+      out
+    end
+
+    def at_most_one_set?(actor, filter, filter_mode)
+      NodeGrammarV2::SINGULAR_SUBJECTS.include?(actor) || (filter == 'king' && filter_mode != 'exclude')
+    end
+
+    def exceeds_one?(comparator, total)
+      total > 1 || (comparator == 'greater_than' && total == 1)
+    end
+
+    def asserts_zero?(comparator, total)
+      return false unless total.is_a?(Numeric)
+
+      (comparator == 'equal_to' && total.zero?) ||
+        (comparator == 'less_than' && total == 1) ||
+        (comparator == 'less_than_or_equal_to' && total.zero?)
+    end
+
+    def admitted_ranks
+      target = data['positionTarget']
+      return [] unless target.is_a?(Numeric)
+
+      if data['positionAxis'] == 'square'
+        [(target.to_i / 8) + 1]
+      else
+        rank_range_for(data['positionComparator'], target.to_i).select { |rank| (1..8).cover?(rank) }
+      end
+    end
+
+    def rank_range_for(comparator, target)
+      case comparator
+      when 'equal_to' then [target]
+      when 'greater_than' then ((target + 1)..8).to_a
+      when 'less_than' then (1...target).to_a
+      when 'greater_than_or_equal_to' then (target..8).to_a
+      when 'less_than_or_equal_to' then (1..target).to_a
+      else []
+      end
+    end
+
+    def legal_pawn_ranks(subject)
+      BASE_PAWN_RANKS - [HOME_RANK_BY_SUBJECT[subject]].compact
+    end
+  end
+end

--- a/app/models/nodes/data_validator.rb
+++ b/app/models/nodes/data_validator.rb
@@ -49,6 +49,13 @@ module Nodes
       else
         record.errors.add(:data, "has invalid kind: #{kind}")
       end
+      validate_condition_satisfiability if record.errors[:data].empty?
+    end
+
+    def validate_condition_satisfiability
+      Nodes::ConditionSatisfiability.reasons(record.data).each do |reason|
+        record.errors.add(:data, reason)
+      end
     end
 
     def validate_condition_data_v2_relational

--- a/app/views/bots/nodes/_editor.html.erb
+++ b/app/views/bots/nodes/_editor.html.erb
@@ -21,9 +21,7 @@
           </div>
 
           <div class="condition-form-comparison" id="cond-left-comparison-section">
-            <button type="button" class="condition-form-comparison__toggle" id="cond-left-comparison-toggle"></button>
-
-            <div class="condition-form-comparison__body hidden" id="cond-left-comparison-body">
+            <div class="condition-form-comparison__body" id="cond-left-comparison-body">
               <div class="condition-form-comparison-grid condition-form-comparison-grid--relational">
                 <div class="condition-form-radio-row" id="cond-left-comparison-metric">
                   <% NodeForm.comparison_metric_options.each_with_index do |(label, value), i| %>
@@ -46,6 +44,7 @@
                   <input id="cond-left-comparison-source-total" type="number" min="0" step="1">
                 </div>
               </div>
+              <p class="condition-form-note hidden" id="cond-left-comparison-locked-note">Comparison unavailable while target uses prior board state.</p>
               <p class="condition-form-note hidden" id="cond-left-aggregate-note">Aggregate value unavailable while target uses aggregate value.</p>
             </div>
           </div>
@@ -89,9 +88,7 @@
 
           <div id="cond-right-relational-fields">
             <div class="condition-form-comparison">
-              <button type="button" class="condition-form-comparison__toggle" id="cond-right-comparison-toggle"></button>
-
-              <div class="condition-form-comparison__body hidden" id="cond-right-comparison-body">
+              <div class="condition-form-comparison__body" id="cond-right-comparison-body">
                 <div class="condition-form-comparison-grid condition-form-comparison-grid--relational">
                   <div class="condition-form-radio-row" id="cond-right-comparison-metric">
                     <% NodeForm.comparison_metric_options.each_with_index do |(label, value), i| %>
@@ -114,6 +111,7 @@
                     <input id="cond-right-comparison-source-total" type="number" min="0" step="1">
                   </div>
                 </div>
+                <p class="condition-form-note hidden" id="cond-right-comparison-locked-note">Comparison unavailable while subject uses prior board state.</p>
                 <p class="condition-form-note hidden" id="cond-right-aggregate-note">Aggregate value unavailable while subject uses aggregate value.</p>
               </div>
             </div>
@@ -152,9 +150,7 @@
           </div>
 
           <div class="condition-form-comparison" id="cond-census-comparison">
-            <button type="button" class="condition-form-comparison__toggle" id="cond-census-comparison-toggle"></button>
-
-            <div class="condition-form-comparison__body hidden" id="cond-census-comparison-body">
+            <div class="condition-form-comparison__body" id="cond-census-comparison-body">
               <div class="condition-form-comparison-grid condition-form-comparison-grid--relational">
                 <div class="condition-form-radio-row" id="cond-census-operator">
                   <% NodeForm.condition_form_position_operator_options.each_with_index do |(label, value), i| %>
@@ -173,18 +169,6 @@
                       <option value="<%= value %>"><%= label %></option>
                     <% end %>
                   </select>
-
-                  <div class="condition-form-inline-pair" id="cond-census-target-filter-row">
-                    <label class="condition-form-checkbox">
-                      <input id="cond-census-target-filter-mode" type="checkbox">
-                      <span>Non-</span>
-                    </label>
-                    <select id="cond-census-target-filter">
-                      <% NodeForm.filter_options.each do |label, value| %>
-                        <option value="<%= value %>"><%= label %></option>
-                      <% end %>
-                    </select>
-                  </div>
 
                   <input id="cond-census-target-total" type="number" min="0" step="1" value="0">
                 </div>
@@ -341,13 +325,23 @@
 
         <section class="condition-form-operator">
           <label>Operator</label>
-          <div class="condition-form-radio-row" id="cond-captures-operator">
-            <% NodeForm.captures_operator_options.each_with_index do |(label, value), i| %>
-              <label class="condition-form-checkbox">
-                <input type="radio" name="cond-captures-operator" value="<%= value %>" <%= 'checked' if i.zero? %>>
-                <span><%= label %></span>
-              </label>
-            <% end %>
+          <div class="condition-form-operator-row">
+            <div class="condition-form-radio-row" id="cond-captures-operator">
+              <% NodeForm.captures_operator_options.each_with_index do |(label, value), i| %>
+                <label class="condition-form-checkbox">
+                  <input type="radio" name="cond-captures-operator" value="<%= value %>" <%= 'checked' if i.zero? %>>
+                  <span><%= label %></span>
+                </label>
+              <% end %>
+            </div>
+
+            <div class="condition-form-comparator-toggle hidden" id="cond-captures-comparator">
+              <label class="condition-form-checkbox"><input type="radio" name="cond-captures-comparator" value="greater_than"><span>&gt;</span></label>
+              <label class="condition-form-checkbox"><input type="radio" name="cond-captures-comparator" value="greater_than_or_equal_to"><span>≥</span></label>
+              <label class="condition-form-checkbox"><input type="radio" name="cond-captures-comparator" value="equal_to" checked><span>=</span></label>
+              <label class="condition-form-checkbox"><input type="radio" name="cond-captures-comparator" value="less_than_or_equal_to"><span>≤</span></label>
+              <label class="condition-form-checkbox"><input type="radio" name="cond-captures-comparator" value="less_than"><span>&lt;</span></label>
+            </div>
           </div>
         </section>
 
@@ -355,8 +349,6 @@
           <div class="condition-form-side__header">
             <span class="condition-form-side__label">Target</span>
           </div>
-
-          <select id="cond-captures-comparator"><%= options_for_select(NodeForm::COMPARATOR_OPTIONS) %></select>
 
           <div class="condition-form-comparison-source-stack" id="cond-captures-target-stack">
             <select id="cond-captures-target">

--- a/spec/models/actors_js_sync_spec.rb
+++ b/spec/models/actors_js_sync_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+# Guards the Ruby ↔ JS mirror: NodeGrammarV2's singular-actor constants are the
+# source of truth; app/javascript/bot_execution/actors.js must match them.
+RSpec.describe 'actors.js singular-actor sets' do
+  let(:source) { File.read(Rails.root.join('app/javascript/bot_execution/actors.js')) }
+
+  def js_set(source, const_name)
+    match = source.match(/export const #{const_name} = Object\.freeze\(new Set\(\[(.*?)\]\)\)/m)
+    raise "could not find #{const_name} in actors.js" unless match
+
+    match[1].scan(/'([^']+)'/).flatten
+  end
+
+  it 'mirrors NodeGrammarV2::SINGULAR_SUBJECTS' do
+    expect(js_set(source, 'SINGULAR_ACTORS')).to match_array(NodeGrammarV2::SINGULAR_SUBJECTS)
+  end
+
+  it 'mirrors NodeGrammarV2::RELATIONAL_SINGULAR_SUBJECTS' do
+    expect(js_set(source, 'RELATIONAL_SINGULAR_ACTORS')).to match_array(NodeGrammarV2::RELATIONAL_SINGULAR_SUBJECTS)
+  end
+end

--- a/spec/models/nodes/condition_satisfiability_spec.rb
+++ b/spec/models/nodes/condition_satisfiability_spec.rb
@@ -79,6 +79,12 @@ RSpec.describe Nodes::ConditionSatisfiability do
         .to include(reason(:single_count_ceiling))
     end
 
+    it 'does not apply to a king-exclude group count above 1' do
+      expect(reasons(census(subject: 'allied', subjectFilter: 'king', subjectFilterMode: 'exclude',
+                            operator: 'count', comparator: 'greater_than', targetTotal: 1)))
+        .to be_empty
+    end
+
     it 'rejects a vacuous singular count upper bound' do
       expect(reasons(census(subject: 'moved_piece', operator: 'count', comparator: 'less_than', targetTotal: 5)))
         .to include(reason(:single_count_ceiling))

--- a/spec/models/nodes/condition_satisfiability_spec.rb
+++ b/spec/models/nodes/condition_satisfiability_spec.rb
@@ -1,0 +1,359 @@
+require 'rails_helper'
+
+RSpec.describe Nodes::ConditionSatisfiability do
+  def reasons(data)
+    described_class.reasons(data.transform_keys(&:to_s))
+  end
+
+  def reason(key)
+    described_class::REASONS.fetch(key)
+  end
+
+  def census(overrides = {})
+    {
+      version: 2, kind: 'census',
+      subject: 'allied', subjectFilter: 'any',
+      operator: 'count', comparator: 'equal_to',
+      target: 'exact_number', targetTotal: 1
+    }.merge(overrides)
+  end
+
+  def relational(overrides = {})
+    {
+      version: 2, kind: 'relational',
+      subject: 'moved_piece', subjectFilter: 'any',
+      operator: 'attack', target: 'enemy', targetFilter: 'any'
+    }.merge(overrides)
+  end
+
+  describe 'comparison floor' do
+    it 'rejects a negative census operand' do
+      expect(reasons(census(subject: 'moved_piece', operator: 'value', targetTotal: -1)))
+        .to include(reason(:negative_operand))
+    end
+
+    it 'rejects census "less than 0"' do
+      expect(reasons(census(subject: 'moved_piece', operator: 'mobility', comparator: 'less_than', targetTotal: 0)))
+        .to include(reason(:below_zero))
+    end
+
+    it 'rejects a negative relational side operand' do
+      expect(reasons(relational(
+        subjectComparisonMetric: 'individual_value', subjectComparator: 'equal_to',
+        subjectComparisonSource: 'exact_number', subjectComparisonSourceTotal: -1
+      ))).to include(reason(:negative_operand))
+    end
+
+    it 'rejects relational "less than 0"' do
+      expect(reasons(relational(
+        subjectComparisonMetric: 'count', subjectComparator: 'less_than',
+        subjectComparisonSource: 'exact_number', subjectComparisonSourceTotal: 0
+      ))).to include(reason(:below_zero))
+    end
+
+    it 'allows a group count of 0' do
+      expect(reasons(census(subject: 'allied', operator: 'count', comparator: 'equal_to', targetTotal: 0)))
+        .to be_empty
+    end
+
+    it 'allows a positive operand' do
+      expect(reasons(census(subject: 'allied', operator: 'count', comparator: 'greater_than', targetTotal: 3)))
+        .to be_empty
+    end
+  end
+
+  describe 'at-most-one count ceiling' do
+    it 'rejects a singular census subject count of 2' do
+      expect(reasons(census(subject: 'moved_piece', operator: 'count', comparator: 'equal_to', targetTotal: 2)))
+        .to include(reason(:single_count_ceiling))
+    end
+
+    it 'rejects a captured-piece census count greater than 1' do
+      expect(reasons(census(subject: 'captured_piece', operator: 'count', comparator: 'greater_than', targetTotal: 1)))
+        .to include(reason(:single_count_ceiling))
+    end
+
+    it 'rejects a king-filtered census count of 2' do
+      expect(reasons(census(subject: 'allied', subjectFilter: 'king', subjectFilterMode: 'include',
+                            operator: 'count', comparator: 'equal_to', targetTotal: 2)))
+        .to include(reason(:single_count_ceiling))
+    end
+
+    it 'rejects a vacuous singular count upper bound' do
+      expect(reasons(census(subject: 'moved_piece', operator: 'count', comparator: 'less_than', targetTotal: 5)))
+        .to include(reason(:single_count_ceiling))
+    end
+
+    it 'rejects a singular relational subject count of 2' do
+      expect(reasons(relational(
+        subject: 'moved_piece',
+        subjectComparisonMetric: 'count', subjectComparator: 'equal_to',
+        subjectComparisonSource: 'exact_number', subjectComparisonSourceTotal: 2
+      ))).to include(reason(:single_count_ceiling))
+    end
+
+    it 'rejects a singular relational target count of 2' do
+      expect(reasons(relational(
+        subject: 'moved_piece', target: 'enemy_moved_piece',
+        targetComparisonMetric: 'count', targetComparator: 'equal_to',
+        targetComparisonSource: 'exact_number', targetComparisonSourceTotal: 2
+      ))).to include(reason(:single_count_ceiling))
+    end
+
+    it 'rejects a king-filtered relational target count of 2' do
+      expect(reasons(relational(
+        target: 'enemy', targetFilter: 'king', targetFilterMode: 'include',
+        targetComparisonMetric: 'count', targetComparator: 'equal_to',
+        targetComparisonSource: 'exact_number', targetComparisonSourceTotal: 2
+      ))).to include(reason(:single_count_ceiling))
+    end
+
+    it 'allows a singular count of 1' do
+      expect(reasons(census(subject: 'moved_piece', operator: 'count', comparator: 'equal_to', targetTotal: 1)))
+        .to be_empty
+    end
+
+    it 'does not apply to an allied group count above 1' do
+      expect(reasons(census(subject: 'allied', subjectFilter: 'any', operator: 'count', comparator: 'equal_to', targetTotal: 5)))
+        .to be_empty
+    end
+
+    it 'does not apply to an enemy group count above 1' do
+      expect(reasons(census(subject: 'enemy', subjectFilter: 'any', operator: 'count', comparator: 'greater_than', targetTotal: 3)))
+        .to be_empty
+    end
+
+    it 'does not apply to a singular value above 1' do
+      expect(reasons(census(subject: 'moved_piece', operator: 'value', comparator: 'equal_to', targetTotal: 9)))
+        .to be_empty
+    end
+
+    it 'does not apply to a singular count compared to the prior board state' do
+      expect(reasons(census(subject: 'captured_piece', operator: 'count', comparator: 'equal_to', target: 'prior_board_state')))
+        .to be_empty
+    end
+
+    it 'allows a king-filtered count of 1' do
+      expect(reasons(census(subject: 'allied', subjectFilter: 'king', subjectFilterMode: 'include',
+                            operator: 'count', comparator: 'equal_to', targetTotal: 1)))
+        .to be_empty
+    end
+  end
+
+  describe 'pawn rank legality' do
+    def pawn_region(overrides = {})
+      census({
+        subject: 'allied', subjectFilter: 'pawn', subjectFilterMode: 'include',
+        operator: 'count', comparator: 'greater_than', target: 'exact_number', targetTotal: 0,
+        positionAxis: 'rank', positionComparator: 'equal_to', positionTarget: 5
+      }.merge(overrides))
+    end
+
+    it 'rejects a pawn on rank 1' do
+      expect(reasons(pawn_region(positionTarget: 1))).to include(reason(:pawn_rank))
+    end
+
+    it 'rejects a pawn on rank 8' do
+      expect(reasons(pawn_region(positionTarget: 8))).to include(reason(:pawn_rank))
+    end
+
+    it 'rejects a pawn pinned to rank 1 by a range comparator' do
+      expect(reasons(pawn_region(positionComparator: 'less_than_or_equal_to', positionTarget: 1)))
+        .to include(reason(:pawn_rank))
+    end
+
+    it 'rejects a pawn pinned to rank 8 by a range comparator' do
+      expect(reasons(pawn_region(positionComparator: 'greater_than', positionTarget: 7)))
+        .to include(reason(:pawn_rank))
+    end
+
+    it 'rejects a pawn on a square that sits on rank 1' do
+      expect(reasons(pawn_region(positionAxis: 'square', positionComparator: 'equal_to', positionTarget: 3)))
+        .to include(reason(:pawn_rank))
+    end
+
+    it 'allows a pawn on a square that sits on rank 5' do
+      expect(reasons(pawn_region(positionAxis: 'square', positionComparator: 'equal_to', positionTarget: 36)))
+        .to be_empty
+    end
+
+    it 'allows a pawn on rank 5' do
+      expect(reasons(pawn_region(positionTarget: 5))).to be_empty
+    end
+
+    it 'allows a pawn on rank 2 for a non-moved subject' do
+      expect(reasons(pawn_region(subject: 'allied', positionTarget: 2))).to be_empty
+    end
+
+    it 'does not apply to the file axis' do
+      expect(reasons(pawn_region(positionAxis: 'file', positionComparator: 'equal_to', positionTarget: 1)))
+        .to be_empty
+    end
+
+    it 'ignores a non-pawn filter on rank 1' do
+      expect(reasons(pawn_region(subjectFilter: 'any', subjectFilterMode: 'include', positionTarget: 1)))
+        .to be_empty
+    end
+
+    it 'ignores an excluded pawn filter on rank 1' do
+      expect(reasons(pawn_region(subjectFilterMode: 'exclude', positionTarget: 1))).to be_empty
+    end
+
+    describe 'moved-pawn home rank' do
+      it 'rejects a moved_piece pawn on rank 2' do
+        expect(reasons(pawn_region(subject: 'moved_piece', positionTarget: 2)))
+          .to include(reason(:moved_pawn_home))
+      end
+
+      it 'allows a moved_piece pawn on rank 3' do
+        expect(reasons(pawn_region(subject: 'moved_piece', positionTarget: 3))).to be_empty
+      end
+
+      it 'allows a moved_piece pawn on rank 7' do
+        expect(reasons(pawn_region(subject: 'moved_piece', positionTarget: 7))).to be_empty
+      end
+
+      it 'rejects an enemy_moved_piece pawn on rank 7' do
+        expect(reasons(pawn_region(subject: 'enemy_moved_piece', positionTarget: 7)))
+          .to include(reason(:moved_pawn_home))
+      end
+
+      it 'allows an enemy_moved_piece pawn on rank 6' do
+        expect(reasons(pawn_region(subject: 'enemy_moved_piece', positionTarget: 6))).to be_empty
+      end
+
+      it 'allows an enemy_moved_piece pawn on rank 2' do
+        expect(reasons(pawn_region(subject: 'enemy_moved_piece', positionTarget: 2))).to be_empty
+      end
+    end
+  end
+
+  describe 'allied team cannot be fully immobile' do
+    def allied_mobility(overrides = {})
+      census({
+        subject: 'allied', subjectFilter: 'any', operator: 'mobility',
+        comparator: 'equal_to', target: 'exact_number', targetTotal: 0
+      }.merge(overrides))
+    end
+
+    it 'rejects allied any mobility = 0' do
+      expect(reasons(allied_mobility)).to include(reason(:allied_stuck))
+    end
+
+    it 'rejects allied any mobility < 1' do
+      expect(reasons(allied_mobility(comparator: 'less_than', targetTotal: 1))).to include(reason(:allied_stuck))
+    end
+
+    it 'allows allied any mobility = 0 within a region' do
+      expect(reasons(allied_mobility(positionAxis: 'rank', positionComparator: 'equal_to', positionTarget: 5)))
+        .to be_empty
+    end
+
+    it 'allows enemy any mobility = 0' do
+      expect(reasons(allied_mobility(subject: 'enemy'))).to be_empty
+    end
+
+    it 'allows allied filtered mobility = 0' do
+      expect(reasons(allied_mobility(subjectFilter: 'queen', subjectFilterMode: 'include'))).to be_empty
+    end
+
+    it 'allows allied any mobility > 0' do
+      expect(reasons(allied_mobility(comparator: 'greater_than', targetTotal: 0))).to be_empty
+    end
+
+    it 'does not apply to a non-mobility operator' do
+      expect(reasons(allied_mobility(operator: 'count'))).to be_empty
+    end
+  end
+
+  describe 'count cannot exceed the prior board state' do
+    def count_growth(overrides = {})
+      census({
+        subject: 'allied', subjectFilter: 'any', operator: 'count',
+        comparator: 'greater_than', target: 'prior_board_state'
+      }.merge(overrides))
+    end
+
+    it 'rejects allied any count > PBS' do
+      expect(reasons(count_growth)).to include(reason(:count_growth))
+    end
+
+    it 'rejects enemy any count > PBS' do
+      expect(reasons(count_growth(subject: 'enemy'))).to include(reason(:count_growth))
+    end
+
+    it 'rejects moved_piece any count > PBS whole-board' do
+      expect(reasons(count_growth(subject: 'moved_piece'))).to include(reason(:count_growth))
+    end
+
+    it 'allows count > PBS within a region' do
+      expect(reasons(count_growth(positionAxis: 'rank', positionComparator: 'equal_to', positionTarget: 5)))
+        .to be_empty
+    end
+
+    it 'allows a filtered count > PBS' do
+      expect(reasons(count_growth(subjectFilter: 'queen', subjectFilterMode: 'include'))).to be_empty
+    end
+
+    it 'allows count = PBS' do
+      expect(reasons(count_growth(comparator: 'equal_to'))).to be_empty
+    end
+
+    it 'allows count < PBS' do
+      expect(reasons(count_growth(comparator: 'less_than'))).to be_empty
+    end
+
+    it 'does not apply to a non-count operator' do
+      expect(reasons(count_growth(operator: 'value'))).to be_empty
+    end
+  end
+
+  describe 'the moved piece must exist' do
+    def moved_count(overrides = {})
+      census({
+        subject: 'moved_piece', subjectFilter: 'any', operator: 'count',
+        comparator: 'equal_to', target: 'exact_number', targetTotal: 0
+      }.merge(overrides))
+    end
+
+    it 'rejects moved_piece any count = 0 whole-board' do
+      expect(reasons(moved_count)).to include(reason(:moved_piece_exists))
+    end
+
+    it 'rejects moved_piece any count < 1 whole-board' do
+      expect(reasons(moved_count(comparator: 'less_than', targetTotal: 1))).to include(reason(:moved_piece_exists))
+    end
+
+    it 'allows moved_piece any count = 0 within a region' do
+      expect(reasons(moved_count(positionAxis: 'rank', positionComparator: 'equal_to', positionTarget: 5)))
+        .to be_empty
+    end
+
+    it 'allows a filtered moved_piece count = 0' do
+      expect(reasons(moved_count(subjectFilter: 'queen', subjectFilterMode: 'include'))).to be_empty
+    end
+
+    it 'allows moved_piece any count > 0' do
+      expect(reasons(moved_count(comparator: 'greater_than', targetTotal: 0))).to be_empty
+    end
+
+    it 'does not apply to a non-count operator' do
+      expect(reasons(moved_count(operator: 'value'))).to be_empty
+    end
+
+    it 'allows enemy_moved_piece any count = 0 (capture or first move)' do
+      expect(reasons(moved_count(subject: 'enemy_moved_piece'))).to be_empty
+    end
+  end
+
+  describe 'non-applicable kinds' do
+    it 'returns no reasons for identity conditions' do
+      expect(reasons(version: 2, kind: 'identity', subject: 'captured_piece', target: 'enemy_moved_piece'))
+        .to be_empty
+    end
+
+    it 'returns no reasons for an unknown kind' do
+      expect(reasons(version: 2, kind: 'mystery')).to be_empty
+    end
+  end
+end

--- a/spec/models/nodes/data_validator_spec.rb
+++ b/spec/models/nodes/data_validator_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.describe Nodes::DataValidator do
+  def condition(data)
+    build(:node, node_type: 'condition', data:)
+  end
+
+  describe 'condition satisfiability wiring' do
+    it 'rejects a structurally valid but impossible census condition' do
+      node = condition(
+        version: 2, kind: 'census', subject: 'moved_piece', subjectFilter: 'any',
+        operator: 'count', comparator: 'equal_to', target: 'exact_number', targetTotal: 2
+      )
+
+      expect(node).not_to be_valid
+      expect(node.errors[:data]).to include(Nodes::ConditionSatisfiability::REASONS[:single_count_ceiling])
+    end
+
+    it 'rejects an impossible pawn-rank condition with the promotion hint' do
+      node = condition(
+        version: 2, kind: 'census', subject: 'allied', subjectFilter: 'pawn', subjectFilterMode: 'include',
+        operator: 'count', comparator: 'greater_than', target: 'exact_number', targetTotal: 0,
+        positionAxis: 'rank', positionComparator: 'equal_to', positionTarget: 1
+      )
+
+      expect(node).not_to be_valid
+      expect(node.errors[:data]).to include(Nodes::ConditionSatisfiability::REASONS[:pawn_rank])
+    end
+
+    it 'rejects an impossible relational condition' do
+      node = condition(
+        version: 2, kind: 'relational', subject: 'moved_piece', subjectFilter: 'any',
+        operator: 'attack', target: 'enemy', targetFilter: 'any',
+        subjectComparisonMetric: 'count', subjectComparator: 'equal_to',
+        subjectComparisonSource: 'exact_number', subjectComparisonSourceTotal: 2
+      )
+
+      expect(node).not_to be_valid
+      expect(node.errors[:data]).to include(Nodes::ConditionSatisfiability::REASONS[:single_count_ceiling])
+    end
+
+    it 'accepts a possible condition' do
+      node = condition(
+        version: 2, kind: 'census', subject: 'allied', subjectFilter: 'any',
+        operator: 'count', comparator: 'greater_than', target: 'exact_number', targetTotal: 0
+      )
+
+      expect(node).to be_valid
+    end
+
+    it 'skips satisfiability when the structure is invalid' do
+      node = condition(
+        version: 2, kind: 'census', subject: 'moved_piece', subjectFilter: 'any',
+        operator: 'count', comparator: 'nonsense', target: 'exact_number', targetTotal: 2
+      )
+
+      expect(node).not_to be_valid
+      expect(node.errors[:data]).to include('has invalid comparator')
+      expect(node.errors[:data]).not_to include(Nodes::ConditionSatisfiability::REASONS[:single_count_ceiling])
+    end
+  end
+end


### PR DESCRIPTION
⏺ Adds single-condition satisfiability gating to the condition editor and makes the comparison UI always-visible.

  Grammar gating (backend + preview)
  - New Nodes::ConditionSatisfiability rejects impossible single conditions at persistence — singular count > 1, pawns on rank 1/8, just-moved pawn on its home rank, allied mobility 0, count > prior board state,
  moved-piece count 0.
  - Mirrored as live-preview detectors in plan.js. A shared fixture (condition_satisfiability_parity.json) asserts both sides agree on the verdict; actors_js_sync_spec guards the actor-set constants.
  - Renames 1-indexed board accessors to *Label (rankLabel/fileLabel) to disambiguate from 0-indexed *Index.

  Condition form overhaul
  - Comparisons always show; the show/hide and Advanced/Simplify toggles are gone. An empty relational comparison reads "count ≥ 1" (the identity) and is omitted from the payload.
  - Census: count/mobility compare only to an integer or the prior board state; the target piece-type filter is removed (tech debt tracked in #NNN — census can drop targetFilter once captures is its own node kind).
  - Captures operator/comparator restyle, "Any piece" → "Any piece type", plus polish and dead-code removal.

  Testing: full JS suite green; new condition_satisfiability_spec, parity specs (Ruby + JS), data_validator additions