### PR TITLE
add cross-language satisfiability parity fixture

### DIFF
--- a/app/javascript/editorV2/panels/condition_preview/plans/__tests__/contradictions_parity.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/plans/__tests__/contradictions_parity.test.js
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import fs from 'node:fs'
+import path from 'node:path'
+import { buildCombinedPlan } from 'editorV2/panels/condition_preview/plans/plan'
+
+// Shared impossible/possible payloads, also loaded by the Ruby spec
+// (spec/models/nodes/condition_satisfiability_parity_spec.rb), so the JS
+// detectors and Nodes::ConditionSatisfiability can't drift on these cases.
+// The JS side checks the verdict; the Ruby side pins the exact reason.
+const parityCases = JSON.parse(
+  fs.readFileSync(path.join(process.cwd(), 'spec/fixtures/condition_satisfiability_parity.json'), 'utf8')
+)
+
+function isContradictory(data) {
+  return buildCombinedPlan([data]).status === 'contradictory'
+}
+
+describe('condition satisfiability parity', () => {
+  it('allows every satisfiable parity case', () => {
+    const flagged = parityCases.filter(c => c.satisfiable && isContradictory(c.data)).map(c => c.name)
+    expect(flagged).toEqual([])
+  })
+
+  it('rejects every unsatisfiable parity case', () => {
+    const missed = parityCases.filter(c => !c.satisfiable && !isContradictory(c.data)).map(c => c.name)
+    expect(missed).toEqual([])
+  })
+})

--- a/spec/fixtures/condition_satisfiability_parity.json
+++ b/spec/fixtures/condition_satisfiability_parity.json
@@ -1,0 +1,86 @@
+[
+  {
+    "name": "singular census count of 2",
+    "satisfiable": false,
+    "reasonKey": "single_count_ceiling",
+    "data": { "version": 2, "kind": "census", "subject": "moved_piece", "subjectFilter": "any", "operator": "count", "comparator": "equal_to", "target": "exact_number", "targetTotal": 2 }
+  },
+  {
+    "name": "singular census count of 1",
+    "satisfiable": true,
+    "data": { "version": 2, "kind": "census", "subject": "moved_piece", "subjectFilter": "any", "operator": "count", "comparator": "equal_to", "target": "exact_number", "targetTotal": 1 }
+  },
+  {
+    "name": "captured-piece census count greater than 1",
+    "satisfiable": false,
+    "reasonKey": "single_count_ceiling",
+    "data": { "version": 2, "kind": "census", "subject": "captured_piece", "subjectFilter": "any", "operator": "count", "comparator": "greater_than", "target": "exact_number", "targetTotal": 1 }
+  },
+  {
+    "name": "king-include census count of 2",
+    "satisfiable": false,
+    "reasonKey": "single_count_ceiling",
+    "data": { "version": 2, "kind": "census", "subject": "allied", "subjectFilter": "king", "subjectFilterMode": "include", "operator": "count", "comparator": "equal_to", "target": "exact_number", "targetTotal": 2 }
+  },
+  {
+    "name": "king-exclude census count above 1",
+    "satisfiable": true,
+    "data": { "version": 2, "kind": "census", "subject": "allied", "subjectFilter": "king", "subjectFilterMode": "exclude", "operator": "count", "comparator": "greater_than", "target": "exact_number", "targetTotal": 1 }
+  },
+  {
+    "name": "singular relational subject count of 2",
+    "satisfiable": false,
+    "reasonKey": "single_count_ceiling",
+    "data": { "version": 2, "kind": "relational", "subject": "moved_piece", "subjectFilter": "any", "operator": "attack", "target": "enemy", "targetFilter": "any", "subjectComparisonMetric": "count", "subjectComparator": "equal_to", "subjectComparisonSource": "exact_number", "subjectComparisonSourceTotal": 2 }
+  },
+  {
+    "name": "plain relational attack",
+    "satisfiable": true,
+    "data": { "version": 2, "kind": "relational", "subject": "moved_piece", "subjectFilter": "any", "operator": "attack", "target": "enemy", "targetFilter": "any" }
+  },
+  {
+    "name": "pawn census on rank 1",
+    "satisfiable": false,
+    "reasonKey": "pawn_rank",
+    "data": { "version": 2, "kind": "census", "subject": "allied", "subjectFilter": "pawn", "subjectFilterMode": "include", "operator": "count", "comparator": "greater_than", "target": "exact_number", "targetTotal": 0, "positionAxis": "rank", "positionComparator": "equal_to", "positionTarget": 1 }
+  },
+  {
+    "name": "pawn census on rank 5",
+    "satisfiable": true,
+    "data": { "version": 2, "kind": "census", "subject": "allied", "subjectFilter": "pawn", "subjectFilterMode": "include", "operator": "count", "comparator": "greater_than", "target": "exact_number", "targetTotal": 0, "positionAxis": "rank", "positionComparator": "equal_to", "positionTarget": 5 }
+  },
+  {
+    "name": "moved_piece pawn on its home rank 2",
+    "satisfiable": false,
+    "reasonKey": "moved_pawn_home",
+    "data": { "version": 2, "kind": "census", "subject": "moved_piece", "subjectFilter": "pawn", "subjectFilterMode": "include", "operator": "count", "comparator": "greater_than", "target": "exact_number", "targetTotal": 0, "positionAxis": "rank", "positionComparator": "equal_to", "positionTarget": 2 }
+  },
+  {
+    "name": "allied mobility of 0",
+    "satisfiable": false,
+    "reasonKey": "allied_stuck",
+    "data": { "version": 2, "kind": "census", "subject": "allied", "subjectFilter": "any", "operator": "mobility", "comparator": "equal_to", "target": "exact_number", "targetTotal": 0 }
+  },
+  {
+    "name": "allied mobility at least 1",
+    "satisfiable": true,
+    "data": { "version": 2, "kind": "census", "subject": "allied", "subjectFilter": "any", "operator": "mobility", "comparator": "greater_than_or_equal_to", "target": "exact_number", "targetTotal": 1 }
+  },
+  {
+    "name": "team count greater than prior board state",
+    "satisfiable": false,
+    "reasonKey": "count_growth",
+    "data": { "version": 2, "kind": "census", "subject": "allied", "subjectFilter": "any", "operator": "count", "comparator": "greater_than", "target": "prior_board_state" }
+  },
+  {
+    "name": "moved_piece count of 0",
+    "satisfiable": false,
+    "reasonKey": "moved_piece_exists",
+    "data": { "version": 2, "kind": "census", "subject": "moved_piece", "subjectFilter": "any", "operator": "count", "comparator": "equal_to", "target": "exact_number", "targetTotal": 0 }
+  },
+  {
+    "name": "group count of 3",
+    "satisfiable": true,
+    "data": { "version": 2, "kind": "census", "subject": "allied", "subjectFilter": "any", "operator": "count", "comparator": "equal_to", "target": "exact_number", "targetTotal": 3 }
+  }
+]

--- a/spec/models/nodes/condition_satisfiability_parity_spec.rb
+++ b/spec/models/nodes/condition_satisfiability_parity_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+# Shared impossible/possible payloads asserted against both the Ruby validator
+# (Nodes::ConditionSatisfiability) and the JS preview detectors. The same file
+# feeds app/javascript/.../__tests__/contradictions_parity.test.js, so the two
+# parallel sources of truth can't drift on these cases. The Ruby side pins the
+# exact reason; the JS side checks the verdict. Drift cases (Ruby's
+# vacuous/negative rejections) live in the per-language specs.
+RSpec.describe 'condition satisfiability parity' do
+  parity_cases = JSON.parse(File.read(Rails.root.join('spec/fixtures/condition_satisfiability_parity.json')))
+  satisfiable_cases = parity_cases.select { |parity_case| parity_case['satisfiable'] }
+  unsatisfiable_cases = parity_cases.reject { |parity_case| parity_case['satisfiable'] }
+
+  it 'allows every satisfiable parity case' do
+    aggregate_failures do
+      satisfiable_cases.each do |parity_case|
+        reasons = Nodes::ConditionSatisfiability.reasons(parity_case['data'])
+        expect(reasons).to(be_empty, "expected '#{parity_case['name']}' to be satisfiable, got: #{reasons}")
+      end
+    end
+  end
+
+  it 'rejects every unsatisfiable parity case with the expected reason' do
+    aggregate_failures do
+      unsatisfiable_cases.each do |parity_case|
+        expected = Nodes::ConditionSatisfiability::REASONS.fetch(parity_case['reasonKey'].to_sym)
+        reasons = Nodes::ConditionSatisfiability.reasons(parity_case['data'])
+        expect(reasons).to(include(expected), "expected '#{parity_case['name']}' to be rejected for #{parity_case['reasonKey']}, got: #{reasons}")
+      end
+    end
+  end
+end


### PR DESCRIPTION
One curated list of impossible/possible condition payloads, loaded by both the Ruby validator spec and the JS preview spec, so Nodes::ConditionSatisfiability and the plan.js detectors can't drift on these cases. Ruby pins the exact reason; JS checks the verdict