### PR TITLE
highlight roles: CSS-variable colors + ROLE_RENDER_ORDER parity test

### DIFF
--- a/app/assets/stylesheets/node_editor.css
+++ b/app/assets/stylesheets/node_editor.css
@@ -1,5 +1,17 @@
 :root {
   --select-arrow: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='8' height='5' viewBox='0 0 8 5'%3E%3Cpolygon points='0,0 8,0 4,5' fill='%23A855F7'/%3E%3C/svg%3E");
+
+  --highlight-attacker:        153 27 27;
+  --highlight-defender:        37 99 235;
+  --highlight-shield:          124 58 237;
+  --highlight-subject:         22 163 74;
+  --highlight-position-subject: 249 115 22;
+  --highlight-target-attack:   244 63 94;
+  --highlight-target-defend:   147 197 253;
+  --highlight-target-shield:   196 181 253;
+  --highlight-target-generic:  134 239 172;
+  --highlight-moved-from:      253 224 71;
+  --highlight-moved-to:        234 179 8;
 }
 
 .page-content.page-content--bot-editor {

--- a/app/javascript/editorV2/panels/condition_preview/shared/__tests__/highlight_roles.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/shared/__tests__/highlight_roles.test.js
@@ -3,11 +3,18 @@ import {
   HIGHLIGHT_ROLES,
   MOVED_FROM,
   MOVED_TO,
+  ROLE_RENDER_ORDER,
   relationSubjectRole,
   relationTargetRole,
   tileDecoration,
   legendEntries
 } from '../highlight_roles.js'
+
+describe('ROLE_RENDER_ORDER', () => {
+  it('includes every role that HIGHLIGHT_ROLES defines', () => {
+    expect(new Set(ROLE_RENDER_ORDER)).toEqual(new Set(Object.keys(HIGHLIGHT_ROLES)))
+  })
+})
 
 describe('relationSubjectRole / relationTargetRole', () => {
   it('maps each operator to its subject and target role keys', () => {
@@ -36,7 +43,7 @@ describe('tileDecoration', () => {
   it('decorates a single-role tile with one inset ring and a tinted background', () => {
     const deco = tileDecoration({ roles: { attacker: [10] } }, 10)
     expect(deco.boxShadow).toBe(`inset 0 0 0 3px ${HIGHLIGHT_ROLES.attacker.color}`)
-    expect(deco.background).toBe(`${HIGHLIGHT_ROLES.attacker.color}40`)
+    expect(deco.background).toBe(HIGHLIGHT_ROLES.attacker.tint)
   })
 
   it('stacks role rings inside the moved rings when a piece carries both', () => {
@@ -61,7 +68,7 @@ describe('tileDecoration', () => {
         `inset 0 0 0 9px ${HIGHLIGHT_ROLES.targetGeneric.color}`
       ].join(', ')
     )
-    expect(deco.background).toBe(`${HIGHLIGHT_ROLES.attacker.color}40`)
+    expect(deco.background).toBe(HIGHLIGHT_ROLES.attacker.tint)
   })
 
   it('shows moved-from + moved-to as concentric rings on a one-square move', () => {

--- a/app/javascript/editorV2/panels/condition_preview/shared/highlight_roles.js
+++ b/app/javascript/editorV2/panels/condition_preview/shared/highlight_roles.js
@@ -1,20 +1,28 @@
-export const HIGHLIGHT_ROLES = {
-  attacker:        { color: '#991b1b', label: 'Attacker' },
-  defender:        { color: '#2563eb', label: 'Defender' },
-  shield:          { color: '#7c3aed', label: 'Shield' },
-  subject:         { color: '#16a34a', label: 'Subject' },
-  positionSubject: { color: '#f97316', label: 'Subject' },
-  targetAttack:    { color: '#f43f5e', label: "Attacker's target" },
-  targetDefend:    { color: '#93c5fd', label: "Defender's target" },
-  targetShield:    { color: '#c4b5fd', label: "Shield's target" },
-  targetGeneric:   { color: '#86efac', label: 'Target' }
+function role(varName, label) {
+  return {
+    color: `rgb(var(${varName}))`,
+    tint:  `rgb(var(${varName}) / 25%)`,
+    label
+  }
 }
 
-export const MOVED_FROM = { color: '#fde047', label: 'Moved from' }
-export const MOVED_TO   = { color: '#eab308', label: 'Moved to' }
+export const HIGHLIGHT_ROLES = {
+  attacker:        role('--highlight-attacker',         'Attacker'),
+  defender:        role('--highlight-defender',         'Defender'),
+  shield:          role('--highlight-shield',           'Shield'),
+  subject:         role('--highlight-subject',          'Subject'),
+  positionSubject: role('--highlight-position-subject', 'Subject'),
+  targetAttack:    role('--highlight-target-attack',    "Attacker's target"),
+  targetDefend:    role('--highlight-target-defend',    "Defender's target"),
+  targetShield:    role('--highlight-target-shield',    "Shield's target"),
+  targetGeneric:   role('--highlight-target-generic',   'Target')
+}
+
+export const MOVED_FROM = role('--highlight-moved-from', 'Moved from')
+export const MOVED_TO   = role('--highlight-moved-to',   'Moved to')
 
 // Innermost first; moved rings drawn outside role rings.
-const ROLE_RENDER_ORDER = [
+export const ROLE_RENDER_ORDER = [
   'attacker', 'defender', 'shield', 'subject', 'positionSubject',
   'targetAttack', 'targetDefend', 'targetShield', 'targetGeneric'
 ]
@@ -37,19 +45,22 @@ export function relationTargetRole(operator) {
   }
 }
 
-function rolesAtPosition(roles, index) {
-  return ROLE_RENDER_ORDER.filter(key => roles[key]?.includes(index))
+function entriesAtPosition(highlights, index) {
+  const roles = highlights.roles || {}
+  const entries = ROLE_RENDER_ORDER
+    .filter(key => roles[key]?.includes(index))
+    .map(key => HIGHLIGHT_ROLES[key])
+  if (highlights.movedStartPosition === index) { entries.push(MOVED_FROM) }
+  if (highlights.movedEndPosition === index)   { entries.push(MOVED_TO) }
+  return entries
 }
 
 export function tileDecoration(highlights, index) {
-  const roles = highlights.roles || {}
-  const colors = rolesAtPosition(roles, index).map(key => HIGHLIGHT_ROLES[key].color)
-  if (highlights.movedStartPosition === index) { colors.push(MOVED_FROM.color) }
-  if (highlights.movedEndPosition === index)   { colors.push(MOVED_TO.color) }
-  if (colors.length === 0) { return null }
+  const entries = entriesAtPosition(highlights, index)
+  if (entries.length === 0) { return null }
 
-  const boxShadow = colors.map((color, ring) => `inset 0 0 0 ${3 * (ring + 1)}px ${color}`).join(', ')
-  return { boxShadow, background: `${colors[0]}40` }
+  const boxShadow = entries.map((e, ring) => `inset 0 0 0 ${3 * (ring + 1)}px ${e.color}`).join(', ')
+  return { boxShadow, background: entries[0].tint }
 }
 
 export function legendEntries(example) {


### PR DESCRIPTION
Eleven --highlight-* RGB-triplet vars in :root replace the JS hex literals; role(varName, label) composes rgb(var(...)) for the ring and rgb(var(...) / 25%) for the background tint. ROLE_RENDER_ORDER is exported and asserted to cover every HIGHLIGHT_ROLES key