### PR TITLE
captures: hide group/set actors from value-comparison targets

### DIFF
--- a/app/javascript/editorV2/__tests__/ConditionForm.test.js
+++ b/app/javascript/editorV2/__tests__/ConditionForm.test.js
@@ -852,6 +852,24 @@ describe('ConditionForm', () => {
       })
     })
 
+    it('hides collection actors (allied/enemy) from value-comparison targets', () => {
+      const panel = buildPanel()
+      const form = new ConditionForm(panel)
+      form.attach()
+
+      panel.querySelector('#cond-mode-captures').dispatchEvent(new Event('click'))
+      const valueOp = panel.querySelector('#cond-captures-operator input[value="value"]')
+      valueOp.checked = true
+      valueOp.dispatchEvent(new Event('change'))
+
+      const target = panel.querySelector('#cond-captures-target')
+      expect(target.querySelector('option[value="allied"]').hidden).toBe(true)
+      expect(target.querySelector('option[value="enemy"]').hidden).toBe(true)
+      expect(target.querySelector('option[value="moved_piece"]').hidden).toBe(false)
+      expect(target.querySelector('option[value="enemy_captured_piece"]').hidden).toBe(false)
+      expect(target.querySelector('option[value="exact_number"]').hidden).toBe(false)
+    })
+
     it('routes a count = 1 captured census node into the captures tab as Exists', () => {
       const panel = buildPanel()
       const form = new ConditionForm(panel)
@@ -983,7 +1001,7 @@ describe('ConditionForm', () => {
       })
     })
 
-    it('builds a value capture with an actor target and target filter', () => {
+    it('builds a value capture with a singular-actor target and target filter', () => {
       const panel = buildPanel()
       const form = new ConditionForm(panel)
       form.attach()
@@ -995,7 +1013,7 @@ describe('ConditionForm', () => {
         subjectFilter: 'any',
         operator: 'value',
         comparator: 'greater_than',
-        target: 'enemy',
+        target: 'enemy_moved_piece',
         targetFilter: 'pawn',
         targetFilterMode: 'exclude'
       }

--- a/app/javascript/editorV2/panels/condition_form/captures_mode.js
+++ b/app/javascript/editorV2/panels/condition_form/captures_mode.js
@@ -1,5 +1,5 @@
 import {
-  disableOptions, showAllOptions, pillValue, setPillChecked
+  disableOptions, hideOptions, showAllOptions, pillValue, setPillChecked
 } from 'editorV2/panels/condition_form/dom_helpers'
 import { censusMeasurePayload } from 'editorV2/panels/condition_form/census_payload'
 
@@ -16,6 +16,7 @@ const DEFAULT_CAPTURES_STATE = {
 }
 
 const CAPTURES_SUBJECTS = ['captured_piece', 'enemy_captured_piece']
+const SINGULAR_ACTORS = ['moved_piece', 'captured_piece', 'enemy_moved_piece', 'enemy_captured_piece']
 
 // exists/does_not_exist → census count=1/count=0; value → census (no region keys);
 // same_piece → identity.
@@ -140,15 +141,15 @@ export default class CapturesMode {
     fields.capturesTargetFilterModeControl?.classList.toggle('condition-form-checkbox--unavailable', !targetFilterModeAvailable)
     fields.capturesEnemyNote?.classList.toggle('hidden', cap.subject !== 'enemy_captured_piece')
 
-    this.disableTargetOptions(cap, fields)
+    this.narrowTargetOptions(cap, fields)
   }
 
-  disableTargetOptions(cap, fields) {
+  narrowTargetOptions(cap, fields) {
     if (!fields.capturesTarget) { return }
     showAllOptions(fields.capturesTarget)
     const all = Array.from(fields.capturesTarget.options).map(o => o.value)
     const allowed = cap.operator === 'same_piece' ? [this.samePiecePartner(cap.subject)] : this.measureTargets()
-    disableOptions(fields.capturesTarget, all.filter(v => !allowed.includes(v)))
+    hideOptions(fields.capturesTarget, all.filter(v => !allowed.includes(v)))
   }
 
   censusOperator(nodeData) {
@@ -165,7 +166,7 @@ export default class CapturesMode {
   }
 
   measureTargets() {
-    return ['exact_number', ...(this.grammarRules.editorSubjects || [])]
+    return ['exact_number', ...(this.grammarRules.editorSubjects || []).filter(s => SINGULAR_ACTORS.includes(s))]
   }
 
   canSamePiece(subject) {

--- a/app/javascript/editorV2/panels/condition_form/dom_helpers.js
+++ b/app/javascript/editorV2/panels/condition_form/dom_helpers.js
@@ -33,6 +33,13 @@ export function disableOptions(control, disallowedValues) {
   })
 }
 
+export function hideOptions(control, valuesToHide) {
+  if (!control?.options) { return }
+  Array.from(control.options).forEach(option => {
+    option.hidden = valuesToHide.includes(option.value)
+  })
+}
+
 export function enableAllOptions(select) {
   Array.from(select.options).forEach(option => {
     option.disabled = false


### PR DESCRIPTION
Only integers and singular actors make sense; group actors are now removed from the dropdown rather than greyed. Adds hideOptions helper, filters measureTargets, renames disableTargetOptions → narrowTargetOptions