### PR TITLE
Main  example highlights

### DIFF
--- a/app/javascript/editorV2/panels/BoardStatePreview.js
+++ b/app/javascript/editorV2/panels/BoardStatePreview.js
@@ -42,8 +42,10 @@ function buildMiniBoardEl() {
 
 function decorateTile(tile, index, highlights) {
   const deco = tileDecoration(highlights, index)
-  tile.style.boxShadow  = deco?.boxShadow  || ''
-  tile.style.background = deco?.background || ''
+  tile.style.boxShadow = deco?.boxShadow || ''
+  // background-image (not the shorthand) so the wood background-color from
+  // .mini-board__tile--light/dark stays underneath and the wash alpha-blends over it.
+  tile.style.backgroundImage = deco ? `linear-gradient(${deco.background}, ${deco.background})` : ''
 }
 
 function renderLayout(boardEl, layout, highlights) {

--- a/app/javascript/editorV2/panels/condition_preview/shared/__tests__/highlight_roles.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/shared/__tests__/highlight_roles.test.js
@@ -43,7 +43,11 @@ describe('tileDecoration', () => {
   it('decorates a single-role tile with one inset ring and a tinted background', () => {
     const deco = tileDecoration({ roles: { attacker: [10] } }, 10)
     expect(deco.boxShadow).toBe(`inset 0 0 0 3px ${HIGHLIGHT_ROLES.attacker.color}`)
+<<<<<<< HEAD
     expect(deco.background).toBe(HIGHLIGHT_ROLES.attacker.tint)
+=======
+    expect(deco.background).toBe(`${HIGHLIGHT_ROLES.attacker.color}59`)
+>>>>>>> 54fe34b (tile fill blends over wood; bump alpha to ~35%)
   })
 
   it('stacks role rings inside the moved rings when a piece carries both', () => {

--- a/app/javascript/editorV2/panels/condition_preview/shared/__tests__/highlight_roles.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/shared/__tests__/highlight_roles.test.js
@@ -43,11 +43,7 @@ describe('tileDecoration', () => {
   it('decorates a single-role tile with one inset ring and a tinted background', () => {
     const deco = tileDecoration({ roles: { attacker: [10] } }, 10)
     expect(deco.boxShadow).toBe(`inset 0 0 0 3px ${HIGHLIGHT_ROLES.attacker.color}`)
-<<<<<<< HEAD
     expect(deco.background).toBe(HIGHLIGHT_ROLES.attacker.tint)
-=======
-    expect(deco.background).toBe(`${HIGHLIGHT_ROLES.attacker.color}59`)
->>>>>>> 54fe34b (tile fill blends over wood; bump alpha to ~35%)
   })
 
   it('stacks role rings inside the moved rings when a piece carries both', () => {

--- a/app/javascript/editorV2/panels/condition_preview/shared/__tests__/move_collection.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/shared/__tests__/move_collection.test.js
@@ -15,11 +15,14 @@ function fakeAnalysis({
   positionFilteredPositions = [],
   relationalActorPositions = []
 } = {}) {
+  // Each query accepts a value or a function — function form lets a test branch
+  // on boardScope to simulate prior vs after evals.
+  const callOrReturn = (v) => (params) => typeof v === 'function' ? v(params) : v
   return {
-    relationalResult: () => relationalResult,
+    relationalResult: callOrReturn(relationalResult),
     capturedPiecePosition: () => capturedPos,
-    positionFilteredPositions: () => positionFilteredPositions,
-    relationalActorPositions: () => relationalActorPositions,
+    positionFilteredPositions: callOrReturn(positionFilteredPositions),
+    relationalActorPositions: callOrReturn(relationalActorPositions),
     afterBoard: () => ({})
   }
 }
@@ -103,7 +106,7 @@ describe('buildAggregatedResult', () => {
 
   it('also evaluates the prior board for a relational plan that compares against PBS', () => {
     const relationalCalls = []
-    const analysis = {
+    const analysis = fakeAnalysis({
       relationalResult: (params) => {
         relationalCalls.push(params)
         if (params.boardScope === 'prior') {
@@ -111,10 +114,8 @@ describe('buildAggregatedResult', () => {
                    subjectPositions: [10, 11], targetPositions: [20, 21] }
         }
         return { pairs: [{ subjectPosition: 10, targetPosition: 20 }], subjectPositions: [10], targetPositions: [20] }
-      },
-      capturedPiecePosition: () => null,
-      afterBoard: () => ({})
-    }
+      }
+    })
     const plan = attackPlan({
       relationParams: { subject: 'allied', target: 'enemy', operator: 'attack' },
       comparisonDescriptors: [{ side: 'subject', source: 'prior_board_state', comparator: 'less_than' }]
@@ -130,16 +131,12 @@ describe('buildAggregatedResult', () => {
 
   it('also evaluates the prior board for a census plan that compares against PBS', () => {
     const positionCalls = []
-    const analysis = {
-      relationalResult: () => ({ pairs: [], subjectPositions: [], targetPositions: [] }),
-      capturedPiecePosition: () => null,
-      positionFilteredPositions: () => [],
+    const analysis = fakeAnalysis({
       relationalActorPositions: ({ boardScope }) => {
         positionCalls.push(boardScope)
         return boardScope === 'prior' ? [4, 5, 6] : [4, 5]
-      },
-      afterBoard: () => ({})
-    }
+      }
+    })
     const plan = censusPlan({
       comparisonDescriptors: [{ side: 'subject', source: 'prior_board_state', comparator: 'less_than' }]
     })
@@ -191,12 +188,13 @@ describe('buildAggregatedHighlights', () => {
     expect(highlights.after.roles).toEqual({ attacker: [10], targetAttack: [20] })
     expect(highlights.prior.roles).toEqual({ attacker: [10], targetAttack: [20] })
     expect(highlights.prior.movedStartPosition).toBe(12)
-    expect(highlights.after.movedStartPosition).toBe(null)
+    expect(highlights.after.movedStartPosition).toBe(12)
     expect(highlights.prior.movedEndPosition).toBe(28)
     expect(highlights.after.movedEndPosition).toBe(28)
   })
 
-  it('tags defend, shield (with its external attacker walked on the after board), and adjacent under their roles', () => {
+  it('tags defend, shield (with its external attacker walked once on the after board and reused for prior), and adjacent under their roles', () => {
+    shieldAttackerPositions.mockClear()
     const shieldPairs = [{ subjectPosition: 13, targetPosition: 23 }]
     const priorBoard = { id: 'prior' }
     const afterBoard = { id: 'after' }
@@ -218,8 +216,9 @@ describe('buildAggregatedHighlights', () => {
     expect(highlights.after.roles.attacker).toEqual([99]) // mocked shieldAttackerPositions
     expect(highlights.after.roles.subject).toEqual([14])
     expect(highlights.after.roles.targetGeneric).toEqual([24])
+    expect(highlights.prior.roles.attacker).toEqual([99]) // non-PBS reuses the after attacker
+    expect(shieldAttackerPositions).toHaveBeenCalledTimes(1)
     expect(shieldAttackerPositions).toHaveBeenCalledWith(shieldPairs, afterBoard)
-    expect(highlights.prior.roles.attacker).toBeUndefined() // no priorPairs → no prior attacker walk
   })
 
   it('uses prior eval for relational prior roles when the plan compares against the prior board', () => {
@@ -303,12 +302,13 @@ describe('buildAggregatedHighlights', () => {
     expect(highlights.after.roles.targetDefend).toEqual([30])
   })
 
-  it('produces no roles when there are no contributions, but keeps the moved markers', () => {
+  it('produces no roles when there are no contributions, but keeps the moved markers on both boards', () => {
     const highlights = build([], [])
     expect(highlights.prior.roles).toEqual({})
     expect(highlights.after.roles).toEqual({})
     expect(highlights.prior.movedStartPosition).toBe(12)
     expect(highlights.prior.movedEndPosition).toBe(28)
+    expect(highlights.after.movedStartPosition).toBe(12)
     expect(highlights.after.movedEndPosition).toBe(28)
   })
 })

--- a/app/javascript/editorV2/panels/condition_preview/shared/__tests__/move_collection.test.js
+++ b/app/javascript/editorV2/panels/condition_preview/shared/__tests__/move_collection.test.js
@@ -83,7 +83,8 @@ describe('buildAggregatedResult', () => {
     expect(result.contributions[0]).toEqual({
       kind: 'census',
       subjectActor: 'allied',
-      subjectPositions: [12, 20]
+      subjectPositions: [12, 20],
+      positionAxis: 'rank'
     })
   })
 
@@ -98,6 +99,55 @@ describe('buildAggregatedResult', () => {
   it('returns null when a relational plan has zero pairs and no descriptor allows zero', () => {
     const analysis = fakeAnalysis()
     expect(buildAggregatedResult({ plans: [attackPlan()] }, analysis)).toBe(null)
+  })
+
+  it('also evaluates the prior board for a relational plan that compares against PBS', () => {
+    const relationalCalls = []
+    const analysis = {
+      relationalResult: (params) => {
+        relationalCalls.push(params)
+        if (params.boardScope === 'prior') {
+          return { pairs: [{ subjectPosition: 10, targetPosition: 20 }, { subjectPosition: 11, targetPosition: 21 }],
+                   subjectPositions: [10, 11], targetPositions: [20, 21] }
+        }
+        return { pairs: [{ subjectPosition: 10, targetPosition: 20 }], subjectPositions: [10], targetPositions: [20] }
+      },
+      capturedPiecePosition: () => null,
+      afterBoard: () => ({})
+    }
+    const plan = attackPlan({
+      relationParams: { subject: 'allied', target: 'enemy', operator: 'attack' },
+      comparisonDescriptors: [{ side: 'subject', source: 'prior_board_state', comparator: 'less_than' }]
+    })
+
+    const result = buildAggregatedResult({ plans: [plan] }, analysis)
+
+    expect(relationalCalls.some(c => c.boardScope === 'prior')).toBe(true)
+    expect(result.contributions[0].priorSubjectPositions).toEqual([10, 11])
+    expect(result.contributions[0].priorTargetPositions).toEqual([20, 21])
+    expect(result.contributions[0].priorPairs).toHaveLength(2)
+  })
+
+  it('also evaluates the prior board for a census plan that compares against PBS', () => {
+    const positionCalls = []
+    const analysis = {
+      relationalResult: () => ({ pairs: [], subjectPositions: [], targetPositions: [] }),
+      capturedPiecePosition: () => null,
+      positionFilteredPositions: () => [],
+      relationalActorPositions: ({ boardScope }) => {
+        positionCalls.push(boardScope)
+        return boardScope === 'prior' ? [4, 5, 6] : [4, 5]
+      },
+      afterBoard: () => ({})
+    }
+    const plan = censusPlan({
+      comparisonDescriptors: [{ side: 'subject', source: 'prior_board_state', comparator: 'less_than' }]
+    })
+
+    const result = buildAggregatedResult({ plans: [plan] }, analysis)
+
+    expect(positionCalls).toContain('prior')
+    expect(result.contributions[0].priorSubjectPositions).toEqual([4, 5, 6])
   })
 
   it('synthesizes a single-pair same_piece contribution at the captured square', () => {
@@ -124,7 +174,8 @@ describe('buildAggregatedHighlights', () => {
       { plans },
       moveObject,
       { subjectPositions: [], targetPositions: [], pairs: [], contributions },
-      {} // priorBoard — shieldAttackerPositions is mocked
+      {}, // priorBoard — shieldAttackerPositions is mocked
+      {}  // afterBoard — same
     )
   }
 
@@ -145,9 +196,10 @@ describe('buildAggregatedHighlights', () => {
     expect(highlights.after.movedEndPosition).toBe(28)
   })
 
-  it('tags defend, shield (with its external attacker), and adjacent under their roles', () => {
+  it('tags defend, shield (with its external attacker walked on the after board), and adjacent under their roles', () => {
     const shieldPairs = [{ subjectPosition: 13, targetPosition: 23 }]
-    const priorBoard = {}
+    const priorBoard = { id: 'prior' }
+    const afterBoard = { id: 'after' }
     const highlights = buildAggregatedHighlights(
       { plans: [attackPlan(), attackPlan(), attackPlan()] },
       moveObject,
@@ -156,7 +208,8 @@ describe('buildAggregatedHighlights', () => {
         { operator: 'shield', subjectActor: 'allied', targetActor: 'enemy', subjectPositions: [13], targetPositions: [23], pairs: shieldPairs },
         { operator: 'adjacent', subjectActor: 'allied', targetActor: 'enemy', subjectPositions: [14], targetPositions: [24], pairs: [] }
       ] },
-      priorBoard
+      priorBoard,
+      afterBoard
     )
     expect(highlights.after.roles.defender).toEqual([11])
     expect(highlights.after.roles.targetDefend).toEqual([21])
@@ -165,7 +218,39 @@ describe('buildAggregatedHighlights', () => {
     expect(highlights.after.roles.attacker).toEqual([99]) // mocked shieldAttackerPositions
     expect(highlights.after.roles.subject).toEqual([14])
     expect(highlights.after.roles.targetGeneric).toEqual([24])
-    expect(shieldAttackerPositions).toHaveBeenCalledWith(shieldPairs, priorBoard)
+    expect(shieldAttackerPositions).toHaveBeenCalledWith(shieldPairs, afterBoard)
+    expect(highlights.prior.roles.attacker).toBeUndefined() // no priorPairs → no prior attacker walk
+  })
+
+  it('uses prior eval for relational prior roles when the plan compares against the prior board', () => {
+    shieldAttackerPositions.mockClear()
+    const priorPairs = [{ subjectPosition: 13, targetPosition: 23 }]
+    const priorBoard = { id: 'prior' }
+    const afterBoard = { id: 'after' }
+    const highlights = buildAggregatedHighlights(
+      { plans: [attackPlan({ operator: 'shield' })] },
+      moveObject,
+      { subjectPositions: [], targetPositions: [], pairs: [], contributions: [{
+        operator: 'shield', subjectActor: 'allied', targetActor: 'enemy',
+        subjectPositions: [13], targetPositions: [23], pairs: [],
+        priorSubjectPositions: [13, 50], priorTargetPositions: [23, 60], priorPairs
+      }] },
+      priorBoard,
+      afterBoard
+    )
+    expect(highlights.prior.roles.shield).toEqual([13, 50])
+    expect(highlights.prior.roles.targetShield).toEqual([23, 60])
+    expect(highlights.prior.roles.attacker).toEqual([99]) // mocked
+    expect(shieldAttackerPositions).toHaveBeenCalledWith(priorPairs, priorBoard)
+  })
+
+  it('uses priorSubjectPositions for census prior roles when present (region-filtered)', () => {
+    const highlights = build(
+      [censusPlan({ positionAxis: 'rank' })],
+      [{ kind: 'census', subjectActor: 'allied', subjectPositions: [4, 5], priorSubjectPositions: [4, 5, 6], positionAxis: 'rank' }]
+    )
+    expect(highlights.prior.roles.positionSubject).toEqual([4, 5, 6])
+    expect(highlights.after.roles.positionSubject).toEqual([4, 5])
   })
 
   it('rewrites the prior position to startPosition when subject/target is moved_piece', () => {
@@ -186,13 +271,22 @@ describe('buildAggregatedHighlights', () => {
     expect(highlights.after.roles.targetAttack).toEqual([28])
   })
 
-  it('tags census subjects under positionSubject', () => {
+  it('tags region-filtered census subjects under positionSubject', () => {
     const highlights = build(
-      [censusPlan()],
-      [{ kind: 'census', subjectActor: 'allied', subjectPositions: [4, 5] }]
+      [censusPlan({ positionAxis: 'rank' })],
+      [{ kind: 'census', subjectActor: 'allied', subjectPositions: [4, 5], positionAxis: 'rank' }]
     )
     expect(highlights.prior.roles.positionSubject).toEqual([4, 5])
     expect(highlights.after.roles.positionSubject).toEqual([4, 5])
+  })
+
+  it('skips highlighting for whole-board census subjects (no positionAxis)', () => {
+    const highlights = build(
+      [censusPlan()],
+      [{ kind: 'census', subjectActor: 'allied', subjectPositions: [4, 5], positionAxis: null }]
+    )
+    expect(highlights.prior.roles.positionSubject).toBeUndefined()
+    expect(highlights.after.roles.positionSubject).toBeUndefined()
   })
 
   it('aggregates multiple contributions in a chain so one piece can carry multiple roles', () => {

--- a/app/javascript/editorV2/panels/condition_preview/shared/enrichment.js
+++ b/app/javascript/editorV2/panels/condition_preview/shared/enrichment.js
@@ -143,7 +143,7 @@ function deriveVerifiedExample({ combinedPlan, priorBoard, moveObject, baseExamp
     afterBoard,
     moveObject: recomputedMoveObject,
     result: aggregatedResult,
-    highlights: buildAggregatedHighlights(combinedPlan, recomputedMoveObject, aggregatedResult, priorBoard),
+    highlights: buildAggregatedHighlights(combinedPlan, recomputedMoveObject, aggregatedResult, priorBoard, afterBoard),
     variantType: movedPieceInRelation ? 'involved' : 'separate',
     geometryKey: `${baseExample.geometryKey}:enriched:${suffix}`,
     movedPieceInRelation,

--- a/app/javascript/editorV2/panels/condition_preview/shared/example_factory.js
+++ b/app/javascript/editorV2/panels/condition_preview/shared/example_factory.js
@@ -17,7 +17,7 @@ export class ExampleFactory {
     if (!aggregatedResult) { return null }
 
     const highlights = buildAggregatedHighlights(
-      this.combinedPlan, candidate.moveObject, aggregatedResult, candidate.priorBoard
+      this.combinedPlan, candidate.moveObject, aggregatedResult, candidate.priorBoard, candidate.afterBoard
     )
     const movedPieceInRelation = (
       aggregatedResult.subjectPositions.includes(candidate.moveObject.endPosition) ||

--- a/app/javascript/editorV2/panels/condition_preview/shared/highlight_roles.js
+++ b/app/javascript/editorV2/panels/condition_preview/shared/highlight_roles.js
@@ -1,7 +1,7 @@
 function role(varName, label) {
   return {
     color: `rgb(var(${varName}))`,
-    tint:  `rgb(var(${varName}) / 25%)`,
+    tint:  `rgb(var(${varName}) / 35%)`,
     label
   }
 }

--- a/app/javascript/editorV2/panels/condition_preview/shared/move_collection.js
+++ b/app/javascript/editorV2/panels/condition_preview/shared/move_collection.js
@@ -75,7 +75,7 @@ function applyCombinatorialFilter(plan, result, analysis) {
   }
 }
 
-function censusSubjectPositions(plan, analysis) {
+function censusSubjectPositions(plan, analysis, boardScope = 'after') {
   if (plan.positionAxis) {
     return analysis.positionFilteredPositions({
       actor: plan.subject,
@@ -83,14 +83,20 @@ function censusSubjectPositions(plan, analysis) {
       filterMode: plan.subjectFilterMode,
       positionAxis: plan.positionAxis,
       positionComparator: plan.positionComparator,
-      positionTarget: plan.positionTarget
+      positionTarget: plan.positionTarget,
+      boardScope
     })
   }
   return analysis.relationalActorPositions({
     actor: plan.subject,
     filter: plan.subjectFilter,
-    filterMode: plan.subjectFilterMode
+    filterMode: plan.subjectFilterMode,
+    boardScope
   })
+}
+
+function comparesAgainstPriorBoard(plan) {
+  return (plan.comparisonDescriptors ?? []).some(d => d.source === PRIOR_BOARD_COMPARISON_SOURCE)
 }
 
 export function buildAggregatedResult(combinedPlan, analysis) {
@@ -126,23 +132,35 @@ export function buildAggregatedResult(combinedPlan, analysis) {
       subjectPositions = [...subjectPositions, ...result.subjectPositions]
       targetPositions = [...targetPositions, ...result.targetPositions]
       pairs = [...pairs, ...result.pairs]
-      contributions.push({
+      const contribution = {
         operator: plan.operator,
         subjectActor: plan.subject,
         targetActor: plan.target,
         subjectPositions: result.subjectPositions,
         targetPositions: result.targetPositions,
         pairs: result.pairs
-      })
+      }
+      if (comparesAgainstPriorBoard(plan)) {
+        const priorRaw = analysis.relationalResult({ ...plan.relationParams, boardScope: 'prior' })
+        contribution.priorSubjectPositions = priorRaw.subjectPositions
+        contribution.priorTargetPositions = priorRaw.targetPositions
+        contribution.priorPairs = priorRaw.pairs
+      }
+      contributions.push(contribution)
     } else if (plan.kind === 'census') {
       // Kept out of the subjectPositions union so movedPieceInRelation /
       // variantType (in example_factory + enrichment) stays relational-only.
       const positions = censusSubjectPositions(plan, analysis)
-      contributions.push({
+      const contribution = {
         kind: 'census',
         subjectActor: plan.subject,
-        subjectPositions: positions
-      })
+        subjectPositions: positions,
+        positionAxis: plan.positionAxis || null
+      }
+      if (comparesAgainstPriorBoard(plan)) {
+        contribution.priorSubjectPositions = censusSubjectPositions(plan, analysis, 'prior')
+      }
+      contributions.push(contribution)
     }
   }
 
@@ -168,7 +186,7 @@ function rolesToArrays(map) {
   return out
 }
 
-export function buildAggregatedHighlights(combinedPlan, moveObject, aggregatedResult, priorBoard) {
+export function buildAggregatedHighlights(combinedPlan, moveObject, aggregatedResult, priorBoard, afterBoard) {
   const start = moveObject.startPosition
   const end = moveObject.endPosition
   const prior = {}
@@ -176,7 +194,9 @@ export function buildAggregatedHighlights(combinedPlan, moveObject, aggregatedRe
 
   for (const c of aggregatedResult.contributions) {
     if (c.kind === 'census') {
-      const priorPos = c.subjectActor === 'moved_piece' ? [start] : c.subjectPositions
+      if (!c.positionAxis) { continue }
+      const priorPos = c.priorSubjectPositions
+        ?? (c.subjectActor === 'moved_piece' ? [start] : c.subjectPositions)
       addRole(prior, 'positionSubject', priorPos)
       addRole(after, 'positionSubject', c.subjectPositions)
       continue
@@ -185,15 +205,21 @@ export function buildAggregatedHighlights(combinedPlan, moveObject, aggregatedRe
     const subjectRole = relationSubjectRole(c.operator)
     const targetRole = relationTargetRole(c.operator)
 
-    addRole(prior, subjectRole, c.subjectActor === 'moved_piece' ? [start] : c.subjectPositions)
     addRole(after, subjectRole, c.subjectPositions)
-    addRole(prior, targetRole, c.targetActor === 'moved_piece' ? [start] : c.targetPositions)
     addRole(after, targetRole, c.targetPositions)
-
     if (c.operator === 'shield' && c.pairs.length > 0) {
-      const attackers = shieldAttackerPositions(c.pairs, priorBoard)
-      addRole(prior, 'attacker', attackers)
-      addRole(after, 'attacker', attackers)
+      addRole(after, 'attacker', shieldAttackerPositions(c.pairs, afterBoard))
+    }
+
+    if (c.priorPairs !== undefined) {
+      addRole(prior, subjectRole, c.priorSubjectPositions)
+      addRole(prior, targetRole, c.priorTargetPositions)
+      if (c.operator === 'shield' && c.priorPairs.length > 0) {
+        addRole(prior, 'attacker', shieldAttackerPositions(c.priorPairs, priorBoard))
+      }
+    } else {
+      addRole(prior, subjectRole, c.subjectActor === 'moved_piece' ? [start] : c.subjectPositions)
+      addRole(prior, targetRole, c.targetActor === 'moved_piece' ? [start] : c.targetPositions)
     }
   }
 

--- a/app/javascript/editorV2/panels/condition_preview/shared/move_collection.js
+++ b/app/javascript/editorV2/panels/condition_preview/shared/move_collection.js
@@ -141,6 +141,8 @@ export function buildAggregatedResult(combinedPlan, analysis) {
         pairs: result.pairs
       }
       if (comparesAgainstPriorBoard(plan)) {
+        // Unfiltered on purpose — we want the literal prior relationships, not
+        // the combinatorial-filtered view (which is an after-board projection).
         const priorRaw = analysis.relationalResult({ ...plan.relationParams, boardScope: 'prior' })
         contribution.priorSubjectPositions = priorRaw.subjectPositions
         contribution.priorTargetPositions = priorRaw.targetPositions
@@ -155,7 +157,7 @@ export function buildAggregatedResult(combinedPlan, analysis) {
         kind: 'census',
         subjectActor: plan.subject,
         subjectPositions: positions,
-        positionAxis: plan.positionAxis || null
+        positionAxis: plan.positionAxis ?? null
       }
       if (comparesAgainstPriorBoard(plan)) {
         contribution.priorSubjectPositions = censusSubjectPositions(plan, analysis, 'prior')
@@ -207,11 +209,13 @@ export function buildAggregatedHighlights(combinedPlan, moveObject, aggregatedRe
 
     addRole(after, subjectRole, c.subjectPositions)
     addRole(after, targetRole, c.targetPositions)
+    let afterAttackers = null
     if (c.operator === 'shield' && c.pairs.length > 0) {
-      addRole(after, 'attacker', shieldAttackerPositions(c.pairs, afterBoard))
+      afterAttackers = shieldAttackerPositions(c.pairs, afterBoard)
+      addRole(after, 'attacker', afterAttackers)
     }
 
-    if (c.priorPairs !== undefined) {
+    if (c.priorPairs) {
       addRole(prior, subjectRole, c.priorSubjectPositions)
       addRole(prior, targetRole, c.priorTargetPositions)
       if (c.operator === 'shield' && c.priorPairs.length > 0) {
@@ -220,11 +224,13 @@ export function buildAggregatedHighlights(combinedPlan, moveObject, aggregatedRe
     } else {
       addRole(prior, subjectRole, c.subjectActor === 'moved_piece' ? [start] : c.subjectPositions)
       addRole(prior, targetRole, c.targetActor === 'moved_piece' ? [start] : c.targetPositions)
+      // Non-PBS shield: relationship holds on both boards, so reuse the after attacker.
+      if (afterAttackers) { addRole(prior, 'attacker', afterAttackers) }
     }
   }
 
   return {
     prior: { roles: rolesToArrays(prior), movedStartPosition: start, movedEndPosition: end },
-    after: { roles: rolesToArrays(after), movedStartPosition: null, movedEndPosition: end }
+    after: { roles: rolesToArrays(after), movedStartPosition: start, movedEndPosition: end }
   }
 }


### PR DESCRIPTION
⏺ ## Board preview

  - **PBS-aware highlights**: relational and census plans whose comparison source is `prior_board_state` get a real prior-board eval. The prior view now shows what *disappeared* — e.g. "allied any < PBS attack
  enemy any" reveals the attack that went away because the moved piece was the attacker.
  - **Shield attacker walks the matching board**: pre-existing bug — the after view was walking the prior board for the external attacker. Now walks `afterBoard` for after; for PBS shield, walks `priorPairs` on
  `priorBoard` for prior; for non-PBS shield, the relationship is identical on both boards so the after attacker is reused for prior (one walk, both swatches).
  - **Whole-board census subjects unhighlighted**: only region-filtered census (`positionAxis` set) adds a `positionSubject` role. Whole-board census would have highlighted every matching piece, which is noise.
  - **Moved-from marker persists on the after board**: the moved-from swatch stays visible through the after phase so the move's origin remains legible after the piece has arrived.

  ## Tile rendering

  - `decorateTile` uses `background-image` (linear-gradient) instead of the `background` shorthand so the wood color from `.mini-board__tile--light/dark` stays underneath and the role wash alpha-blends over it.
  - Tint alpha bumped from 25% to 35% (one-line change in the `role()` helper since #225 centralized it).

  ## Tests

  `buildAggregatedHighlights` signature gains `afterBoard`; both callers (`example_factory.js`, `enrichment.js`) updated. `move_collection.test.js` adds four new cases (PBS-relational eval, PBS-census eval, prior
  eval drives prior roles, whole-board census skip), updates the shield test to assert the after-board walk and the prior reuse, and pins `after.movedStartPosition` to the start square. `fakeAnalysis` extended to
  accept function-shape queries so the PBS-eval tests use the helper.

  Known limitation: prior-board highlights may briefly show a marker at the moved-to square in some edge cases; not currently surfaced as confusing