### PR TITLE
Main  elo

### DIFF
--- a/app/assets/stylesheets/index_pages.css
+++ b/app/assets/stylesheets/index_pages.css
@@ -140,7 +140,7 @@
   color: var(--text-primary);
 }
 
-.index-pagination span[aria-current] {
+.index-pagination [aria-current] {
   background: #A855F7;
   color: #1E1E1E;
   border-color: #A855F7;

--- a/app/controllers/matches/bot_vs_bot_controller.rb
+++ b/app/controllers/matches/bot_vs_bot_controller.rb
@@ -1,4 +1,6 @@
 class Matches::BotVsBotController < ApplicationController
+  OPPONENT_PAGE_SIZE = 12
+
   before_action :authenticate_registered_or_guest_user!, only: [:create]
 
   def new
@@ -31,6 +33,7 @@ class Matches::BotVsBotController < ApplicationController
     @all_opponent_bots = creation.all_opponent_bots
     @selected_own_bot_id = creation.selected_own_bot_id
     @selected_opponent_bot_id = creation.selected_opponent_bot_id
+    @opponent_landing_page = creation.opponent_page(per_page: OPPONENT_PAGE_SIZE)
   end
 
   def paginate_bot_lists
@@ -50,11 +53,17 @@ class Matches::BotVsBotController < ApplicationController
     )
     @opponent_bots_pagy, @opponent_bots = pagy(
       @all_opponent_bots.with_name(params[:opponent_name]),
-      limit: 8,
+      limit: OPPONENT_PAGE_SIZE,
       page_param: :opponent_page,
-      page: params[:opponent_page],
+      page: params[:opponent_page] || default_opponent_page,
       params: shared_params.merge(own_bot_page: params[:own_bot_page])
     )
+  end
+
+  def default_opponent_page
+    return if params[:opponent_name].present?
+
+    @opponent_landing_page
   end
 
   def setup_params

--- a/app/controllers/matches/bot_vs_bot_controller.rb
+++ b/app/controllers/matches/bot_vs_bot_controller.rb
@@ -47,14 +47,14 @@ class Matches::BotVsBotController < ApplicationController
     @own_bots_pagy, @own_bots = pagy(
       @own_bots.with_name(params[:own_bot_name]),
       limit: 8,
-      page_param: :own_bot_page,
+      page_key: 'own_bot_page',
       page: params[:own_bot_page],
       params: shared_params.merge(opponent_page: params[:opponent_page])
     )
     @opponent_bots_pagy, @opponent_bots = pagy(
       @all_opponent_bots.with_name(params[:opponent_name]),
       limit: OPPONENT_PAGE_SIZE,
-      page_param: :opponent_page,
+      page_key: 'opponent_page',
       page: params[:opponent_page] || default_opponent_page,
       params: shared_params.merge(own_bot_page: params[:own_bot_page])
     )

--- a/app/javascript/controllers/match_setup_controller.js
+++ b/app/javascript/controllers/match_setup_controller.js
@@ -1,7 +1,12 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
-  static targets = ["staleBotConfirmation", "form"]
+  static targets = ["staleBotConfirmation", "form", "opponentForm", "ownBotIdField"]
+
+  ownBotChosen(event) {
+    this.ownBotIdFieldTargets.forEach((field) => { field.value = event.target.value })
+    this.opponentFormTarget.requestSubmit()
+  }
 
   confirmStaleCompile(event) {
     if (this.staleBotConfirmationTarget.value === 'compile') { return }

--- a/app/jobs/compute_match_job.rb
+++ b/app/jobs/compute_match_job.rb
@@ -55,6 +55,7 @@ class ComputeMatchJob < ApplicationJob
         profile_data: result_payload['profile']
       )
 
+      apply_ratings(match)
       match.tournament&.enqueue_next_match!
     end
   rescue StandardError => error
@@ -64,6 +65,12 @@ class ComputeMatchJob < ApplicationJob
   end
 
   private
+
+  def apply_ratings(match)
+    Ratings::ApplyMatchResult.new(match).call
+  rescue StandardError => error
+    Rails.logger.error("Rating update failed for match #{match.id}: #{error.message}")
+  end
 
   def start_match!(match)
     expected_status = match.tournament.present? ? Match.statuses[:queued] : Match.statuses[:pending]

--- a/app/models/bot.rb
+++ b/app/models/bot.rb
@@ -2,16 +2,22 @@
 #
 # Table name: bots
 #
-#  id          :bigint           not null, primary key
-#  commands    :json
-#  created_at :datetime         not null
-#  updated_at :datetime         not null
-#  user_id    :bigint           not null
-#  name       :string
-#  description :text
+#  id                     :bigint           not null, primary key
+#  user_id                :bigint
+#  commands               :json
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  name                   :string
+#  description            :text
+#  compiled_program       :json
+#  compiled_program_stale :boolean          default(TRUE), not null
+#  rating                 :float            default(1000.0), not null
+#  rating_deviation       :float            default(350.0), not null
+#  rating_volatility      :float            default(0.06), not null
 #
 class Bot < ApplicationRecord
   SYSTEM_BOT_NAME = 'Seed Bot'
+  RECOMPILE_RD_BUMP = 250.0
 
   def self.system_bot
     find_by(name: SYSTEM_BOT_NAME)
@@ -52,10 +58,10 @@ class Bot < ApplicationRecord
   end
 
   def compile_program!
-    update_columns(
-      compiled_program: BotCompiler.new(self).compile,
-      compiled_program_stale: false
-    )
+    new_program = BotCompiler.new(self).compile
+    changed = compiled_program.present? && new_program.as_json != compiled_program
+    update_columns(compiled_program: new_program, compiled_program_stale: false)
+    inflate_deviation_for_recompile! if changed
   end
 
   def mark_compiled_program_stale!
@@ -70,7 +76,19 @@ class Bot < ApplicationRecord
     compiled_program.deep_dup
   end
 
+  def rating_state
+    Glicko2::Rating.new(rating: rating, deviation: rating_deviation, volatility: rating_volatility)
+  end
+
+  def apply_rating!(state)
+    update_columns(rating: state.rating, rating_deviation: state.deviation, rating_volatility: state.volatility)
+  end
+
   private
+
+  def inflate_deviation_for_recompile!
+    with_lock { apply_rating!(rating_state.with_inflated_deviation(RECOMPILE_RD_BUMP)) }
+  end
 
   def destroy_open_tournament_entries
     tournament_entries

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -2,23 +2,32 @@
  #
  # Table name: matches
  #
- #  id                :bigint           not null, primary key
- #  allowed_to_move   :string           default("W"), not null
- #  captured_pieces   :json
- #  lay_out           :json
- #  movement_notation :json
- #  previous_layouts  :json
- #  error_message     :text
- #  profile_data      :json
- #  result            :integer
- #  status            :integer          default("pending"), not null
- #  created_at        :datetime         not null
- #  updated_at        :datetime         not null
- #  creator_id        :bigint
- #  white_player_type :string
- #  white_player_id   :bigint
- #  black_player_type :string
- #  black_player_id   :bigint
+ #  id                               :bigint           not null, primary key
+ #  lay_out                          :json
+ #  captured_pieces                  :json
+ #  allowed_to_move                  :string           default("W"), not null
+ #  movement_notation                :json
+ #  previous_layouts                 :json
+ #  created_at                       :datetime         not null
+ #  updated_at                       :datetime         not null
+ #  creator_id                       :bigint
+ #  white_player_type                :string
+ #  white_player_id                  :bigint
+ #  black_player_type                :string
+ #  black_player_id                  :bigint
+ #  status                           :integer          default(0), not null
+ #  result                           :integer
+ #  error_message                    :text
+ #  white_compiled_program_snapshot  :json
+ #  black_compiled_program_snapshot  :json
+ #  tournament_id                    :bigint
+ #  profile_data                     :json
+ #  white_tournament_entry_id        :bigint
+ #  black_tournament_entry_id        :bigint
+ #  white_rating_before              :float
+ #  white_rating_after               :float
+ #  black_rating_before              :float
+ #  black_rating_after               :float
  #
 class Match < ApplicationRecord
   attribute :captured_pieces, default: []

--- a/app/services/glicko2.rb
+++ b/app/services/glicko2.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Glicko2
+  SCALE = 173.7178
+  ANCHOR = 1500.0
+  TAU = 0.5
+  CONVERGENCE = 1e-6
+  DEFAULT_DEVIATION = 350.0
+  DEFAULT_VOLATILITY = 0.06
+end

--- a/app/services/glicko2/rating.rb
+++ b/app/services/glicko2/rating.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Glicko2
+  class Rating
+    attr_reader :rating, :deviation, :volatility
+
+    def initialize(rating:, deviation:, volatility: DEFAULT_VOLATILITY)
+      @rating = rating
+      @deviation = deviation
+      @volatility = volatility
+    end
+
+    def with_inflated_deviation(bump)
+      self.class.new(
+        rating: rating,
+        deviation: [Math.sqrt(deviation**2 + bump**2), DEFAULT_DEVIATION].min,
+        volatility: volatility
+      )
+    end
+  end
+end

--- a/app/services/glicko2/result.rb
+++ b/app/services/glicko2/result.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module Glicko2
+  class Result
+    attr_reader :opponent, :score
+
+    def initialize(opponent:, score:)
+      @opponent = opponent
+      @score = score
+    end
+  end
+end

--- a/app/services/glicko2/update.rb
+++ b/app/services/glicko2/update.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module Glicko2
+  class Update
+    def initialize(rating:, results:)
+      @rating = rating
+      @results = results
+    end
+
+    def result
+      return inactive_rating if @results.empty?
+
+      new_phi = 1.0 / Math.sqrt(1.0 / phi_star**2 + 1.0 / variance)
+      new_mu = mu + new_phi**2 * results_weight_sum
+
+      Rating.new(
+        rating: ANCHOR + SCALE * new_mu,
+        deviation: SCALE * new_phi,
+        volatility: new_volatility
+      )
+    end
+
+    private
+
+    def mu
+      @mu ||= (@rating.rating - ANCHOR) / SCALE
+    end
+
+    def phi
+      @phi ||= @rating.deviation / SCALE
+    end
+
+    def opponents
+      @opponents ||= @results.map do |game|
+        opponent_mu = (game.opponent.rating - ANCHOR) / SCALE
+        opponent_phi = game.opponent.deviation / SCALE
+        weight = 1.0 / Math.sqrt(1.0 + 3.0 * opponent_phi**2 / Math::PI**2)
+        expected = 1.0 / (1.0 + Math.exp(-weight * (mu - opponent_mu)))
+        { weight: weight, expected: expected, score: game.score }
+      end
+    end
+
+    def variance
+      @variance ||= 1.0 / opponents.sum { |o| o[:weight]**2 * o[:expected] * (1.0 - o[:expected]) }
+    end
+
+    def results_weight_sum
+      @results_weight_sum ||= opponents.sum { |o| o[:weight] * (o[:score] - o[:expected]) }
+    end
+
+    def delta
+      @delta ||= variance * results_weight_sum
+    end
+
+    def new_volatility
+      @new_volatility ||= VolatilitySolver.new(
+        sigma: @rating.volatility, phi: phi, variance: variance, delta: delta
+      ).solve
+    end
+
+    def phi_star
+      @phi_star ||= Math.sqrt(phi**2 + new_volatility**2)
+    end
+
+    def inactive_rating
+      Rating.new(
+        rating: @rating.rating,
+        deviation: SCALE * Math.sqrt(phi**2 + @rating.volatility**2),
+        volatility: @rating.volatility
+      )
+    end
+  end
+end

--- a/app/services/glicko2/volatility_solver.rb
+++ b/app/services/glicko2/volatility_solver.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Glicko2
+  class VolatilitySolver
+    def initialize(sigma:, phi:, variance:, delta:)
+      @sigma = sigma
+      @phi = phi
+      @variance = variance
+      @delta = delta
+    end
+
+    def solve
+      bound_a = a
+      bound_b = initial_bound_b
+      f_a = f(bound_a)
+      f_b = f(bound_b)
+
+      while (bound_b - bound_a).abs > CONVERGENCE
+        estimate = bound_a + (bound_a - bound_b) * f_a / (f_b - f_a)
+        f_estimate = f(estimate)
+        if f_estimate * f_b <= 0
+          bound_a = bound_b
+          f_a = f_b
+        else
+          f_a /= 2.0
+        end
+        bound_b = estimate
+        f_b = f_estimate
+      end
+
+      Math.exp(bound_a / 2.0)
+    end
+
+    private
+
+    def a
+      @a ||= Math.log(@sigma**2)
+    end
+
+    def initial_bound_b
+      return Math.log(@delta**2 - @phi**2 - @variance) if @delta**2 > @phi**2 + @variance
+
+      k = 1
+      k += 1 while f(a - k * TAU).negative?
+      a - k * TAU
+    end
+
+    def f(x)
+      ex = Math.exp(x)
+      ((ex * (@delta**2 - @phi**2 - @variance - ex)) / (2.0 * (@phi**2 + @variance + ex)**2)) -
+        ((x - a) / TAU**2)
+    end
+  end
+end

--- a/app/services/matches/create_bot_vs_bot.rb
+++ b/app/services/matches/create_bot_vs_bot.rb
@@ -48,6 +48,20 @@ class Matches::CreateBotVsBot
     true
   end
 
+  def opponent_offset
+    bot = selected_own_bot
+    return nil unless bot
+
+    all_opponent_bots.where('bots.rating < ?', bot.rating).count
+  end
+
+  def opponent_page(per_page:)
+    offset = opponent_offset
+    return if offset.nil?
+
+    (offset / per_page) + 1
+  end
+
   private
 
   def load_bot_options
@@ -55,10 +69,10 @@ class Matches::CreateBotVsBot
       @own_bots = @user.bots.order(:name)
       @all_opponent_bots = Bot.where(user: @user)
                              .or(Bot.compiled.where.not(user: @user))
-                             .order(:name)
+                             .order(:rating)
     else
       @own_bots = Bot.none
-      @all_opponent_bots = Bot.compiled.order(:name)
+      @all_opponent_bots = Bot.compiled.order(:rating)
     end
   end
 

--- a/app/services/ratings/apply_match_result.rb
+++ b/app/services/ratings/apply_match_result.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module Ratings
+  class ApplyMatchResult
+    SCORES = {
+      'white_win' => [1.0, 0.0],
+      'black_win' => [0.0, 1.0],
+      'stalemate' => [0.5, 0.5],
+      'threefold_repetition' => [0.5, 0.5],
+      'fifty_move_rule' => [0.5, 0.5]
+    }.freeze
+
+    def initialize(match)
+      @match = match
+    end
+
+    def call
+      return false unless eligible?
+
+      white_score, black_score = SCORES.fetch(@match.result)
+      apply(@match.white_player, @match.black_player, white_score, black_score)
+      true
+    end
+
+    private
+
+    def eligible?
+      @match.completed? &&
+        SCORES.key?(@match.result) &&
+        two_distinct_bots? &&
+        versions_current? &&
+        @match.white_rating_after.nil?
+    end
+
+    def two_distinct_bots?
+      @match.white_player_type == 'Bot' &&
+        @match.black_player_type == 'Bot' &&
+        @match.white_player_id != @match.black_player_id
+    end
+
+    def versions_current?
+      played_with_current_program?(:white, @match.white_player) &&
+        played_with_current_program?(:black, @match.black_player)
+    end
+
+    def played_with_current_program?(side, bot)
+      @match.compiled_program_snapshot_for(side) == bot.compiled_program
+    end
+
+    def apply(white, black, white_score, black_score)
+      ActiveRecord::Base.transaction do
+        [white, black].sort_by(&:id).each(&:lock!)
+
+        white_before = white.rating_state
+        black_before = black.rating_state
+        white_after = recomputed(white_before, black_before, white_score)
+        black_after = recomputed(black_before, white_before, black_score)
+
+        white.apply_rating!(white_after)
+        black.apply_rating!(black_after)
+        @match.update_columns(
+          white_rating_before: white_before.rating,
+          white_rating_after: white_after.rating,
+          black_rating_before: black_before.rating,
+          black_rating_after: black_after.rating
+        )
+      end
+    end
+
+    def recomputed(rating, opponent, score)
+      Glicko2::Update.new(
+        rating: rating,
+        results: [Glicko2::Result.new(opponent: opponent, score: score)]
+      ).result
+    end
+  end
+end

--- a/app/views/matches/new.html.erb
+++ b/app/views/matches/new.html.erb
@@ -26,7 +26,7 @@
         <h2>Your Bot</h2>
         <%= turbo_frame_tag "own-bots-frame" do %>
           <%= form_with url: new_bot_vs_bot_match_path, method: :get, local: true, class: 'match-setup-filter-form' do |f| %>
-            <%= f.hidden_field :own_bot_id, value: params[:own_bot_id] %>
+            <%= f.hidden_field :own_bot_id, value: params[:own_bot_id], data: { match_setup_target: 'ownBotIdField' } %>
             <%= f.hidden_field :opponent_bot_id, value: params[:opponent_bot_id] %>
             <%= f.hidden_field :opponent_name, value: params[:opponent_name] %>
             <%= f.hidden_field :opponent_page, value: params[:opponent_page] %>
@@ -40,12 +40,14 @@
                     name="match[own_bot_id]"
                     value="<%= bot.id %>"
                     form="match-form"
+                    data-action="change->match-setup#ownBotChosen"
                     <%= 'checked' if @selected_own_bot_id.to_i == bot.id %>
                     data-bot-name="<%= bot.name %>"
                     data-bot-stale="<%= bot.compiled_program_stale? %>"
                     data-bot-owned="true">
                   <span>
                     <strong><%= bot.name %></strong>
+                    <small class="match-bot-rating"><%= bot.rating.round %></small>
                     <small>by <%= bot.user.email %></small>
                     <%= ' (needs recompile)' if bot.compiled_program_stale? %>
                   </span>
@@ -68,8 +70,8 @@
       <div class="match-setup-section">
         <h2>Opponent Bot</h2>
         <%= turbo_frame_tag "opponent-bots-frame" do %>
-          <%= form_with url: new_bot_vs_bot_match_path, method: :get, local: true, class: 'match-setup-filter-form' do |f| %>
-            <%= f.hidden_field :own_bot_id, value: params[:own_bot_id] %>
+          <%= form_with url: new_bot_vs_bot_match_path, method: :get, local: true, class: 'match-setup-filter-form', data: { match_setup_target: 'opponentForm' } do |f| %>
+            <%= f.hidden_field :own_bot_id, value: params[:own_bot_id], data: { match_setup_target: 'ownBotIdField' } %>
             <%= f.hidden_field :opponent_bot_id, value: params[:opponent_bot_id] %>
             <%= f.hidden_field :own_bot_name, value: params[:own_bot_name] %>
             <%= f.hidden_field :own_bot_page, value: params[:own_bot_page] %>
@@ -89,6 +91,7 @@
                     data-bot-owned="<%= current_user && bot.user_id == current_user.id %>">
                   <span>
                     <strong><%= bot.name %></strong>
+                    <small class="match-bot-rating"><%= bot.rating.round %></small>
                     <small>by <%= bot.user.email %></small>
                     <%= ' (needs recompile)' if bot.compiled_program_stale? %>
                   </span>

--- a/bin/render-build.sh
+++ b/bin/render-build.sh
@@ -7,4 +7,4 @@ bundle exec rails assets:precompile
 bundle exec rails assets:clean
 bundle exec rails db:migrate
 bundle exec rails db:seed
-bundle exec rails conditions:census_value_any_to_non_king
+# bundle exec rails conditions:census_value_any_to_non_king

--- a/db/migrate/20260601003341_add_rating_tracking_to_bots_and_matches.rb
+++ b/db/migrate/20260601003341_add_rating_tracking_to_bots_and_matches.rb
@@ -1,0 +1,12 @@
+class AddRatingTrackingToBotsAndMatches < ActiveRecord::Migration[7.1]
+  def change
+    add_column :bots, :rating, :float, null: false, default: 1000.0
+    add_column :bots, :rating_deviation, :float, null: false, default: 350.0
+    add_column :bots, :rating_volatility, :float, null: false, default: 0.06
+
+    add_column :matches, :white_rating_before, :float
+    add_column :matches, :white_rating_after, :float
+    add_column :matches, :black_rating_before, :float
+    add_column :matches, :black_rating_after, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_05_16_120000) do
+ActiveRecord::Schema[7.1].define(version: 2026_06_01_003341) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -23,6 +23,9 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_16_120000) do
     t.text "description"
     t.json "compiled_program"
     t.boolean "compiled_program_stale", default: true, null: false
+    t.float "rating", default: 1000.0, null: false
+    t.float "rating_deviation", default: 350.0, null: false
+    t.float "rating_volatility", default: 0.06, null: false
     t.index ["name"], name: "index_bots_on_name", unique: true
     t.index ["user_id"], name: "index_bots_on_user_id"
   end
@@ -149,6 +152,10 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_16_120000) do
     t.json "profile_data"
     t.bigint "white_tournament_entry_id"
     t.bigint "black_tournament_entry_id"
+    t.float "white_rating_before"
+    t.float "white_rating_after"
+    t.float "black_rating_before"
+    t.float "black_rating_after"
     t.index ["black_player_type", "black_player_id"], name: "index_matches_on_black_player"
     t.index ["black_tournament_entry_id"], name: "index_matches_on_black_tournament_entry_id"
     t.index ["creator_id"], name: "index_matches_on_creator_id"

--- a/spec/jobs/compute_match_job_spec.rb
+++ b/spec/jobs/compute_match_job_spec.rb
@@ -189,5 +189,70 @@ RSpec.describe ComputeMatchJob, type: :job do
       expect(payload.dig('error', 'message')).to eq('Match computation completed without writing a result payload')
       expect(payload.dig('process', 'exit_status')).to eq(0)
     end
+
+    it 'applies rating changes to both bots on a rated result' do
+      match = Match.create!(
+        creator: user,
+        white_player: white_bot,
+        black_player: black_bot,
+        white_compiled_program_snapshot: white_bot.compiled_program,
+        black_compiled_program_snapshot: black_bot.compiled_program,
+        status: :pending,
+        allowed_to_move: 'W',
+        captured_pieces: [],
+        movement_notation: [],
+        previous_layouts: []
+      )
+
+      status = instance_double(Process::Status, success?: true)
+      payload = {
+        result: 'white_win',
+        lay_out: Array.new(64, 'ee'),
+        captured_pieces: [],
+        allowed_to_move: 'B',
+        movement_notation: ['1. e4', 'e5'],
+        previous_layouts: []
+      }
+      allow_any_instance_of(ComputeMatchJob).to receive(:run_match_process).and_return(['', '', status])
+      allow_any_instance_of(ComputeMatchJob).to receive(:read_result_file).and_return(payload.to_json)
+
+      described_class.perform_now(match.id)
+
+      expect(white_bot.reload.rating).to be > 1000.0
+      expect(black_bot.reload.rating).to be < 1000.0
+      expect(match.reload.white_rating_after).to be_present
+    end
+
+    it 'leaves the match completed when rating application raises' do
+      match = Match.create!(
+        creator: user,
+        white_player: white_bot,
+        black_player: black_bot,
+        white_compiled_program_snapshot: white_bot.compiled_program,
+        black_compiled_program_snapshot: black_bot.compiled_program,
+        status: :pending,
+        allowed_to_move: 'W',
+        captured_pieces: [],
+        movement_notation: [],
+        previous_layouts: []
+      )
+
+      status = instance_double(Process::Status, success?: true)
+      payload = {
+        result: 'white_win',
+        lay_out: Array.new(64, 'ee'),
+        captured_pieces: [],
+        allowed_to_move: 'B',
+        movement_notation: ['1. e4', 'e5'],
+        previous_layouts: []
+      }
+      allow_any_instance_of(ComputeMatchJob).to receive(:run_match_process).and_return(['', '', status])
+      allow_any_instance_of(ComputeMatchJob).to receive(:read_result_file).and_return(payload.to_json)
+      allow(Ratings::ApplyMatchResult).to receive(:new).and_raise(StandardError, 'boom')
+
+      described_class.perform_now(match.id)
+
+      expect(match.reload).to be_completed
+    end
   end
 end

--- a/spec/models/bot_spec.rb
+++ b/spec/models/bot_spec.rb
@@ -253,4 +253,39 @@ RSpec.describe Bot, type: :model do
       expect(bot.reload.compiled_program_stale).to be(true)
     end
   end
+
+  describe '#compile_program! rating deviation' do
+    it 'inflates deviation when the compiled program changes' do
+      bot = create(:bot, :compiled)
+      bot.update_columns(rating_deviation: 50.0)
+      allow_any_instance_of(BotCompiler).to receive(:compile).and_return(root: 'root', nodes: { 'n1' => {} })
+
+      expect { bot.compile_program! }.to(change { bot.reload.rating_deviation })
+      expect(bot.rating_deviation).to be > 50.0
+    end
+
+    it 'leaves deviation unchanged when the recompiled program is identical' do
+      bot = create(:bot, :compiled)
+      bot.update_columns(rating_deviation: 50.0)
+      allow_any_instance_of(BotCompiler).to receive(:compile).and_return(root: 'root', nodes: {})
+
+      expect { bot.compile_program! }.not_to(change { bot.reload.rating_deviation })
+    end
+
+    it 'does not change the rating itself on recompile' do
+      bot = create(:bot, :compiled)
+      bot.update_columns(rating: 1200.0, rating_deviation: 50.0)
+      allow_any_instance_of(BotCompiler).to receive(:compile).and_return(root: 'root', nodes: { 'n1' => {} })
+
+      expect { bot.compile_program! }.not_to(change { bot.reload.rating })
+    end
+
+    it 'does not inflate on the first compile' do
+      bot = create(:bot)
+      bot.update_columns(rating_deviation: 50.0)
+      allow_any_instance_of(BotCompiler).to receive(:compile).and_return(root: 'root', nodes: {})
+
+      expect { bot.compile_program! }.not_to(change { bot.reload.rating_deviation })
+    end
+  end
 end

--- a/spec/requests/matches/bot_vs_bot_controller_spec.rb
+++ b/spec/requests/matches/bot_vs_bot_controller_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Matches::BotVsBot opponent pagination', type: :request do
+  let(:user) { create(:user) }
+  let(:opponent_owner) { create(:user) }
+
+  def rated_opponent(rating, name: nil)
+    attrs = { user: opponent_owner }
+    attrs[:name] = name if name
+    bot = create(:bot, :compiled, **attrs)
+    bot.update_columns(rating: rating)
+    bot
+  end
+
+  def shows_opponent?(bot)
+    response.body.include?(%(value="#{bot.id}"))
+  end
+
+  # Own bot at 1000 with 12 opponents below it (so it lands on page 2 of the
+  # 12-per-page opponent list) and one opponent above it.
+  let!(:own_bot) do
+    bot = create(:bot, :compiled, user: user)
+    bot.update_columns(rating: 1000.0)
+    bot
+  end
+  let!(:weakling) { rated_opponent(50, name: 'Weakling') } # lowest — page 1
+  let!(:titan)    { rated_opponent(1500, name: 'Titan') }  # highest — own bot's landing page
+  let!(:fillers)  { Array.new(11) { |i| rated_opponent(100 + i) } }
+
+  before { sign_in user }
+
+  it 'honors an explicit page instead of re-centering on the selected bot' do
+    get new_bot_vs_bot_match_path(own_bot_id: own_bot.id, opponent_page: 1)
+
+    expect(shows_opponent?(weakling)).to be(true)
+    expect(shows_opponent?(titan)).to be(false)
+  end
+
+  it 'lands on the page around the selected bot when no page is given' do
+    get new_bot_vs_bot_match_path(own_bot_id: own_bot.id)
+
+    expect(shows_opponent?(titan)).to be(true)
+    expect(shows_opponent?(weakling)).to be(false)
+    # the opponent nav must key off opponent_page, not pagy's default `page`,
+    # or clicking a page re-centers instead of navigating
+    expect(response.body).to include('opponent_page=1')
+  end
+
+  it 'lets name search reach a bot outside the centered page' do
+    get new_bot_vs_bot_match_path(own_bot_id: own_bot.id, opponent_name: 'Weakling')
+
+    expect(shows_opponent?(weakling)).to be(true)
+  end
+end

--- a/spec/services/glicko2/rating_spec.rb
+++ b/spec/services/glicko2/rating_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Glicko2::Rating do
+  describe '#with_inflated_deviation' do
+    it 'combines the current deviation with the bump in quadrature' do
+      inflated = described_class.new(rating: 1000, deviation: 50, volatility: 0.06)
+                                .with_inflated_deviation(250)
+      expect(inflated.deviation).to be_within(0.01).of(Math.sqrt(50**2 + 250**2))
+    end
+
+    it 'caps the deviation at the default maximum' do
+      inflated = described_class.new(rating: 1000, deviation: 300, volatility: 0.06)
+                                .with_inflated_deviation(250)
+      expect(inflated.deviation).to eq(Glicko2::DEFAULT_DEVIATION)
+    end
+
+    it 'leaves rating and volatility untouched' do
+      inflated = described_class.new(rating: 1200, deviation: 50, volatility: 0.05)
+                                .with_inflated_deviation(250)
+      expect(inflated.rating).to eq(1200)
+      expect(inflated.volatility).to eq(0.05)
+    end
+  end
+end

--- a/spec/services/glicko2/update_spec.rb
+++ b/spec/services/glicko2/update_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Glicko2::Update do
+  def rating(rating:, deviation:, volatility: Glicko2::DEFAULT_VOLATILITY)
+    Glicko2::Rating.new(rating: rating, deviation: deviation, volatility: volatility)
+  end
+
+  describe '#result' do
+    context "Glickman's published worked example" do
+      subject(:updated) do
+        described_class.new(
+          rating: rating(rating: 1500, deviation: 200, volatility: 0.06),
+          results: [
+            Glicko2::Result.new(opponent: rating(rating: 1400, deviation: 30),  score: 1),
+            Glicko2::Result.new(opponent: rating(rating: 1550, deviation: 100), score: 0),
+            Glicko2::Result.new(opponent: rating(rating: 1700, deviation: 300), score: 0)
+          ]
+        ).result
+      end
+
+      it 'matches the reference rating' do
+        expect(updated.rating).to be_within(0.5).of(1464.06)
+      end
+
+      it 'matches the reference deviation' do
+        expect(updated.deviation).to be_within(0.5).of(151.52)
+      end
+
+      it 'matches the reference volatility' do
+        expect(updated.volatility).to be_within(0.0001).of(0.05999)
+      end
+    end
+
+    context 'a symmetric matchup' do
+      let(:even) { rating(rating: 1500, deviation: 200, volatility: 0.06) }
+
+      it 'moves the winner up and the loser down by equal amounts' do
+        winner = described_class.new(
+          rating: even,
+          results: [Glicko2::Result.new(opponent: even, score: 1)]
+        ).result
+
+        loser = described_class.new(
+          rating: even,
+          results: [Glicko2::Result.new(opponent: even, score: 0)]
+        ).result
+
+        expect(winner.rating).to be > 1500
+        expect(loser.rating).to be < 1500
+        expect(winner.rating - 1500).to be_within(0.001).of(1500 - loser.rating)
+      end
+    end
+  end
+end

--- a/spec/services/matches/create_bot_vs_bot_spec.rb
+++ b/spec/services/matches/create_bot_vs_bot_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Matches::CreateBotVsBot do
+  let(:user) { create(:user) }
+  let(:other) { create(:user) }
+
+  def rated_bot(rating, owner)
+    bot = create(:bot, :compiled, user: owner)
+    bot.update_columns(rating: rating)
+    bot
+  end
+
+  def creation(params = {})
+    described_class.new(user: user, params: params)
+  end
+
+  describe 'opponent ordering' do
+    it 'orders opponents by rating, lowest first' do
+      high = rated_bot(1300, other)
+      low = rated_bot(700, other)
+      mid = rated_bot(1000, other)
+
+      expect(creation.all_opponent_bots.to_a).to eq([low, mid, high])
+    end
+  end
+
+  describe '#opponent_offset' do
+    it 'counts how many opponents rate below the selected own bot' do
+      own = rated_bot(1000, user)
+      rated_bot(700, other)
+      rated_bot(800, other)
+      rated_bot(1200, other)
+
+      expect(creation(own_bot_id: own.id).opponent_offset).to eq(2)
+    end
+
+    it 'is nil when no own bot is selected' do
+      rated_bot(700, other)
+
+      expect(creation.opponent_offset).to be_nil
+    end
+  end
+
+  describe '#opponent_page' do
+    it 'returns the page, at the given size, that holds the own bot by rating' do
+      own = rated_bot(2000, user)
+      15.times { |i| rated_bot(1000 + (i * 10), other) }
+
+      expect(creation(own_bot_id: own.id).opponent_page(per_page: 12)).to eq(2)
+    end
+
+    it 'is nil when no own bot is selected' do
+      rated_bot(1000, other)
+
+      expect(creation.opponent_page(per_page: 12)).to be_nil
+    end
+  end
+end

--- a/spec/services/ratings/apply_match_result_spec.rb
+++ b/spec/services/ratings/apply_match_result_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Ratings::ApplyMatchResult do
+  def compiled_bot
+    create(:bot, :compiled)
+  end
+
+  def completed_match(white:, black:, result: :white_win, **overrides)
+    create(
+      :match,
+      white_player: white,
+      black_player: black,
+      white_compiled_program_snapshot: white.compiled_program,
+      black_compiled_program_snapshot: black.compiled_program,
+      status: :completed,
+      result: result,
+      lay_out: ['ee'],
+      movement_notation: ['1. e4'],
+      **overrides
+    )
+  end
+
+  describe '#call' do
+    context 'an eligible bot-vs-bot match' do
+      let(:white) { compiled_bot }
+      let(:black) { compiled_bot }
+      let(:match) { completed_match(white: white, black: black, result: :white_win) }
+
+      it 'raises the winner and lowers the loser' do
+        described_class.new(match).call
+        expect(white.reload.rating).to be > 1000.0
+        expect(black.reload.rating).to be < 1000.0
+      end
+
+      it 'records before and after ratings on the match' do
+        described_class.new(match).call
+        match.reload
+        expect(match.white_rating_before).to eq(1000.0)
+        expect(match.black_rating_before).to eq(1000.0)
+        expect(match.white_rating_after).to eq(white.reload.rating)
+        expect(match.black_rating_after).to eq(black.reload.rating)
+      end
+
+      it 'is idempotent' do
+        described_class.new(match).call
+        settled = white.reload.rating
+        described_class.new(match).call
+        expect(white.reload.rating).to eq(settled)
+      end
+    end
+
+    context 'ineligible matches leave ratings untouched' do
+      it 'skips a human-vs-bot match' do
+        bot = compiled_bot
+        human = create(:user)
+        match = completed_match(white: bot, black: bot, result: :white_win,
+                                black_player: human, black_compiled_program_snapshot: nil)
+        expect { described_class.new(match).call }.not_to(change { bot.reload.rating })
+        expect(match.reload.white_rating_after).to be_nil
+      end
+
+      it 'skips a no-contest result (capped)' do
+        white = compiled_bot
+        black = compiled_bot
+        match = completed_match(white: white, black: black, result: :capped)
+        described_class.new(match).call
+        expect(white.reload.rating).to eq(1000.0)
+        expect(black.reload.rating).to eq(1000.0)
+      end
+
+      it 'skips a bot playing itself' do
+        bot = compiled_bot
+        match = completed_match(white: bot, black: bot, result: :white_win)
+        expect { described_class.new(match).call }.not_to(change { bot.reload.rating })
+      end
+
+      it 'skips when a bot was recompiled since the match was played' do
+        white = compiled_bot
+        black = compiled_bot
+        match = completed_match(white: white, black: black, result: :white_win)
+        white.update_columns(compiled_program: { 'root' => 'root', 'nodes' => { 'added' => 1 } })
+
+        described_class.new(match).call
+        expect(white.reload.rating).to eq(1000.0)
+        expect(black.reload.rating).to eq(1000.0)
+        expect(match.reload.white_rating_after).to be_nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
  ELO ratings for bots, using Glicko-2 (an improved ELO — a rating also carries how
  confident we are in it, not just the number).

  - Completed bot-vs-bot games move both ratings (winner up, loser down), saved on
    the match. Tournament games count if the bot wasn't recompiled since entering;
    human and no-contest games don't.
  - Recompiling a bot widens its rating's uncertainty so its next games re-settle faster.
  - The opponent picker sorts by rating and opens on the page around your bot; each
    bot shows its rating.