### PR TITLE
Worktree bot editor review cleanup

### DIFF
--- a/app/controllers/bot_nodes_controller.rb
+++ b/app/controllers/bot_nodes_controller.rb
@@ -1,17 +1,13 @@
 class BotNodesController < ApplicationController
   before_action :authenticate_registered_or_guest_user!
   before_action :set_bot
-  before_action :set_node, only: [:show, :edit, :update, :update_position]
+  before_action :set_node, only: [:show, :update]
 
   def show
     respond_to do |format|
       format.html { render partial: 'bots/nodes/preview', locals: { node: @node } }
       format.json { render json: @node }
     end
-  end
-
-  def edit
-    render json: @node
   end
 
   def create
@@ -54,14 +50,6 @@ class BotNodesController < ApplicationController
       deleted_node_ids: deleted_node_ids,
       deleted_connection_ids: deleted_connection_ids.uniq
     }
-  end
-
-  def update_position
-    if @node.update(position_x: params[:position_x], position_y: params[:position_y])
-      render json: @node
-    else
-      render json: @node.errors, status: :unprocessable_entity
-    end
   end
 
   def batch_update_positions

--- a/app/controllers/bots_controller.rb
+++ b/app/controllers/bots_controller.rb
@@ -90,7 +90,7 @@ class BotsController < ApplicationController
   end
 
   def bot_params
-    params.require(:bot).permit(:name, :description, :commands)
+    params.require(:bot).permit(:name, :description)
   end
 
   def set_edit_view_data

--- a/app/controllers/bots_controller.rb
+++ b/app/controllers/bots_controller.rb
@@ -23,11 +23,12 @@ class BotsController < ApplicationController
   end
 
   def edit
-    @nodes = @bot.nodes.includes(:outgoing_connections, :incoming_connections)
-    @connections = @bot.nodes.flat_map(&:outgoing_connections)
     respond_to do |format|
       format.html { set_edit_view_data }
-      format.json { render json: { nodes: @nodes, connections: @connections } }
+      format.json do
+        nodes = @bot.nodes.includes(:outgoing_connections)
+        render json: { nodes: nodes, connections: nodes.flat_map(&:outgoing_connections) }
+      end
     end
   end
 

--- a/app/javascript/editorV2/EditorActions.js
+++ b/app/javascript/editorV2/EditorActions.js
@@ -86,7 +86,7 @@ class EditorActions {
   togglePreview() {
     if (this.boardStatePreview?.isEnabled && this.boardStatePreview?.mode !== 'idle') {
       this.boardStatePreview.toggle()
-    } else if (this.store.getSelectedNodeIds().length > 1) {
+    } else if (this.boardStatePreview && this.store.getSelectedNodeIds().length > 1) {
       this.boardStatePreview.isEnabled = true
       this.renderSelectionPreview()
     } else if (this.clickHandler?.getEditingNodeId() && this.clickHandler?.conditionForm) {

--- a/app/javascript/editorV2/__tests__/EditorActions.test.js
+++ b/app/javascript/editorV2/__tests__/EditorActions.test.js
@@ -62,6 +62,16 @@ describe('EditorActions', () => {
     vi.restoreAllMocks()
   })
 
+  // ===== togglePreview =====
+
+  describe('togglePreview', () => {
+    it('does not throw on multi-select when there is no board state preview', () => {
+      store.setSelectedNodeIds(['root', 'condition'])
+      expect(editorActions.boardStatePreview).toBeUndefined()
+      expect(() => editorActions.togglePreview()).not.toThrow()
+    })
+  })
+
   // ===== deleteSelected =====
 
   describe('deleteSelected', () => {

--- a/app/javascript/editorV2/__tests__/NodeRenderer.test.js
+++ b/app/javascript/editorV2/__tests__/NodeRenderer.test.js
@@ -1,0 +1,39 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import NodeRenderer from '../rendering/NodeRenderer'
+import Store from '../state/Store'
+import Node from '../models/Node'
+import { EVENTS } from '../constants'
+
+describe('NodeRenderer', () => {
+  let container
+  let store
+  let api
+  let renderer
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    store = new Store()
+    api = { getNodePreviewHtml: vi.fn().mockResolvedValue('<span>preview</span>') }
+    renderer = new NodeRenderer(container, store, api)
+  })
+
+  afterEach(() => {
+    renderer.destroy()
+    container.remove()
+    vi.restoreAllMocks()
+  })
+
+  it('fetches the preview when a node is persisted', () => {
+    const fetchSpy = vi.spyOn(renderer, 'fetchPreview')
+    store.emit(EVENTS.NODE_PERSISTED, { clientId: 'node-1' })
+    expect(fetchSpy).toHaveBeenCalledWith('node-1')
+  })
+
+  it('does not fetch the preview on an optimistic data update', () => {
+    store.addNode(new Node({ clientId: 'node-1', type: 'condition', position: { x: 0, y: 0 }, data: {} }))
+    const fetchSpy = vi.spyOn(renderer, 'fetchPreview')
+    store.updateNode('node-1', { data: { foo: 'bar' } })
+    expect(fetchSpy).not.toHaveBeenCalled()
+  })
+})

--- a/app/javascript/editorV2/__tests__/SyncManager.test.js
+++ b/app/javascript/editorV2/__tests__/SyncManager.test.js
@@ -6,6 +6,7 @@ import Node from '../models/Node.js'
 import Connection from '../models/Connection.js'
 import Graph from '../models/Graph.js'
 import { DEFAULT_CONDITION_DATA } from '../utils/nodeDefaults.js'
+import { EVENTS } from '../constants.js'
 
 describe('SyncManager', () => {
   let store
@@ -551,6 +552,19 @@ describe('SyncManager', () => {
 
       expect(store.getNode('n1').data.foo).toBe('bar')
       expect(store.getNode('n1').data.baz).toBeUndefined()
+    })
+
+    it('emits NODE_PERSISTED after the save succeeds', async () => {
+      const persisted = []
+      store.subscribe((event, data) => { if (event === EVENTS.NODE_PERSISTED) { persisted.push(data) } })
+      await syncManager.updateNodeData('n1', { baz: 'qux' })
+      expect(persisted).toEqual([{ clientId: 'n1' }])
+    })
+
+    it('updates the store only once', async () => {
+      const updateSpy = vi.spyOn(store, 'updateNode')
+      await syncManager.updateNodeData('n1', { baz: 'qux' })
+      expect(updateSpy).toHaveBeenCalledTimes(1)
     })
   })
 

--- a/app/javascript/editorV2/__tests__/SyncManager.test.js
+++ b/app/javascript/editorV2/__tests__/SyncManager.test.js
@@ -566,6 +566,17 @@ describe('SyncManager', () => {
       await syncManager.updateNodeData('n1', { baz: 'qux' })
       expect(updateSpy).toHaveBeenCalledTimes(1)
     })
+
+    it('does not emit NODE_PERSISTED when the save fails', async () => {
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+      mockApi.updateNode.mockRejectedValue(new Error('Network error'))
+      const persisted = []
+      store.subscribe((event, data) => { if (event === EVENTS.NODE_PERSISTED) { persisted.push(data) } })
+
+      await expect(syncManager.updateNodeData('n1', { baz: 'qux' })).rejects.toThrow('Network error')
+
+      expect(persisted).toEqual([])
+    })
   })
 
   describe('deleteNodes (single node)', () => {

--- a/app/javascript/editorV2/__tests__/SyncManager.test.js
+++ b/app/javascript/editorV2/__tests__/SyncManager.test.js
@@ -26,8 +26,8 @@ describe('SyncManager', () => {
       createConnection: vi.fn(),
       deleteConnection: vi.fn(),
       loadBot: vi.fn(),
-      getServerId: vi.fn(),
-      getClientId: vi.fn(),
+      getNodeServerId: vi.fn(),
+      getNodeClientId: vi.fn(),
       isSynced: vi.fn()
     }
     
@@ -879,21 +879,21 @@ describe('SyncManager', () => {
   })
 
   describe('utility methods', () => {
-    it('getServerId delegates to api', () => {
-      mockApi.getServerId.mockReturnValue(123)
+    it('getNodeServerId delegates to api', () => {
+      mockApi.getNodeServerId.mockReturnValue(123)
 
-      const result = syncManager.getServerId('client-123')
+      const result = syncManager.getNodeServerId('client-123')
 
-      expect(mockApi.getServerId).toHaveBeenCalledWith('client-123')
+      expect(mockApi.getNodeServerId).toHaveBeenCalledWith('client-123')
       expect(result).toBe(123)
     })
 
-    it('getClientId delegates to api', () => {
-      mockApi.getClientId.mockReturnValue('client-123')
+    it('getNodeClientId delegates to api', () => {
+      mockApi.getNodeClientId.mockReturnValue('client-123')
 
-      const result = syncManager.getClientId(123)
+      const result = syncManager.getNodeClientId(123)
 
-      expect(mockApi.getClientId).toHaveBeenCalledWith(123)
+      expect(mockApi.getNodeClientId).toHaveBeenCalledWith(123)
       expect(result).toBe('client-123')
     })
 

--- a/app/javascript/editorV2/api.js
+++ b/app/javascript/editorV2/api.js
@@ -418,16 +418,16 @@ class API {
    * @param {string} clientId - Node client ID
    * @returns {number|null} Server ID or null
    */
-  getServerId(clientId) {
+  getNodeServerId(clientId) {
     return this.nodeClientToServer.get(clientId) || null
   }
-  
+
   /**
    * Get client ID for a node server ID
    * @param {number} serverId - Node server ID
    * @returns {string|null} Client ID or null
    */
-  getClientId(serverId) {
+  getNodeClientId(serverId) {
     return this.nodeServerToClient.get(serverId) || null
   }
   

--- a/app/javascript/editorV2/constants.js
+++ b/app/javascript/editorV2/constants.js
@@ -54,6 +54,7 @@ export const NODE_COLORS = {
 export const EVENTS = {
   NODE_ADD: 'node:add',
   NODE_UPDATE: 'node:update',
+  NODE_PERSISTED: 'node:persisted',
   NODE_REMOVE: 'node:remove',
   CONNECTION_ADD: 'connection:add',
   CONNECTION_UPDATE: 'connection:update',

--- a/app/javascript/editorV2/handlers/ClickHandler.js
+++ b/app/javascript/editorV2/handlers/ClickHandler.js
@@ -287,7 +287,7 @@ class ClickHandler {
     if (!this.editorPanel) { return }
     const actionType = this.editorPanel.querySelector('#action-type')
     const actionValue = this.editorPanel.querySelector('#action-value')
-    if (actionType) { actionType.value = node.data.actionType || node.data.action_type || 'add' }
+    if (actionType) { actionType.value = node.data.actionType || 'add' }
     if (actionValue) { actionValue.value = node.data.value || 1 }
   }
 

--- a/app/javascript/editorV2/rendering/NodeRenderer.js
+++ b/app/javascript/editorV2/rendering/NodeRenderer.js
@@ -53,7 +53,11 @@ class NodeRenderer {
       case EVENTS.NODE_UPDATE:
         this.updateNode(data.clientId, data.updates)
         break
-      
+
+      case EVENTS.NODE_PERSISTED:
+        this.fetchPreview(data.clientId)
+        break
+
       case EVENTS.NODE_REMOVE:
         this.removeNode(data.clientId)
         break
@@ -146,14 +150,12 @@ class NodeRenderer {
       }
     }
 
-    // Refetch preview when data changes or when the server ID arrives.
-    // Newly created nodes render optimistically before they have a server ID,
-    // so the first preview fetch can only succeed after sync completes.
-    if (updates.data !== undefined || updates.serverId !== undefined) {
+    // serverId arrives after an optimistic create — the first point a server preview can be fetched.
+    if (updates.serverId !== undefined) {
       this.fetchPreview(clientId)
-      if (updates.data !== undefined && snapshot) {
-        this.nodeSnapshot.set(clientId, { ...snapshot, dataKey: JSON.stringify(updates.data) })
-      }
+    }
+    if (updates.data !== undefined && snapshot) {
+      this.nodeSnapshot.set(clientId, { ...snapshot, dataKey: JSON.stringify(updates.data) })
     }
   }
   

--- a/app/javascript/editorV2/state/Store.js
+++ b/app/javascript/editorV2/state/Store.js
@@ -3,6 +3,21 @@ import Graph from 'editorV2/models/Graph'
 import Node from 'editorV2/models/Node'
 import Connection from 'editorV2/models/Connection'
 
+function defaultViewState() {
+  return {
+    zoom: 1,
+    panX: 0,
+    panY: 0,
+    selectedNodeIds: [],
+    primarySelectedNodeId: null,
+    editingNodeId: null,
+    recentPlacementAnchor: null,
+    isMarqueeSelecting: false,
+    marqueeStart: null,
+    marqueeCurrent: null
+  }
+}
+
 /**
  * Store - Single source of truth for application state
  * 
@@ -17,21 +32,10 @@ class Store {
   constructor() {
     // Graph state (undoable)
     this.graph = new Graph()
-    
+
     // View state (not undoable)
-    this.viewState = {
-      zoom: 1,
-      panX: 0,
-      panY: 0,
-      selectedNodeIds: [],
-      primarySelectedNodeId: null,
-      editingNodeId: null,
-      recentPlacementAnchor: null,
-      isMarqueeSelecting: false,
-      marqueeStart: null,
-      marqueeCurrent: null
-    }
-    this.subscribers = [] 
+    this.viewState = defaultViewState()
+    this.subscribers = []
     this.isUpdating = false 
     this.destroyed = false
 
@@ -366,18 +370,7 @@ class Store {
   
   clear() {
     this.graph = new Graph()
-    this.viewState = {
-      zoom: 1,
-      panX: 0,
-      panY: 0,
-      selectedNodeIds: [],
-      primarySelectedNodeId: null,
-      editingNodeId: null,
-      recentPlacementAnchor: null,
-      isMarqueeSelecting: false,
-      marqueeStart: null,
-      marqueeCurrent: null
-    }
+    this.viewState = defaultViewState()
     this.clickSuppressedUntil = 0
     this.emit(EVENTS.GRAPH_REPLACE, { graph: this.graph })
   }

--- a/app/javascript/editorV2/sync/SyncManager.js
+++ b/app/javascript/editorV2/sync/SyncManager.js
@@ -8,6 +8,7 @@ import { showError } from 'editorV2/utils/errors'
 import { showErrorDialog } from 'editorV2/utils/ErrorDialog'
 import { normalizeNodeData } from 'editorV2/utils/nodeDefaults'
 import { buildTemplateInsertOperation } from 'editorV2/templates/TemplateInserter'
+import { EVENTS } from 'editorV2/constants'
 
 /**
  * SyncManager
@@ -766,10 +767,9 @@ class SyncManager {
       // 2. Sync with server
       await this.api.updateNode(clientId, { data: newData })
 
-      // 3. Re-emit the data update after the server save completes so
-      // preview rendering refetches against committed server state.
-      this.store.updateNode(clientId, { data: newData })
-      
+      // 3. Signal persistence so the preview refetches committed server state
+      this.store.emit(EVENTS.NODE_PERSISTED, { clientId })
+
       // 4. Push to history after success
       this.history.push('Update node', {
         type: 'updateNodeData',
@@ -781,9 +781,9 @@ class SyncManager {
       this.notifyPersistedMutation()
       
     } catch (error) {
-      // 4. Rollback on failure
+      // 5. Rollback on failure
       this.store.updateNode(clientId, { data: previousData })
-      
+
       showError(`Failed to save node: ${error.message}`)
       console.error('Failed to update node data:', error)
       

--- a/app/javascript/editorV2/sync/SyncManager.js
+++ b/app/javascript/editorV2/sync/SyncManager.js
@@ -1056,21 +1056,21 @@ class SyncManager {
   // ===== Utility =====
   
   /**
-   * Get server ID for a client ID
-   * @param {string} clientId - Client ID
+   * Get server ID for a node client ID
+   * @param {string} clientId - Node client ID
    * @returns {number|null}
    */
-  getServerId(clientId) {
-    return this.api.getServerId(clientId)
+  getNodeServerId(clientId) {
+    return this.api.getNodeServerId(clientId)
   }
-  
+
   /**
-   * Get client ID for a server ID
-   * @param {number} serverId - Server ID
+   * Get client ID for a node server ID
+   * @param {number} serverId - Node server ID
    * @returns {string|null}
    */
-  getClientId(serverId) {
-    return this.api.getClientId(serverId)
+  getNodeClientId(serverId) {
+    return this.api.getNodeClientId(serverId)
   }
   
   /**

--- a/app/models/bot.rb
+++ b/app/models/bot.rb
@@ -18,9 +18,6 @@ class Bot < ApplicationRecord
   SYSTEM_BOT_NAME = 'Seed Bot'
   RECOMPILE_RD_BUMP = 250.0
 
-  def self.system_bot
-    find_by(name: SYSTEM_BOT_NAME)
-  end
   belongs_to :user
   has_many :matches_as_white_player, as: :white_player, class_name: 'Match', dependent: :nullify
   has_many :matches_as_black_player, as: :black_player, class_name: 'Match', dependent: :nullify
@@ -30,12 +27,12 @@ class Bot < ApplicationRecord
   has_many :connections, through: :nodes, source: :outgoing_connections
 
   scope :compiled,             ->         { where(compiled_program_stale: false).where.not(compiled_program: nil) }
-  scope :stale,             ->         { where(compiled_program_stale: true) }
+  scope :stale,                ->         { where(compiled_program_stale: true) }
   scope :with_name,            ->(name)   { where("bots.name ILIKE ?", "%#{name}%") }
   scope :with_compiled_status, ->(status) {
     case status
-    when 'compiled' then where(compiled_program_stale: false).where.not(compiled_program: nil)
-    when 'stale'    then where(compiled_program_stale: true)
+    when 'compiled' then compiled
+    when 'stale'    then stale
     end
   }
   scope :filtered, ->(name: nil, compiled_status: nil) {
@@ -51,7 +48,15 @@ class Bot < ApplicationRecord
   after_create :create_root_node
   
   validate :root_node_must_exist, on: :update
-  
+
+  def self.system_bot
+    find_by(name: SYSTEM_BOT_NAME)
+  end
+
+  def self.mark_stale_for(bot_id)
+    find_by(id: bot_id)&.mark_compiled_program_stale!
+  end
+
   def root_node
     nodes.find_by(node_type: 'root')
   end

--- a/app/models/bot.rb
+++ b/app/models/bot.rb
@@ -4,7 +4,6 @@
 #
 #  id                     :bigint           not null, primary key
 #  user_id                :bigint
-#  commands               :json
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #  name                   :string

--- a/app/models/connection.rb
+++ b/app/models/connection.rb
@@ -25,8 +25,7 @@ class Connection < ApplicationRecord
   private
 
   def mark_bot_compiled_program_stale
-    bot_id = source_node&.bot_id || target_node&.bot_id
-    Bot.where(id: bot_id).find_each(&:mark_compiled_program_stale!)
+    Bot.mark_stale_for(source_node&.bot_id || target_node&.bot_id)
   end
 
   def source_and_target_must_be_different

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -59,9 +59,13 @@ class Node < ApplicationRecord
   end
 
   def mark_bot_compiled_program_stale_if_needed
-    return if previously_persisted? && destroyed? == false && !saved_change_to_position_x? && !saved_change_to_position_y? && !saved_change_to_data?
+    Bot.mark_stale_for(bot_id) if compilation_relevant_change?
+  end
 
-    Bot.mark_stale_for(bot_id)
+  def compilation_relevant_change?
+    return true if !previously_persisted? || destroyed?
+
+    saved_change_to_position_x? || saved_change_to_position_y? || saved_change_to_data?
   end
   
   def single_root_per_bot

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -61,7 +61,7 @@ class Node < ApplicationRecord
   def mark_bot_compiled_program_stale_if_needed
     return if previously_persisted? && destroyed? == false && !saved_change_to_position_x? && !saved_change_to_position_y? && !saved_change_to_data?
 
-    Bot.where(id: bot_id).find_each(&:mark_compiled_program_stale!)
+    Bot.mark_stale_for(bot_id)
   end
   
   def single_root_per_bot

--- a/app/models/nodes/data_validator.rb
+++ b/app/models/nodes/data_validator.rb
@@ -5,8 +5,8 @@ module Nodes
     CONDITION_V2_CENSUS_KEYS = %w[ version kind subject subjectFilter subjectFilterMode operator comparator target targetFilter targetFilterMode targetTotal positionAxis positionComparator positionTarget ].freeze
     CONDITION_V2_CENSUS_REQUIRED_KEYS = %w[version kind subject subjectFilter operator comparator target].freeze
     CONDITION_V2_IDENTITY_KEYS = %w[ version kind subject target ].freeze
-    ACTION_TYPES = %w[add subtract set return].freeze
-    ACTION_KEYS = %w[actionType value].freeze
+    SCORE_ACTION_TYPES = %w[add subtract set return].freeze
+    SCORE_KEYS = %w[actionType value].freeze
     ORGANIZER_KEYS = %w[title notes].freeze
 
     class << self
@@ -160,10 +160,10 @@ module Nodes
 
     def validate_score_data
       return record.errors.add(:data, 'must be a hash') unless record.data.is_a?(Hash)
-      return unless validate_keys(allowed: ACTION_KEYS, required: ACTION_KEYS)
+      return unless validate_keys(allowed: SCORE_KEYS, required: SCORE_KEYS)
       action_type = record.data['actionType'] || record.data[:actionType]
       value = record.data['value'] || record.data[:value]
-      record.errors.add(:data, 'has invalid actionType') unless ACTION_TYPES.include?(action_type)
+      record.errors.add(:data, 'has invalid actionType') unless SCORE_ACTION_TYPES.include?(action_type)
       record.errors.add(:data, 'value must be numeric') unless value.is_a?(Numeric)
     end
 

--- a/app/models/nodes/data_validator.rb
+++ b/app/models/nodes/data_validator.rb
@@ -1,7 +1,9 @@
 module Nodes
   class DataValidator
     CONDITION_V2_RELATION_KEYS = %w[ version kind subject subjectFilter subjectFilterMode subjectComparisonMetric subjectComparator subjectComparisonSource subjectComparisonSourceTotal operator target targetFilter targetFilterMode targetComparisonMetric targetComparator targetComparisonSource targetComparisonSourceTotal ].freeze
+    CONDITION_V2_RELATION_REQUIRED_KEYS = %w[version kind subject subjectFilter operator target targetFilter].freeze
     CONDITION_V2_CENSUS_KEYS = %w[ version kind subject subjectFilter subjectFilterMode operator comparator target targetFilter targetFilterMode targetTotal positionAxis positionComparator positionTarget ].freeze
+    CONDITION_V2_CENSUS_REQUIRED_KEYS = %w[version kind subject subjectFilter operator comparator target].freeze
     CONDITION_V2_IDENTITY_KEYS = %w[ version kind subject target ].freeze
     ACTION_TYPES = %w[add subtract set return].freeze
     ACTION_KEYS = %w[actionType value].freeze
@@ -32,6 +34,17 @@ module Nodes
 
     attr_reader :record
 
+    def validate_keys(allowed:, required: [])
+      keys = record.data.keys.map(&:to_s)
+      extra_keys = keys - allowed
+      record.errors.add(:data, "contains invalid keys: #{extra_keys.join(', ')}") if extra_keys.any?
+      missing_keys = required - keys
+      return true if missing_keys.empty?
+
+      record.errors.add(:data, "is missing required keys: #{missing_keys.join(', ')}")
+      false
+    end
+
     def validate_condition_data
       return record.errors.add(:data, 'must be a hash') unless record.data.is_a?(Hash)
       validate_condition_data_v2
@@ -59,16 +72,7 @@ module Nodes
     end
 
     def validate_condition_data_v2_relational
-      keys = record.data.keys.map(&:to_s)
-      extra_keys = keys - CONDITION_V2_RELATION_KEYS
-      missing_keys = %w[version kind subject subjectFilter operator target targetFilter] - keys
-      if extra_keys.any?
-        record.errors.add(:data, "contains invalid keys: #{extra_keys.join(', ')}")
-      end
-      if missing_keys.any?
-        record.errors.add(:data, "is missing required keys: #{missing_keys.join(', ')}")
-        return
-      end
+      return unless validate_keys(allowed: CONDITION_V2_RELATION_KEYS, required: CONDITION_V2_RELATION_REQUIRED_KEYS)
       subject = record.data['subject']
       subject_filter = record.data['subjectFilter']
       subject_filter_mode = record.data['subjectFilterMode']
@@ -107,16 +111,7 @@ module Nodes
     end
 
     def validate_condition_data_v2_census
-      keys = record.data.keys.map(&:to_s)
-      extra_keys = keys - CONDITION_V2_CENSUS_KEYS
-      missing_keys = %w[version kind subject subjectFilter operator comparator target] - keys
-      if extra_keys.any?
-        record.errors.add(:data, "contains invalid keys: #{extra_keys.join(', ')}")
-      end
-      if missing_keys.any?
-        record.errors.add(:data, "is missing required keys: #{missing_keys.join(', ')}")
-        return
-      end
+      return unless validate_keys(allowed: CONDITION_V2_CENSUS_KEYS, required: CONDITION_V2_CENSUS_REQUIRED_KEYS)
       subject = record.data['subject']
       subject_filter = record.data['subjectFilter']
       subject_filter_mode = record.data['subjectFilterMode']
@@ -155,16 +150,7 @@ module Nodes
     end
 
     def validate_condition_data_v2_identity
-      keys = record.data.keys.map(&:to_s)
-      extra_keys = keys - CONDITION_V2_IDENTITY_KEYS
-      missing_keys = %w[version kind subject target] - keys
-      if extra_keys.any?
-        record.errors.add(:data, "contains invalid keys: #{extra_keys.join(', ')}")
-      end
-      if missing_keys.any?
-        record.errors.add(:data, "is missing required keys: #{missing_keys.join(', ')}")
-        return
-      end
+      return unless validate_keys(allowed: CONDITION_V2_IDENTITY_KEYS, required: CONDITION_V2_IDENTITY_KEYS)
       subject = record.data['subject']
       target = record.data['target']
       unless NodeGrammarRules.valid_identity_pair?(subject:, target:)
@@ -174,16 +160,7 @@ module Nodes
 
     def validate_score_data
       return record.errors.add(:data, 'must be a hash') unless record.data.is_a?(Hash)
-      keys = record.data.keys.map(&:to_s)
-      extra_keys = keys - ACTION_KEYS
-      missing_keys = ACTION_KEYS - keys
-      if extra_keys.any?
-        record.errors.add(:data, "contains invalid keys: #{extra_keys.join(', ')}")
-      end
-      if missing_keys.any?
-        record.errors.add(:data, "is missing required keys: #{missing_keys.join(', ')}")
-        return
-      end
+      return unless validate_keys(allowed: ACTION_KEYS, required: ACTION_KEYS)
       action_type = record.data['actionType'] || record.data[:actionType]
       value = record.data['value'] || record.data[:value]
       record.errors.add(:data, 'has invalid actionType') unless ACTION_TYPES.include?(action_type)
@@ -192,11 +169,7 @@ module Nodes
 
     def validate_organizer_data
       return record.errors.add(:data, 'must be a hash') unless record.data.is_a?(Hash)
-      keys = record.data.keys.map(&:to_s)
-      extra_keys = keys - ORGANIZER_KEYS
-      if extra_keys.any?
-        record.errors.add(:data, "contains invalid keys: #{extra_keys.join(', ')}")
-      end
+      validate_keys(allowed: ORGANIZER_KEYS)
       title = record.data['title'] || record.data[:title]
       notes = record.data['notes'] || record.data[:notes]
       record.errors.add(:data, 'title must be a string') unless title.is_a?(String)

--- a/app/presenters/node_presenter.rb
+++ b/app/presenters/node_presenter.rb
@@ -64,11 +64,11 @@ class NodePresenter
     self.class.condition_preview_chunks_for(data)
   end
 
-  def action_type
+  def score_action_type
     data[:actionType] || 'add'
   end
 
-  def action_value
+  def score_value
     data[:value] || 1
   end
 

--- a/app/presenters/node_presenter.rb
+++ b/app/presenters/node_presenter.rb
@@ -65,7 +65,7 @@ class NodePresenter
   end
 
   def action_type
-    data[:actionType] || data[:action_type] || 'add'
+    data[:actionType] || 'add'
   end
 
   def action_value

--- a/app/services/bot_cloner.rb
+++ b/app/services/bot_cloner.rb
@@ -8,8 +8,7 @@ class BotCloner
     ActiveRecord::Base.transaction do
       new_bot = @user.bots.create!(
         name: next_clone_name,
-        description: @source_bot.description,
-        commands: @source_bot.commands
+        description: @source_bot.description
       )
 
       id_map = {}

--- a/app/services/bot_compiler.rb
+++ b/app/services/bot_compiler.rb
@@ -15,6 +15,13 @@ class BotCompiler
 
   PROGRAM_VERSION = 1
 
+  SCORE_KEYS = %i[actionType value].freeze
+  CONDITION_KEYS_BY_KIND = {
+    'relational' => Nodes::DataValidator::CONDITION_V2_RELATION_KEYS.map(&:to_sym).freeze,
+    'census'     => Nodes::DataValidator::CONDITION_V2_CENSUS_KEYS.map(&:to_sym).freeze,
+    'identity'   => Nodes::DataValidator::CONDITION_V2_IDENTITY_KEYS.map(&:to_sym).freeze
+  }.freeze
+
   def initialize(bot, node_dimensions = ApplicationHelper::NODE_DIMENSIONS)
     @bot = bot
     @node_dimensions = node_dimensions
@@ -90,62 +97,9 @@ class BotCompiler
 
     case node.node_type
     when 'condition'
-      kind = raw['kind'] || raw[:kind]
-
-      case kind
-      when 'census'
-        # Unary shape plus optional region keys; compact drops absent ones.
-        {
-          version: 2,
-          kind: 'census',
-          subject: raw['subject'] || raw[:subject],
-          subjectFilter: raw['subjectFilter'] || raw[:subjectFilter],
-          subjectFilterMode: raw['subjectFilterMode'] || raw[:subjectFilterMode],
-          operator: raw['operator'] || raw[:operator],
-          comparator: raw['comparator'] || raw[:comparator],
-          target: raw['target'] || raw[:target],
-          targetFilter: raw['targetFilter'] || raw[:targetFilter],
-          targetFilterMode: raw['targetFilterMode'] || raw[:targetFilterMode],
-          targetTotal: hash_value(raw, 'targetTotal'),
-          positionAxis: raw['positionAxis'] || raw[:positionAxis],
-          positionComparator: raw['positionComparator'] || raw[:positionComparator],
-          positionTarget: hash_value(raw, 'positionTarget')
-        }.compact
-      when 'identity'
-        {
-          version: 2,
-          kind: 'identity',
-          subject: raw['subject'] || raw[:subject],
-          target: raw['target'] || raw[:target]
-        }.compact
-      when 'relational'
-        {
-          version: 2,
-          kind: 'relational',
-          subject: raw['subject'] || raw[:subject],
-          subjectFilter: raw['subjectFilter'] || raw[:subjectFilter],
-          subjectFilterMode: raw['subjectFilterMode'] || raw[:subjectFilterMode],
-          subjectComparisonMetric: raw['subjectComparisonMetric'] || raw[:subjectComparisonMetric],
-          subjectComparator: raw['subjectComparator'] || raw[:subjectComparator],
-          subjectComparisonSource: raw['subjectComparisonSource'] || raw[:subjectComparisonSource],
-          subjectComparisonSourceTotal: hash_value(raw, 'subjectComparisonSourceTotal'),
-          operator: raw['operator'] || raw[:operator],
-          target: raw['target'] || raw[:target],
-          targetFilter: raw['targetFilter'] || raw[:targetFilter],
-          targetFilterMode: raw['targetFilterMode'] || raw[:targetFilterMode],
-          targetComparisonMetric: raw['targetComparisonMetric'] || raw[:targetComparisonMetric],
-          targetComparator: raw['targetComparator'] || raw[:targetComparator],
-          targetComparisonSource: raw['targetComparisonSource'] || raw[:targetComparisonSource],
-          targetComparisonSourceTotal: hash_value(raw, 'targetComparisonSourceTotal')
-        }.compact
-      else
-        raw
-      end
+      normalize_condition_data(raw)
     when 'score'
-      {
-        actionType: raw['actionType'] || raw[:actionType],
-        value: raw['value'] || raw[:value]
-      }
+      raw.symbolize_keys.slice(*SCORE_KEYS)
     else
       # Organizers carry freeform user-authored text. We intentionally strip that
       # data out during compilation so annotation content never becomes part of the
@@ -154,8 +108,11 @@ class BotCompiler
     end
   end
 
-  def hash_value(hash, key)
-    hash.key?(key) ? hash[key] : hash[key.to_sym]
+  def normalize_condition_data(raw)
+    allowed = CONDITION_KEYS_BY_KIND[raw['kind'] || raw[:kind]]
+    return raw unless allowed
+
+    raw.symbolize_keys.slice(*allowed)
   end
 
 end

--- a/app/views/bots/nodes/types/_score.html.erb
+++ b/app/views/bots/nodes/types/_score.html.erb
@@ -1,6 +1,6 @@
-<% action_type = presenter.action_type %>
-<% value = presenter.action_value %>
+<% score_action_type = presenter.score_action_type %>
+<% value = presenter.score_value %>
 <div class="node-preview score-preview">
-  <span class="score-preview__type"><%= action_type.to_s.humanize %></span>
+  <span class="score-preview__type"><%= score_action_type.to_s.humanize %></span>
   <span class="score-preview__value"><%= value %></span>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,10 +12,9 @@ Rails.application.routes.draw do
       post :compile
       post :clone
     end
-    resources :nodes, controller: 'bot_nodes', except: [:index, :new, :destroy] do
+    resources :nodes, controller: 'bot_nodes', except: [:index, :new, :destroy, :edit] do
       member do
         post :connect
-        post :update_position
       end
       collection do
         delete :batch_destroy

--- a/db/migrate/20260602120000_drop_commands_from_bots.rb
+++ b/db/migrate/20260602120000_drop_commands_from_bots.rb
@@ -1,0 +1,5 @@
+class DropCommandsFromBots < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :bots, :commands, :json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_06_01_003341) do
+ActiveRecord::Schema[7.1].define(version: 2026_06_02_120000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "bots", force: :cascade do |t|
     t.bigint "user_id"
-    t.json "commands"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "name"

--- a/spec/features/editor_v2_spec.rb
+++ b/spec/features/editor_v2_spec.rb
@@ -82,6 +82,7 @@ RSpec.describe 'EditorV2', type: :feature, js: true, slow: true do
       click_button '+ Condition'
 
       expect_node_count(2)
+      wait_until { Node.where(bot: bot, node_type: 'condition').count == 1 }
       expect(Node.where(bot: bot, node_type: 'condition').count).to eq(1)
       expect_history_count(2)
     end
@@ -90,6 +91,7 @@ RSpec.describe 'EditorV2', type: :feature, js: true, slow: true do
       click_button '+ Score'
 
       expect_node_count(2)
+      wait_until { Node.where(bot: bot, node_type: 'score').count == 1 }
       expect(Node.where(bot: bot, node_type: 'score').count).to eq(1)
       expect_history_count(2)
     end
@@ -161,13 +163,13 @@ RSpec.describe 'EditorV2', type: :feature, js: true, slow: true do
       visit edit_bot_path(bot)
       wait_for_editor
 
-      expect(connection_count).to eq(1)
+      expect_connection_count(1)
 
       select_node(condition_node.id)
       delete_selected_node
 
       expect_node_count(2) # root + action
-      expect(connection_count).to eq(0)
+      expect_connection_count(0)
     end
   end
 
@@ -187,7 +189,7 @@ RSpec.describe 'EditorV2', type: :feature, js: true, slow: true do
 
       create_connection(node1.id, node2.id)
 
-      expect(connection_count).to eq(1)
+      expect_connection_count(1)
       expect(Connection.where(source_node_id: node1.id, target_node_id: node2.id).count).to eq(1)
       expect_history_count(2)
     end
@@ -196,13 +198,13 @@ RSpec.describe 'EditorV2', type: :feature, js: true, slow: true do
       wait_for_editor
 
       create_connection(node1.id, node2.id)
-      expect(connection_count).to eq(1)
+      expect_connection_count(1)
 
       # Try to create same connection again
       create_connection(node1.id, node2.id)
 
       # Should still be 1, no duplicate
-      expect(connection_count).to eq(1)
+      expect_connection_count(1)
     end
 
     it 'does not allow self-connections' do
@@ -323,6 +325,7 @@ RSpec.describe 'EditorV2', type: :feature, js: true, slow: true do
 
         expect_node_count(2)
         # Node should be restored
+        wait_until { Node.where(bot: bot, node_type: 'condition').count == 1 }
         expect(Node.where(bot: bot, node_type: 'condition').count).to eq(1)
       end
     end
@@ -343,11 +346,11 @@ RSpec.describe 'EditorV2', type: :feature, js: true, slow: true do
         wait_for_editor
 
         create_connection(node1.id, node2.id)
-        expect(connection_count).to eq(1)
+        expect_connection_count(1)
 
         click_undo
 
-        expect(connection_count).to eq(0)
+        expect_connection_count(0)
         expect_history_count(1)
       end
 
@@ -358,7 +361,7 @@ RSpec.describe 'EditorV2', type: :feature, js: true, slow: true do
         click_undo
         click_redo
 
-        expect(connection_count).to eq(1)
+        expect_connection_count(1)
       end
     end
 
@@ -573,7 +576,7 @@ RSpec.describe 'EditorV2', type: :feature, js: true, slow: true do
       page.evaluate_script("
         window.editorAPI.syncManager.updateNodePosition('#{original_client_id}', 200, 200)
       ")
-      sleep ASYNC_WAIT
+      wait_until { at_position?(original_client_id, 200, 200) }
 
       # Client ID should remain stable
       expect(find_node_client_id(condition_node.id)).to eq(original_client_id)
@@ -638,24 +641,24 @@ RSpec.describe 'EditorV2', type: :feature, js: true, slow: true do
 
       # Operation 3: Connect condition -> action
       create_connection(condition_node.id, action_node.id)
-      expect(connection_count).to eq(1)
+      expect_connection_count(1)
       expect_history_count(4)
 
       # Operation 4: Delete condition node (cascade deletes connection)
       select_node(condition_node.id)
       delete_selected_node
       expect_node_count(2)
-      expect(connection_count).to eq(0)
+      expect_connection_count(0)
       expect_history_count(5)
 
       # Undo operation 4
       click_undo
       expect_node_count(3)
-      expect(connection_count).to eq(1)
+      expect_connection_count(1)
 
       # Undo operation 3
       click_undo
-      expect(connection_count).to eq(0)
+      expect_connection_count(0)
 
       # Undo operation 2
       click_undo
@@ -674,11 +677,11 @@ RSpec.describe 'EditorV2', type: :feature, js: true, slow: true do
       expect_node_count(3)
 
       click_redo
-      expect(connection_count).to eq(1)
+      expect_connection_count(1)
 
       click_redo
       expect_node_count(2)
-      expect(connection_count).to eq(0)
+      expect_connection_count(0)
     end
   end
 
@@ -702,7 +705,7 @@ RSpec.describe 'EditorV2', type: :feature, js: true, slow: true do
       # Drag condition node (connected to 2 score nodes)
       # Original position: condition at (100, 100), action1 at (200, 100), action2 at (200, 200)
       # Move condition to (300, 300)
-      drag_node(condition_node.id, 300, 300)
+      drag_node_with_descendants(condition_node.id, 300, 300)
 
       # Condition should be at new position
       expect_node_position(condition_node.id, 300, 300)
@@ -717,7 +720,7 @@ RSpec.describe 'EditorV2', type: :feature, js: true, slow: true do
       expect_node_count(4)
 
       # Drag with Shift key (only condition moves)
-      drag_node_with_shift(condition_node.id, 300, 300)
+      drag_single_node(condition_node.id, 300, 300)
 
       # Condition should be at new position
       expect_node_position(condition_node.id, 300, 300)
@@ -731,7 +734,7 @@ RSpec.describe 'EditorV2', type: :feature, js: true, slow: true do
       wait_for_editor
       expect_history_count(1)
 
-      drag_node(condition_node.id, 300, 300)
+      drag_node_with_descendants(condition_node.id, 300, 300)
 
       # History count should increase by 1
       expect_history_count(2)
@@ -748,7 +751,7 @@ RSpec.describe 'EditorV2', type: :feature, js: true, slow: true do
       original_action2_x = 200
       original_action2_y = 200
 
-      drag_node(condition_node.id, 300, 300)
+      drag_node_with_descendants(condition_node.id, 300, 300)
       expect_history_count(2)
 
       # Undo
@@ -763,7 +766,7 @@ RSpec.describe 'EditorV2', type: :feature, js: true, slow: true do
     it 'redoes all positions when dragging with children' do
       wait_for_editor
 
-      drag_node(condition_node.id, 300, 300)
+      drag_node_with_descendants(condition_node.id, 300, 300)
       click_undo
       click_redo
 

--- a/spec/presenters/node_presenter_spec.rb
+++ b/spec/presenters/node_presenter_spec.rb
@@ -191,12 +191,9 @@ RSpec.describe NodePresenter do
   end
 
   describe '#action_type' do
-    it 'prefers actionType, then action_type, then add' do
-      node = build(:node, :score, data: { actionType: 'multiply', action_type: 'subtract', value: 1 })
+    it 'returns actionType, defaulting to add' do
+      node = build(:node, :score, data: { actionType: 'multiply', value: 1 })
       expect(described_class.new(node).action_type).to eq('multiply')
-
-      node = build(:node, :score, data: { action_type: 'subtract', value: 1 })
-      expect(described_class.new(node).action_type).to eq('subtract')
 
       node = build(:node, :score, data: { value: 1 })
       expect(described_class.new(node).action_type).to eq('add')

--- a/spec/presenters/node_presenter_spec.rb
+++ b/spec/presenters/node_presenter_spec.rb
@@ -190,23 +190,23 @@ RSpec.describe NodePresenter do
     end
   end
 
-  describe '#action_type' do
+  describe '#score_action_type' do
     it 'returns actionType, defaulting to add' do
       node = build(:node, :score, data: { actionType: 'multiply', value: 1 })
-      expect(described_class.new(node).action_type).to eq('multiply')
+      expect(described_class.new(node).score_action_type).to eq('multiply')
 
       node = build(:node, :score, data: { value: 1 })
-      expect(described_class.new(node).action_type).to eq('add')
+      expect(described_class.new(node).score_action_type).to eq('add')
     end
   end
 
-  describe '#action_value' do
+  describe '#score_value' do
     it 'defaults to 1 when the value is nil and preserves zero' do
       node = build(:node, :score, data: { actionType: 'add', value: nil })
-      expect(described_class.new(node).action_value).to eq(1)
+      expect(described_class.new(node).score_value).to eq(1)
 
       node = build(:node, :score, data: { actionType: 'add', value: 0 })
-      expect(described_class.new(node).action_value).to eq(0)
+      expect(described_class.new(node).score_value).to eq(0)
     end
   end
 

--- a/spec/requests/bot_nodes_controller_spec.rb
+++ b/spec/requests/bot_nodes_controller_spec.rb
@@ -41,17 +41,6 @@ RSpec.describe BotNodesController, type: :request do
     end
   end
 
-  describe 'GET #edit' do
-    before { sign_in user }
-
-    it 'returns the node as JSON' do
-      get edit_bot_node_path(bot, node, format: :json)
-      expect(response).to have_http_status(:success)
-      json = JSON.parse(response.body)
-      expect(json['id']).to eq(node.id)
-    end
-  end
-
   describe 'POST #create' do
     before do
       sign_in user
@@ -222,18 +211,6 @@ RSpec.describe BotNodesController, type: :request do
       expect(response).to have_http_status(:success)
       expect(JSON.parse(response.body)).to eq('deleted_node_ids' => [], 'deleted_connection_ids' => [])
       expect(root.reload).to be_present
-    end
-  end
-
-  describe 'POST #update_position' do
-    before { sign_in user }
-
-    it 'updates the node position' do
-      post update_position_bot_node_path(bot, node), params: { position_x: 150.5, position_y: 250.0 }
-      node.reload
-      expect(node.position_x).to eq(150.5)
-      expect(node.position_y).to eq(250.0)
-      expect(response).to have_http_status(:success)
     end
   end
 

--- a/spec/services/bot_compiler_spec.rb
+++ b/spec/services/bot_compiler_spec.rb
@@ -203,6 +203,21 @@ RSpec.describe BotCompiler do
       end
     end
 
+    context 'score nodes' do
+      let!(:root) { bot.root_node }
+      let!(:score) do
+        create(:node, :score, bot: bot, position_x: 100, position_y: 100, data: { actionType: 'set', value: 7 })
+      end
+
+      before { connect_nodes(root, score) }
+
+      it 'preserves score actionType and value in compiled output' do
+        compiled = described_class.new(bot).compile
+
+        expect(compiled[:nodes][score.id.to_s][:data]).to eq({ actionType: 'set', value: 7 })
+      end
+    end
+
     context 'disconnected nodes' do
       let!(:root) { bot.root_node }
       let!(:connected) { create(:node, :condition, bot: bot, position_x: 100, position_y: 100) }

--- a/spec/support/editor_v2_helpers.rb
+++ b/spec/support/editor_v2_helpers.rb
@@ -21,7 +21,7 @@ module EditorV2Helpers
       (function() {
         const nodes = window.editorAPI.store.getNodes();
         for (const node of nodes) {
-          const sid = window.editorAPI.api.getServerId(node.clientId);
+          const sid = window.editorAPI.api.getNodeServerId(node.clientId);
           if (sid === #{server_id}) {
             return node.clientId;
           }
@@ -46,7 +46,7 @@ module EditorV2Helpers
   # @param client_id [String] The client UUID
   # @return [Integer, nil] The server ID or nil if not found
   def get_server_id(client_id)
-    page.evaluate_script("window.editorAPI.api.getServerId('#{client_id}')")
+    page.evaluate_script("window.editorAPI.api.getNodeServerId('#{client_id}')")
   end
 
   # Wait for the editor to fully initialize

--- a/spec/support/editor_v2_helpers.rb
+++ b/spec/support/editor_v2_helpers.rb
@@ -1,21 +1,20 @@
 # frozen_string_literal: true
 
-# Helper methods for EditorV2 feature tests
-# Provides utilities for finding nodes by server ID via client ID mapping,
-# and common editor operations.
-
 require "timeout"
 
-# Timing constants for async operations
-ASYNC_WAIT = 0.5  # Wait for async server sync operations
-SELECTION_WAIT = 0.1  # Wait for selection animation
-MOUSE_CLICK_OFFSET = 5  # Offset from element edge for drag simulation
+DRAG_GRAB_OFFSET = 5
 
 module EditorV2Helpers
-  # Find a node's client ID given its server (database) ID
-  # Uses window.editorAPI to map server IDs to client IDs
-  # @param server_id [Integer] The database ID of the node
-  # @return [String, nil] The client UUID or nil if not found
+  def wait_until(timeout: Capybara.default_max_wait_time)
+    Timeout.timeout(timeout) { sleep 0.05 until yield }
+  rescue Timeout::Error
+    nil
+  end
+
+  def click_ignoring_overlap(element)
+    page.execute_script('arguments[0].click()', element)
+  end
+
   def find_node_client_id(server_id)
     page.evaluate_script(<<~JS)
       (function() {
@@ -31,58 +30,39 @@ module EditorV2Helpers
     JS
   end
 
-  # Find a node DOM element by its server (database) ID
-  # Uses the client ID mapping to find the correct element
-  # @param server_id [Integer] The database ID of the node
-  # @return [Capybara::Element] The node element
   def find_node_by_server_id(server_id)
     client_id = find_node_client_id(server_id)
     raise "No client ID found for server ID #{server_id}" if client_id.nil?
-    
+
     find(".node[data-client-id='#{client_id}']")
   end
 
-  # Get the server (database) ID for a client ID
-  # @param client_id [String] The client UUID
-  # @return [Integer, nil] The server ID or nil if not found
   def get_server_id(client_id)
     page.evaluate_script("window.editorAPI.api.getNodeServerId('#{client_id}')")
   end
 
-  # Wait for the editor to fully initialize
-  # Ensures canvas and nodes are present before proceeding
   def wait_for_editor
     expect(page).to have_css('#nodes-canvas', wait: 5)
     expect(page).to have_css('#connections-canvas', wait: 5)
-    # Wait for at least root node to be rendered
     expect(page).to have_css('.node', wait: 10)
   end
 
-  # Assert history count (format: "X/50")
-  # @param n [Integer] Expected history count
   def expect_history_count(n)
     expect(page).to have_css('.undo-count', text: /^\(#{n}\/50\)/, wait: 3)
   end
 
-  # Count visible nodes in DOM
-  # @return [Integer] Number of visible .node elements
   def visible_node_count
     all('.node').count
   end
 
-  # Wait for expected node count in DOM
-  # @param expected_count [Integer] Expected number of nodes
   def expect_node_count(expected_count)
     expect(page).to have_css('.node', count: expected_count, wait: 2)
   end
 
-  # Count connections in store
-  # @return [Integer] Number of connections
   def connection_count
     page.evaluate_script('window.editorAPI.store.getConnections().length')
   end
 
-  # Poll the connection store until it reaches the expected size.
   def expect_connection_count(expected_count)
     Timeout.timeout(Capybara.default_max_wait_time) do
       sleep 0.05 until connection_count == expected_count
@@ -93,80 +73,66 @@ module EditorV2Helpers
     expect(connection_count).to eq(expected_count)
   end
 
-  # Check if undo button is enabled
-  # Uses Capybara's built-in waiting for async state changes
-  # @return [Boolean] true if enabled, false if disabled
   def undo_enabled?
     page.has_button?('↩ Undo', disabled: false, wait: 2)
   end
 
-  # Check if redo button is enabled
-  # Uses Capybara's built-in waiting for async state changes
-  # @return [Boolean] true if enabled, false if disabled
   def redo_enabled?
     page.has_button?('↪ Redo', disabled: false, wait: 2)
   end
 
-  # Click undo button and wait for loading to complete
   def click_undo
     find('.btn-undo').click
     expect(page).not_to have_css('.btn-undo.loading', wait: 2)
   end
 
-  # Click redo button and wait for loading to complete
   def click_redo
     find('.btn-redo').click
     expect(page).not_to have_css('.btn-redo.loading', wait: 2)
   end
 
-  # Click undo button without waiting for loading (for error scenarios)
   def click_undo_without_waiting
     find('.btn-undo').click
   end
 
-  # Click redo button without waiting for loading (for error scenarios)
   def click_redo_without_waiting
     find('.btn-redo').click
   end
 
-  # Select a node by clicking it
-  # @param server_id [Integer] The database ID of the node
   def select_node(server_id)
-    element = find_node_by_server_id(server_id)
-    # Use JavaScript click to avoid header overlap issues at small viewport sizes
-    page.execute_script('arguments[0].click()', element)
-    sleep SELECTION_WAIT
+    client_id = find_node_client_id(server_id)
+    raise "No client ID found for server ID #{server_id}" if client_id.nil?
+    click_ignoring_overlap(find(".node[data-client-id='#{client_id}']"))
+    expect(page).to have_css(".node[data-client-id='#{client_id}'].selected", wait: Capybara.default_max_wait_time)
   end
 
-  # Delete the currently selected node via toolbar button
-  # Accepts the confirmation dialog
   def delete_selected_node
-    delete_button = find('.btn-delete-node')
-    # Use JavaScript click to avoid toolbar/header overlap issues in the feature-test viewport.
-    page.execute_script('arguments[0].click()', delete_button)
+    selected_client_ids = Array(page.evaluate_script('window.editorAPI.store.getSelectedNodeIds()'))
+    server_ids = selected_client_ids.map { |client_id| get_server_id(client_id) }.compact
+    click_ignoring_overlap(find('.btn-delete-node'))
     page.accept_confirm
-    sleep 0.3 # Wait for async deletion
+    selected_client_ids.each do |client_id|
+      expect(page).to have_no_css(".node[data-client-id='#{client_id}']", wait: 5)
+    end
+    wait_until { Node.where(id: server_ids).none? } if server_ids.any?
   end
 
-  # Create a connection by dragging from source to target
-  # @param source_server_id [Integer] The database ID of the source node
-  # @param target_server_id [Integer] The database ID of the target node
   def create_connection(source_server_id, target_server_id)
     source_client = find_node_client_id(source_server_id)
     target_client = find_node_client_id(target_server_id)
-    
+
     source_connector = find(".node[data-client-id='#{source_client}'] .node-connector.output")
     target_connector = find(".node[data-client-id='#{target_client}'] .node-connector.input")
-    
+
     source_connector.drag_to(target_connector)
-    sleep 0.3 # Wait for connection to be created
+    expect(page).to have_css(
+      "line.connection-line[data-source-id='#{source_client}'][data-target-id='#{target_client}']",
+      visible: :all,
+      wait: 5
+    )
+    wait_until { Connection.where(source_node_id: source_server_id, target_node_id: target_server_id).count.positive? }
   end
 
-  # Delete a connection via its delete button.
-  # The button is always mounted at the connection midpoint but CSS-hidden
-  # until hover, so locate it with visible: :all and click via JS.
-  # @param source_server_id [Integer] The database ID of the source node
-  # @param target_server_id [Integer] The database ID of the target node
   def delete_connection(source_server_id, target_server_id)
     source_client = find_node_client_id(source_server_id)
     target_client = find_node_client_id(target_server_id)
@@ -175,42 +141,30 @@ module EditorV2Helpers
       ".connection-delete-btn[data-source-id='#{source_client}'][data-target-id='#{target_client}']",
       visible: :all
     )
-    page.execute_script('arguments[0].click()', delete_btn)
+    click_ignoring_overlap(delete_btn)
 
     expect(page).to have_no_css(
       "line.connection-line[data-source-id='#{source_client}'][data-target-id='#{target_client}']",
       visible: :all,
       wait: 5
     )
+    wait_until { Connection.where(source_node_id: source_server_id, target_node_id: target_server_id).count.zero? }
   end
 
-  # Find a node in the database by its properties
   # Useful when server ID changes after undo/redo
-  # @param bot [Bot] The bot instance
-  # @param node_type [String] The node type
-  # @param position_x [Integer] X position
-  # @param position_y [Integer] Y position
-  # @param data [Hash] Optional data to match
-  # @return [Node, nil] The matching node or nil
   def find_node_by_properties(bot:, node_type:, position_x:, position_y:, data: {})
     Node.where(bot: bot, node_type: node_type, position_x: position_x, position_y: position_y)
         .detect { |n| data.all? { |k, v| n.data[k] == v } }
   end
 
-  # Get the current state from the editor API
-  # Useful for verifying client-side state
-  # @return [Hash] The serialized state
   def get_editor_state
     page.evaluate_script('window.editorAPI.store.getState()')
   end
 
-  # Check if the editor API is available
-  # @return [Boolean] true if editorAPI is defined
   def editor_api_available?
     page.evaluate_script('typeof window.editorAPI !== "undefined"')
   end
 
-  # Simulate network offline by mocking fetch
   def go_offline
     page.execute_script(<<~JS)
       window.__originalFetch = window.fetch;
@@ -218,33 +172,19 @@ module EditorV2Helpers
     JS
   end
 
-  # Restore network by restoring original fetch
   def go_online
     page.execute_script('window.fetch = window.__originalFetch;')
   end
 
-  # Simulate dragging a node to a new position
-  # All descendants will move with the node (unless Shift key is used)
-  # @param server_id [Integer] The database ID of the node
-  # @param new_x [Integer] Target X position
-  # @param new_y [Integer] Target Y position
-  def drag_node(server_id, new_x, new_y)
+  def drag_node_with_descendants(server_id, new_x, new_y)
     client_id = find_node_client_id(server_id)
-    
-    # Get current position from store
-    current = page.evaluate_script(<<~JS)
-      (function() {
-        const node = window.editorAPI.store.getNode('#{client_id}');
-        return { x: node.position.x, y: node.position.y };
-      })();
-    JS
-    
+
+    current = node_position(client_id)
     current_x = current['x']
     current_y = current['y']
-    start = graph_to_client_coordinates( current_x + MOUSE_CLICK_OFFSET, current_y + MOUSE_CLICK_OFFSET )
-    finish = graph_to_client_coordinates( new_x + MOUSE_CLICK_OFFSET, new_y + MOUSE_CLICK_OFFSET )
+    start = graph_to_client_coordinates(current_x + DRAG_GRAB_OFFSET, current_y + DRAG_GRAB_OFFSET)
+    finish = graph_to_client_coordinates(new_x + DRAG_GRAB_OFFSET, new_y + DRAG_GRAB_OFFSET)
 
-    
     page.execute_script(<<~JS)
       (function() {
         const el = document.querySelector('[data-client-id="#{client_id}"]');
@@ -286,29 +226,18 @@ module EditorV2Helpers
       })();
     JS
 
-    sleep ASYNC_WAIT
+    wait_until { at_position?(client_id, new_x, new_y) }
   end
 
-  # Simulate dragging a node with Shift key held (drag node only, no children)
-  # @param server_id [Integer] The database ID of the node
-  # @param new_x [Integer] Target X position
-  # @param new_y [Integer] Target Y position
-  def drag_node_with_shift(server_id, new_x, new_y)
+  def drag_single_node(server_id, new_x, new_y)
     client_id = find_node_client_id(server_id)
-    
-    # Get current position from store
-    current = page.evaluate_script(<<~JS)
-      (function() {
-        const node = window.editorAPI.store.getNode('#{client_id}');
-        return { x: node.position.x, y: node.position.y };
-      })();
-    JS
-    
+
+    current = node_position(client_id)
     current_x = current['x']
     current_y = current['y']
-    start = graph_to_client_coordinates( current_x + MOUSE_CLICK_OFFSET, current_y + MOUSE_CLICK_OFFSET )
-    finish = graph_to_client_coordinates( new_x + MOUSE_CLICK_OFFSET, new_y + MOUSE_CLICK_OFFSET )
-    
+    start = graph_to_client_coordinates(current_x + DRAG_GRAB_OFFSET, current_y + DRAG_GRAB_OFFSET)
+    finish = graph_to_client_coordinates(new_x + DRAG_GRAB_OFFSET, new_y + DRAG_GRAB_OFFSET)
+
     page.execute_script(<<~JS)
       (function() {
         const el = document.querySelector('[data-client-id="#{client_id}"]');
@@ -350,22 +279,23 @@ module EditorV2Helpers
         }));
       })();
     JS
-    
-    sleep ASYNC_WAIT
+
+    wait_until { at_position?(client_id, new_x, new_y) }
   end
 
-  # Assert that a node is at a specific position
-  # @param server_id [Integer] The database ID of the node
-  # @param expected_x [Integer] Expected X position
-  # @param expected_y [Integer] Expected Y position
+  def node_position(client_id)
+    page.evaluate_script("(function(){const n=window.editorAPI.store.getNode('#{client_id}');return n?{x:n.position.x,y:n.position.y}:null;})()")
+  end
+
+  def at_position?(client_id, x, y)
+    pos = node_position(client_id)
+    pos && (pos['x'].to_f - x).abs <= 0.5 && (pos['y'].to_f - y).abs <= 0.5
+  end
+
   def expect_node_position(server_id, expected_x, expected_y)
     client_id = find_node_client_id(server_id)
-    actual = page.evaluate_script(<<~JS)
-      (function() {
-        const node = window.editorAPI.store.getNode('#{client_id}');
-        return { x: node.position.x, y: node.position.y };
-      })();
-    JS
+    wait_until { at_position?(client_id, expected_x, expected_y) }
+    actual = node_position(client_id)
     expect(actual['x']).to be_within(0.5).of(expected_x)
     expect(actual['y']).to be_within(0.5).of(expected_y)
   end

--- a/spec/support/editor_v2_helpers.rb
+++ b/spec/support/editor_v2_helpers.rb
@@ -5,6 +5,8 @@ require "timeout"
 DRAG_GRAB_OFFSET = 5
 
 module EditorV2Helpers
+  # Polls until the block is truthy; on timeout it returns nil instead of raising,
+  # so pair it with an assertion when a stuck state should fail the test.
   def wait_until(timeout: Capybara.default_max_wait_time)
     Timeout.timeout(timeout) { sleep 0.05 until yield }
   rescue Timeout::Error


### PR DESCRIPTION
Code-review-driven cleanup of the bot editor area. No user-facing behavior
  change; one dead column dropped via migration. 7 commits, each self-contained.

  ## Bug fixes
  - `bots#edit`: fix N+1 + ignored eager-load on the editor's JSON load path
  - `EditorActions#togglePreview`: guard against a null-deref on multi-select
    when no board-state preview exists

  ## Dead code removed
  - Unused `update_position` and node `edit` actions (+ routes, specs)
  - Unused `bots.commands` column (migration) and its `bot_params`/`BotCloner` refs

  ## Refactors (behavior-preserving)
  - `BotCompiler#normalize_data`: select already-normalized keys instead of
    re-deriving each condition kind by hand (characterization spec asserts
    byte-identical compiled output)
  - `updateNodeData`: replace a double store-write with a `NODE_PERSISTED` event
    the renderer fetches previews on
  - Dedupe `Bot` scopes; extract `Bot.mark_stale_for`, `validate_keys`,
    `defaultViewState`
  - Rename API node id getters → `getNodeServerId`/`getNodeClientId`
  - Finish the action→score rename on the Ruby side (constants/methods only;
    the persisted `actionType` key is intentionally unchanged)

  ## Tests
  - De-flake the editor feature specs: deterministic waits + server-commit
    synchronization (closes an undo-vs-in-flight-delete race)

  ## Verification
  - `rspec --tag all`: 517 examples, 0 failures
  - `vitest run`: 1840 passed
  - Slow feature specs stabilized (was ~1-in-3 flaky → 8/8 consecutive)