### PR TITLE
Clean up the matches feature: bug fixes + refactors

### DIFF
--- a/app/controllers/concerns/matches/setup_form.rb
+++ b/app/controllers/concerns/matches/setup_form.rb
@@ -1,0 +1,11 @@
+module Matches::SetupForm
+  extend ActiveSupport::Concern
+
+  included { helper_method :user_has_no_own_bots? }
+
+  private
+
+  def user_has_no_own_bots?
+    current_user.nil? || current_user.bots.empty?
+  end
+end

--- a/app/controllers/concerns/matches/setup_form.rb
+++ b/app/controllers/concerns/matches/setup_form.rb
@@ -1,11 +1,15 @@
 module Matches::SetupForm
   extend ActiveSupport::Concern
 
-  included { helper_method :user_has_no_own_bots? }
+  included { helper_method :user_has_no_own_bots?, :stale_bot_message_template }
 
   private
 
   def user_has_no_own_bots?
     current_user.nil? || current_user.bots.empty?
+  end
+
+  def stale_bot_message_template
+    Matches::StaleBotConfirmation::MESSAGE_TEMPLATE
   end
 end

--- a/app/controllers/matches/bot_vs_bot_controller.rb
+++ b/app/controllers/matches/bot_vs_bot_controller.rb
@@ -27,8 +27,6 @@ class Matches::BotVsBotController < ApplicationController
   end
 
   def assign_form_state(setup)
-    @own_bot_options = setup.own_bots
-    @opponent_bot_options = setup.all_opponent_bots
     @selected_own_bot_id = setup.selected_own_bot_id
     @selected_opponent_bot_id = setup.selected_opponent_bot_id
   end
@@ -42,14 +40,14 @@ class Matches::BotVsBotController < ApplicationController
     }.compact
 
     @own_bots_pagy, @own_bots = pagy(
-      @own_bot_options.with_name(params[:own_bot_name]),
+      setup.own_bots.with_name(params[:own_bot_name]),
       limit: OWN_BOT_PAGE_SIZE,
       page_key: 'own_bot_page',
       page: params[:own_bot_page],
       params: shared_params.merge(opponent_page: params[:opponent_page])
     )
     @opponent_bots_pagy, @opponent_bots = pagy(
-      @opponent_bot_options.with_name(params[:opponent_name]),
+      setup.all_opponent_bots.with_name(params[:opponent_name]),
       limit: OPPONENT_PAGE_SIZE,
       page_key: 'opponent_page',
       page: params[:opponent_page] || default_opponent_page(setup),

--- a/app/controllers/matches/bot_vs_bot_controller.rb
+++ b/app/controllers/matches/bot_vs_bot_controller.rb
@@ -1,43 +1,39 @@
 class Matches::BotVsBotController < ApplicationController
+  include Matches::SetupForm
+
   OWN_BOT_PAGE_SIZE = 8
   OPPONENT_PAGE_SIZE = 12
 
   before_action :authenticate_registered_or_guest_user!, only: [:create]
 
   def new
-    creation = Matches::CreateBotVsBot.new(user: current_user, params: setup_params)
-    assign_form_state(creation)
-    paginate_bot_lists
-    @user_has_no_own_bots = current_user.nil? || current_user.bots.empty?
-
-    render 'matches/new'
+    render_form(Matches::CreateBotVsBot.new(user: current_user, params: setup_params))
   end
 
   def create
-    creation = Matches::CreateBotVsBot.new(user: current_user, params: match_params)
+    setup = Matches::CreateBotVsBot.new(user: current_user, params: match_params)
+    return redirect_to match_path(setup.match), notice: 'Match created. Generation will begin soon.' if setup.call
 
-    if creation.call
-      redirect_to match_path(creation.match), notice: 'Match created. Generation will begin soon.'
-    else
-      assign_form_state(creation)
-      paginate_bot_lists
-      @user_has_no_own_bots = current_user.nil? || current_user.bots.empty?
-      flash.now[:alert] = creation.error_message
-      render 'matches/new', status: :unprocessable_entity
-    end
+    flash.now[:alert] = setup.error_message
+    render_form(setup, status: :unprocessable_entity)
   end
 
   private
 
-  def assign_form_state(creation)
-    @own_bot_options = creation.own_bots
-    @opponent_bot_options = creation.all_opponent_bots
-    @selected_own_bot_id = creation.selected_own_bot_id
-    @selected_opponent_bot_id = creation.selected_opponent_bot_id
-    @opponent_landing_page = creation.opponent_page(per_page: OPPONENT_PAGE_SIZE)
+  def render_form(setup, status: :ok)
+    assign_form_state(setup)
+    paginate_bot_lists(setup)
+    render 'matches/new', status: status
   end
 
-  def paginate_bot_lists
+  def assign_form_state(setup)
+    @own_bot_options = setup.own_bots
+    @opponent_bot_options = setup.all_opponent_bots
+    @selected_own_bot_id = setup.selected_own_bot_id
+    @selected_opponent_bot_id = setup.selected_opponent_bot_id
+  end
+
+  def paginate_bot_lists(setup)
     shared_params = {
       own_bot_id: params[:own_bot_id],
       own_bot_name: params[:own_bot_name],
@@ -56,15 +52,15 @@ class Matches::BotVsBotController < ApplicationController
       @opponent_bot_options.with_name(params[:opponent_name]),
       limit: OPPONENT_PAGE_SIZE,
       page_key: 'opponent_page',
-      page: params[:opponent_page] || default_opponent_page,
+      page: params[:opponent_page] || default_opponent_page(setup),
       params: shared_params.merge(own_bot_page: params[:own_bot_page])
     )
   end
 
-  def default_opponent_page
+  def default_opponent_page(setup)
     return if params[:opponent_name].present?
 
-    @opponent_landing_page
+    setup.opponent_page(per_page: OPPONENT_PAGE_SIZE)
   end
 
   def setup_params

--- a/app/controllers/matches/bot_vs_bot_controller.rb
+++ b/app/controllers/matches/bot_vs_bot_controller.rb
@@ -1,4 +1,5 @@
 class Matches::BotVsBotController < ApplicationController
+  OWN_BOT_PAGE_SIZE = 8
   OPPONENT_PAGE_SIZE = 12
 
   before_action :authenticate_registered_or_guest_user!, only: [:create]
@@ -29,8 +30,8 @@ class Matches::BotVsBotController < ApplicationController
   private
 
   def assign_form_state(creation)
-    @own_bots = creation.own_bots
-    @all_opponent_bots = creation.all_opponent_bots
+    @own_bot_options = creation.own_bots
+    @opponent_bot_options = creation.all_opponent_bots
     @selected_own_bot_id = creation.selected_own_bot_id
     @selected_opponent_bot_id = creation.selected_opponent_bot_id
     @opponent_landing_page = creation.opponent_page(per_page: OPPONENT_PAGE_SIZE)
@@ -45,14 +46,14 @@ class Matches::BotVsBotController < ApplicationController
     }.compact
 
     @own_bots_pagy, @own_bots = pagy(
-      @own_bots.with_name(params[:own_bot_name]),
-      limit: 8,
+      @own_bot_options.with_name(params[:own_bot_name]),
+      limit: OWN_BOT_PAGE_SIZE,
       page_key: 'own_bot_page',
       page: params[:own_bot_page],
       params: shared_params.merge(opponent_page: params[:opponent_page])
     )
     @opponent_bots_pagy, @opponent_bots = pagy(
-      @all_opponent_bots.with_name(params[:opponent_name]),
+      @opponent_bot_options.with_name(params[:opponent_name]),
       limit: OPPONENT_PAGE_SIZE,
       page_key: 'opponent_page',
       page: params[:opponent_page] || default_opponent_page,

--- a/app/controllers/matches/human_vs_bot_controller.rb
+++ b/app/controllers/matches/human_vs_bot_controller.rb
@@ -46,19 +46,18 @@ class Matches::HumanVsBotController < ApplicationController
 
   def render_form(setup, status: :ok)
     assign_form_state(setup)
-    paginate_bot_list
+    paginate_bot_list(setup)
     render 'matches/new_human_vs_bot', status: status
   end
 
   def assign_form_state(setup)
-    @play_bots = setup.play_bots
     @selected_bot_id = setup.selected_bot_id
     @selected_color = setup.selected_color
   end
 
-  def paginate_bot_list
+  def paginate_bot_list(setup)
     @play_bots_pagy, @play_bots = pagy(
-      @play_bots.with_name(params[:bot_name]),
+      setup.play_bots.with_name(params[:bot_name]),
       limit: BOT_PAGE_SIZE,
       page_key: 'bot_page',
       page: params[:bot_page],

--- a/app/controllers/matches/human_vs_bot_controller.rb
+++ b/app/controllers/matches/human_vs_bot_controller.rb
@@ -20,7 +20,7 @@ class Matches::HumanVsBotController < ApplicationController
 
   def live
     @match = current_user.created_matches.find(params[:id])
-    unless @match.running? && @match.interactive_human_vs_bot_for?(current_user)
+    unless @match.running? && @match.human_vs_bot_for?(current_user)
       return redirect_to match_path(@match), alert: 'This match is no longer playable.'
     end
 

--- a/app/controllers/matches/human_vs_bot_controller.rb
+++ b/app/controllers/matches/human_vs_bot_controller.rb
@@ -1,30 +1,21 @@
 class Matches::HumanVsBotController < ApplicationController
+  include Matches::SetupForm
+
   BOT_PAGE_SIZE = 8
 
   before_action -> { current_user_or_create_guest! }, only: [:create]
   before_action :authenticate_registered_or_guest_user!, only: [:live, :complete]
 
   def new
-    creation = Matches::CreateHumanVsBot.new(user: current_user, params: setup_params)
-    assign_form_state(creation)
-    paginate_bot_list
-    @user_has_no_own_bots = current_user.nil? || current_user.bots.empty?
-
-    render 'matches/new_human_vs_bot'
+    render_form(Matches::CreateHumanVsBot.new(user: current_user, params: setup_params))
   end
 
   def create
-    creation = Matches::CreateHumanVsBot.new(user: current_user, params: match_params)
+    setup = Matches::CreateHumanVsBot.new(user: current_user, params: match_params)
+    return redirect_to live_human_vs_bot_match_path(setup.match) if setup.call
 
-    if creation.call
-      redirect_to live_human_vs_bot_match_path(creation.match)
-    else
-      assign_form_state(creation)
-      paginate_bot_list
-      @user_has_no_own_bots = current_user.bots.empty?
-      flash.now[:alert] = creation.error_message
-      render 'matches/new_human_vs_bot', status: :unprocessable_entity
-    end
+    flash.now[:alert] = setup.error_message
+    render_form(setup, status: :unprocessable_entity)
   end
 
   def live
@@ -53,10 +44,16 @@ class Matches::HumanVsBotController < ApplicationController
 
   private
 
-  def assign_form_state(creation)
-    @play_bots = creation.play_bots
-    @selected_bot_id = creation.selected_bot_id
-    @selected_color = creation.selected_color
+  def render_form(setup, status: :ok)
+    assign_form_state(setup)
+    paginate_bot_list
+    render 'matches/new_human_vs_bot', status: status
+  end
+
+  def assign_form_state(setup)
+    @play_bots = setup.play_bots
+    @selected_bot_id = setup.selected_bot_id
+    @selected_color = setup.selected_color
   end
 
   def paginate_bot_list

--- a/app/controllers/matches/human_vs_bot_controller.rb
+++ b/app/controllers/matches/human_vs_bot_controller.rb
@@ -61,7 +61,7 @@ class Matches::HumanVsBotController < ApplicationController
     @play_bots_pagy, @play_bots = pagy(
       @play_bots.with_name(params[:bot_name]),
       limit: 8,
-      page_param: :bot_page,
+      page_key: 'bot_page',
       page: params[:bot_page],
       params: { bot_id: params[:bot_id], bot_name: params[:bot_name], human_color: params[:human_color] }.compact
     )

--- a/app/controllers/matches/human_vs_bot_controller.rb
+++ b/app/controllers/matches/human_vs_bot_controller.rb
@@ -1,4 +1,6 @@
 class Matches::HumanVsBotController < ApplicationController
+  BOT_PAGE_SIZE = 8
+
   before_action -> { current_user_or_create_guest! }, only: [:create]
   before_action :authenticate_registered_or_guest_user!, only: [:live, :complete]
 
@@ -27,7 +29,7 @@ class Matches::HumanVsBotController < ApplicationController
 
   def live
     @match = current_user.created_matches.find(params[:id])
-    unless @match.running? && interactive_play_match?(@match)
+    unless @match.running? && @match.interactive_human_vs_bot_for?(current_user)
       return redirect_to match_path(@match), alert: 'This match is no longer playable.'
     end
 
@@ -60,17 +62,11 @@ class Matches::HumanVsBotController < ApplicationController
   def paginate_bot_list
     @play_bots_pagy, @play_bots = pagy(
       @play_bots.with_name(params[:bot_name]),
-      limit: 8,
+      limit: BOT_PAGE_SIZE,
       page_key: 'bot_page',
       page: params[:bot_page],
       params: { bot_id: params[:bot_id], bot_name: params[:bot_name], human_color: params[:human_color] }.compact
     )
-  end
-
-  def interactive_play_match?(match)
-    players = [match.white_player, match.black_player]
-    players.count { |player| player == current_user } == 1 &&
-      players.count { |player| player.is_a?(Bot) } == 1
   end
 
   def setup_params

--- a/app/javascript/controllers/match_setup_controller.js
+++ b/app/javascript/controllers/match_setup_controller.js
@@ -14,7 +14,7 @@ export default class extends Controller {
     const staleOwnedBots = this.selectedStaleOwnedBots()
     if (staleOwnedBots.length === 0) { return }
     event.preventDefault()
-    const names = staleOwnedBots.map(bot => bot.name).join(' and ')
+    const names = [...new Set(staleOwnedBots.map(bot => bot.name))].join(' and ')
     const message = this.staleMessageTemplateValue.replace('%{names}', names)
     if (!window.confirm(message)) { return }
     this.staleBotConfirmationTarget.value = 'compile'

--- a/app/javascript/controllers/match_setup_controller.js
+++ b/app/javascript/controllers/match_setup_controller.js
@@ -2,6 +2,7 @@ import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
   static targets = ["staleBotConfirmation", "form", "opponentForm", "ownBotIdField"]
+  static values = { staleMessageTemplate: String }
 
   ownBotChosen(event) {
     this.ownBotIdFieldTargets.forEach((field) => { field.value = event.target.value })
@@ -13,9 +14,8 @@ export default class extends Controller {
     const staleOwnedBots = this.selectedStaleOwnedBots()
     if (staleOwnedBots.length === 0) { return }
     event.preventDefault()
-    const message = staleOwnedBots.length === 1
-      ? `${staleOwnedBots[0].name} needs to be recompiled before match generation. Compile and continue?`
-      : `${staleOwnedBots.map(bot => bot.name).join(' and ')} each need to be recompiled before match generation. Compile both and continue?`
+    const names = staleOwnedBots.map(bot => bot.name).join(' and ')
+    const message = this.staleMessageTemplateValue.replace('%{names}', names)
     if (!window.confirm(message)) { return }
     this.staleBotConfirmationTarget.value = 'compile'
     this.formTarget.submit()

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -123,18 +123,18 @@ class Match < ApplicationRecord
 
   private
 
-  def normalize_player(player)
-    symbol = player.to_sym
-    return symbol if %i[white black].include?(symbol)
-
-    raise ArgumentError, "Unknown match player: #{player.inspect}"
-  end
-
   def tournament_compiled_program_snapshot_for(player)
     tournament_entry = tournament_entry_for_player(player)
     return tournament_entry.frozen_compiled_program_snapshot if tournament_entry&.frozen_compiled_program_snapshot.present?
 
     nil
+  end
+
+  def normalize_player(player)
+    symbol = player.to_sym
+    return symbol if %i[white black].include?(symbol)
+
+    raise ArgumentError, "Unknown match player: #{player.inspect}"
   end
 
   def tournament_entry_for_player(player)

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -70,6 +70,13 @@ class Match < ApplicationRecord
     (black_player_type == 'Bot' && black_player&.user_id == user.id)
   end
 
+  def interactive_human_vs_bot_for?(user)
+    return false unless user
+    players = [white_player, black_player]
+    players.count { |player| player == user } == 1 &&
+      players.count { |player| player.is_a?(Bot) } == 1
+  end
+
   def first_bot_match_for?(user)
     return false unless bot_owned_by?(user)
     bot_ids = user.bots.pluck(:id)
@@ -84,14 +91,7 @@ class Match < ApplicationRecord
   def compiled_program_snapshot_for(player)
     return tournament_compiled_program_snapshot_for(player) if tournament.present?
 
-    case player.to_sym
-    when :white
-      white_compiled_program_snapshot
-    when :black
-      black_compiled_program_snapshot
-    else
-      raise ArgumentError, "Unknown match player for compiled program snapshot: #{player.inspect}"
-    end
+    normalize_player(player) == :white ? white_compiled_program_snapshot : black_compiled_program_snapshot
   end
 
   def player_display_name_for(player)
@@ -102,12 +102,18 @@ class Match < ApplicationRecord
     fallback_player_label(player)
   end
 
+  def bot_owner_id_for(player)
+    tournament_entry = tournament_entry_for_player(player)
+    return tournament_entry.bot_owner_id if tournament_entry&.bot_owner_id
+
+    record = player_record_for(player)
+    record.is_a?(Bot) ? record.user_id : ''
+  end
+
   def winner
-    return false if result != "white_win" && result != "black_win"
-    if result == "white_win"
-      player_display_name_for(:white)
-    else
-      player_display_name_for(:black)
+    case result
+    when "white_win" then player_display_name_for(:white)
+    when "black_win" then player_display_name_for(:black)
     end
   end
 
@@ -117,6 +123,13 @@ class Match < ApplicationRecord
 
   private
 
+  def normalize_player(player)
+    symbol = player.to_sym
+    return symbol if %i[white black].include?(symbol)
+
+    raise ArgumentError, "Unknown match player: #{player.inspect}"
+  end
+
   def tournament_compiled_program_snapshot_for(player)
     tournament_entry = tournament_entry_for_player(player)
     return tournament_entry.frozen_compiled_program_snapshot if tournament_entry&.frozen_compiled_program_snapshot.present?
@@ -125,36 +138,16 @@ class Match < ApplicationRecord
   end
 
   def tournament_entry_for_player(player)
-    case player.to_sym
-    when :white
-      white_tournament_entry
-    when :black
-      black_tournament_entry
-    else
-      raise ArgumentError, "Unknown match player: #{player.inspect}"
-    end
+    normalize_player(player) == :white ? white_tournament_entry : black_tournament_entry
   end
 
   def player_record_for(player)
-    case player.to_sym
-    when :white
-      white_player
-    when :black
-      black_player
-    else
-      raise ArgumentError, "Unknown match player: #{player.inspect}"
-    end
+    normalize_player(player) == :white ? white_player : black_player
   end
 
   def fallback_player_label(player)
-    case player.to_sym
-    when :white
-      "#{white_player_type} #{white_player_id}".strip.presence || 'Unknown player'
-    when :black
-      "#{black_player_type} #{black_player_id}".strip.presence || 'Unknown player'
-    else
-      raise ArgumentError, "Unknown match player: #{player.inspect}"
-    end
+    type, id = normalize_player(player) == :white ? [white_player_type, white_player_id] : [black_player_type, black_player_id]
+    "#{type} #{id}".strip.presence || 'Unknown player'
   end
 
   def completed_matches_require_replay_state

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -61,9 +61,6 @@ class Match < ApplicationRecord
 
   validate :completed_matches_require_replay_state
 
-  scope :active, -> { where(status: [statuses[:queued], statuses[:running]]) }
-  scope :unfinished, -> { where(status: [statuses[:pending], statuses[:queued], statuses[:running]]) }
-
   def bot_owned_by?(user)
     return false unless user
     (white_player_type == 'Bot' && white_player&.user_id == user.id) ||

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -67,7 +67,7 @@ class Match < ApplicationRecord
     (black_player_type == 'Bot' && black_player&.user_id == user.id)
   end
 
-  def interactive_human_vs_bot_for?(user)
+  def human_vs_bot_for?(user)
     return false unless user
     players = [white_player, black_player]
     players.count { |player| player == user } == 1 &&
@@ -104,7 +104,7 @@ class Match < ApplicationRecord
     return tournament_entry.bot_owner_id if tournament_entry&.bot_owner_id
 
     record = player_record_for(player)
-    record.is_a?(Bot) ? record.user_id : ''
+    record.user_id if record.is_a?(Bot)
   end
 
   def winner

--- a/app/services/matches/complete_human_vs_bot.rb
+++ b/app/services/matches/complete_human_vs_bot.rb
@@ -9,7 +9,7 @@ class Matches::CompleteHumanVsBot
 
   def call
     @match = @user.created_matches.find(@match_id)
-    raise ActiveRecord::RecordNotFound unless interactive_play_match?
+    raise ActiveRecord::RecordNotFound unless match.interactive_human_vs_bot_for?(@user)
 
     return true if match.completed? || match.failed?
 
@@ -24,12 +24,6 @@ class Matches::CompleteHumanVsBot
   end
 
   private
-
-  def interactive_play_match?
-    players = [match.white_player, match.black_player]
-    players.count { |player| player == @user } == 1 &&
-      players.count { |player| player.is_a?(Bot) } == 1
-  end
 
   def fail_match
     match.update!(

--- a/app/services/matches/complete_human_vs_bot.rb
+++ b/app/services/matches/complete_human_vs_bot.rb
@@ -34,19 +34,29 @@ class Matches::CompleteHumanVsBot
   end
 
   def complete_match
-    match.update!(
+    attributes = replay_attributes
+    return false unless attributes
+
+    match.update!(attributes)
+  end
+
+  def replay_attributes
+    {
       status: :completed,
+      error_message: nil,
       result: @params.fetch(:result),
       lay_out: @params.fetch(:lay_out),
       captured_pieces: @params.fetch(:captured_pieces),
       allowed_to_move: @params.fetch(:allowed_to_move),
       movement_notation: @params.fetch(:movement_notation),
-      previous_layouts: @params.fetch(:previous_layouts),
-      error_message: nil
-    )
+      previous_layouts: @params.fetch(:previous_layouts)
+    }
   rescue KeyError => error
-    field = error.is_a?(ActionController::ParameterMissing) ? error.param : error.key
-    fail_with("Missing match completion field: #{field}.")
+    fail_with("Missing match completion field: #{missing_field(error)}.")
+  end
+
+  def missing_field(error)
+    error.is_a?(ActionController::ParameterMissing) ? error.param : error.key
   end
 
   def fail_with(message)

--- a/app/services/matches/complete_human_vs_bot.rb
+++ b/app/services/matches/complete_human_vs_bot.rb
@@ -9,7 +9,7 @@ class Matches::CompleteHumanVsBot
 
   def call
     @match = @user.created_matches.find(@match_id)
-    raise ActiveRecord::RecordNotFound unless match.interactive_human_vs_bot_for?(@user)
+    raise ActiveRecord::RecordNotFound unless match.human_vs_bot_for?(@user)
 
     return true if match.completed? || match.failed?
 

--- a/app/services/matches/complete_human_vs_bot.rb
+++ b/app/services/matches/complete_human_vs_bot.rb
@@ -50,6 +50,9 @@ class Matches::CompleteHumanVsBot
       previous_layouts: @params.fetch(:previous_layouts),
       error_message: nil
     )
+  rescue KeyError => error
+    field = error.is_a?(ActionController::ParameterMissing) ? error.param : error.key
+    fail_with("Missing match completion field: #{field}.")
   end
 
   def fail_with(message)

--- a/app/services/matches/create_bot_vs_bot.rb
+++ b/app/services/matches/create_bot_vs_bot.rb
@@ -68,13 +68,14 @@ class Matches::CreateBotVsBot
 
   def load_bot_options
     if @user
-      @own_bots = @user.bots.order(:name)
+      @own_bots = @user.bots.includes(:user).order(:name)
       @all_opponent_bots = Bot.where(user: @user)
                              .or(Bot.compiled.where.not(user: @user))
+                             .includes(:user)
                              .order(:rating)
     else
       @own_bots = Bot.none
-      @all_opponent_bots = Bot.compiled.order(:rating)
+      @all_opponent_bots = Bot.compiled.includes(:user).order(:rating)
     end
   end
 

--- a/app/services/matches/create_bot_vs_bot.rb
+++ b/app/services/matches/create_bot_vs_bot.rb
@@ -1,4 +1,6 @@
 class Matches::CreateBotVsBot
+  include Matches::StaleBotConfirmation
+
   attr_reader :all_opponent_bots,
     :error_message,
     :match,
@@ -92,22 +94,11 @@ class Matches::CreateBotVsBot
     bots.compact.select { |bot| bot.user_id == @user.id && bot.compiled_program_stale? }
   end
 
-  def compile_confirmation_requested?
-    @params[:stale_bot_confirmation] == 'compile'
-  end
-
   def compile_selected_bots(bots)
     bots.each(&:compile_program!)
     true
   rescue StandardError => error
     fail_with("Selected stale bot#{'s' if bots.length != 1} could not be compiled: #{error.message}")
-  end
-
-  def stale_compile_message(bots)
-    names = bots.map(&:name).uniq.join(', ')
-    return "#{names} needs to be recompiled before match generation." if bots.length == 1
-
-    "#{names} each need to be recompiled before match generation."
   end
 
   def fail_with(message)

--- a/app/services/matches/create_human_vs_bot.rb
+++ b/app/services/matches/create_human_vs_bot.rb
@@ -1,4 +1,6 @@
 class Matches::CreateHumanVsBot
+  include Matches::StaleBotConfirmation
+
   attr_reader :error_message, :match, :play_bots, :selected_bot_id, :selected_color
 
   def initialize(user:, params:)
@@ -59,19 +61,11 @@ class Matches::CreateHumanVsBot
     play_bots.find_by(id: selected_bot_id)
   end
 
-  def compile_confirmation_requested?
-    @params[:stale_bot_confirmation] == 'compile'
-  end
-
   def compile_bot(bot)
     bot.compile_program!
     true
   rescue StandardError => error
     fail_with("Bot could not be compiled: #{error.message}")
-  end
-
-  def stale_compile_message(bot)
-    "#{bot.name} needs to be recompiled before you can play. Compile and continue?"
   end
 
   def resolve_human_team(color)

--- a/app/services/matches/stale_bot_confirmation.rb
+++ b/app/services/matches/stale_bot_confirmation.rb
@@ -1,0 +1,19 @@
+module Matches::StaleBotConfirmation
+  CONFIRMATION_VALUE = 'compile'
+  MESSAGE_TEMPLATE = '%{names} must be recompiled first. Compile and continue?'
+
+  def self.message_for(bots)
+    names = Array(bots).map(&:name).uniq.join(' and ')
+    format(MESSAGE_TEMPLATE, names: names)
+  end
+
+  private
+
+  def compile_confirmation_requested?
+    @params[:stale_bot_confirmation] == CONFIRMATION_VALUE
+  end
+
+  def stale_compile_message(bots)
+    Matches::StaleBotConfirmation.message_for(bots)
+  end
+end

--- a/app/views/matches/_bot_list.html.erb
+++ b/app/views/matches/_bot_list.html.erb
@@ -1,0 +1,18 @@
+<div class="match-bot-list-frame">
+  <div class="match-bot-list">
+    <% bots.each do |bot| %>
+      <%= render 'matches/bot_option',
+        bot: bot,
+        radio_name: radio_name,
+        checked: selected_id.to_i == bot.id,
+        change_action: local_assigns[:change_action],
+        show_details: show_details %>
+    <% end %>
+  </div>
+  <div class="match-bot-scroll-track" aria-hidden="true">
+    <div class="match-bot-scroll-thumb"></div>
+  </div>
+</div>
+<div class="index-pagination">
+  <%== pagy.series_nav if pagy.pages > 1 %>
+</div>

--- a/app/views/matches/_bot_option.html.erb
+++ b/app/views/matches/_bot_option.html.erb
@@ -1,0 +1,20 @@
+<% owned = current_user.present? && bot.user_id == current_user.id %>
+<label class="match-bot-option">
+  <input type="radio"
+    name="<%= radio_name %>"
+    value="<%= bot.id %>"
+    form="match-form"
+    <%= 'checked' if checked %>
+    <% if local_assigns[:change_action].present? %>data-action="<%= change_action %>"<% end %>
+    data-bot-name="<%= bot.name %>"
+    data-bot-stale="<%= bot.compiled_program_stale? %>"
+    data-bot-owned="<%= owned %>">
+  <span>
+    <strong><%= bot.name %></strong>
+    <% if show_details %>
+      <small class="match-bot-rating"><%= bot.rating.round %></small>
+      <small>by <%= bot.user.email %></small>
+    <% end %>
+    <%= ' (needs recompile)' if bot.compiled_program_stale? %>
+  </span>
+</label>

--- a/app/views/matches/live.html.erb
+++ b/app/views/matches/live.html.erb
@@ -25,7 +25,4 @@
 
     <%= render 'shared/match_arena', match: @match %>
   </div>
-
-  <button id="undo-button">undo</button>
-  <button id="pause-button">pause</button>
 </div>

--- a/app/views/matches/new.html.erb
+++ b/app/views/matches/new.html.erb
@@ -1,5 +1,5 @@
 <div class="match-setup-page" data-controller="match-setup"
-  data-match-setup-stale-message-template-value="<%= Matches::StaleBotConfirmation::MESSAGE_TEMPLATE %>">
+  data-match-setup-stale-message-template-value="<%= stale_bot_message_template %>">
   <h1>Set Up Match</h1>
   <p>Choose one of your bots and an opponent. Colors will be assigned randomly.</p>
   <p><%= link_to 'Play against one of your bots instead', new_human_vs_bot_match_path %></p>

--- a/app/views/matches/new.html.erb
+++ b/app/views/matches/new.html.erb
@@ -1,4 +1,5 @@
-<div class="match-setup-page" data-controller="match-setup">
+<div class="match-setup-page" data-controller="match-setup"
+  data-match-setup-stale-message-template-value="<%= Matches::StaleBotConfirmation::MESSAGE_TEMPLATE %>">
   <h1>Set Up Match</h1>
   <p>Choose one of your bots and an opponent. Colors will be assigned randomly.</p>
   <p><%= link_to 'Play against one of your bots instead', new_human_vs_bot_match_path %></p>

--- a/app/views/matches/new.html.erb
+++ b/app/views/matches/new.html.erb
@@ -3,7 +3,7 @@
   <h1>Set Up Match</h1>
   <p>Choose one of your bots and an opponent. Colors will be assigned randomly.</p>
   <p><%= link_to 'Play against one of your bots instead', new_human_vs_bot_match_path %></p>
-  <% if @user_has_no_own_bots %>
+  <% if user_has_no_own_bots? %>
     <p class="notice">You don't have any bots yet. <%= link_to 'Build one', new_bot_path %> to get started.</p>
   <% end %>
 

--- a/app/views/matches/new.html.erb
+++ b/app/views/matches/new.html.erb
@@ -32,35 +32,13 @@
             <%= f.hidden_field :opponent_page, value: params[:opponent_page] %>
             <%= f.text_field :own_bot_name, value: params[:own_bot_name], placeholder: 'Search by name', class: 'index-filter-input match-setup-filter-input' %>
           <% end %>
-          <div class="match-bot-list-frame">
-            <div class="match-bot-list">
-              <% @own_bots.each do |bot| %>
-                <label class="match-bot-option">
-                  <input type="radio"
-                    name="match[own_bot_id]"
-                    value="<%= bot.id %>"
-                    form="match-form"
-                    data-action="change->match-setup#ownBotChosen"
-                    <%= 'checked' if @selected_own_bot_id.to_i == bot.id %>
-                    data-bot-name="<%= bot.name %>"
-                    data-bot-stale="<%= bot.compiled_program_stale? %>"
-                    data-bot-owned="true">
-                  <span>
-                    <strong><%= bot.name %></strong>
-                    <small class="match-bot-rating"><%= bot.rating.round %></small>
-                    <small>by <%= bot.user.email %></small>
-                    <%= ' (needs recompile)' if bot.compiled_program_stale? %>
-                  </span>
-                </label>
-              <% end %>
-            </div>
-            <div class="match-bot-scroll-track" aria-hidden="true">
-              <div class="match-bot-scroll-thumb"></div>
-            </div>
-          </div>
-          <div class="index-pagination">
-            <%== @own_bots_pagy.series_nav if @own_bots_pagy.pages > 1 %>
-          </div>
+          <%= render 'matches/bot_list',
+            bots: @own_bots,
+            pagy: @own_bots_pagy,
+            radio_name: 'match[own_bot_id]',
+            selected_id: @selected_own_bot_id,
+            change_action: 'change->match-setup#ownBotChosen',
+            show_details: true %>
         <% end %>
       </div>
       <button type="submit" form="match-form" class="btn btn-primary">Create Match</button>
@@ -77,34 +55,12 @@
             <%= f.hidden_field :own_bot_page, value: params[:own_bot_page] %>
             <%= f.text_field :opponent_name, value: params[:opponent_name], placeholder: 'Search by name', class: 'index-filter-input match-setup-filter-input' %>
           <% end %>
-          <div class="match-bot-list-frame">
-            <div class="match-bot-list">
-              <% @opponent_bots.each do |bot| %>
-                <label class="match-bot-option">
-                  <input type="radio"
-                    name="match[opponent_bot_id]"
-                    value="<%= bot.id %>"
-                    form="match-form"
-                    <%= 'checked' if @selected_opponent_bot_id.to_i == bot.id %>
-                    data-bot-name="<%= bot.name %>"
-                    data-bot-stale="<%= bot.compiled_program_stale? %>"
-                    data-bot-owned="<%= current_user && bot.user_id == current_user.id %>">
-                  <span>
-                    <strong><%= bot.name %></strong>
-                    <small class="match-bot-rating"><%= bot.rating.round %></small>
-                    <small>by <%= bot.user.email %></small>
-                    <%= ' (needs recompile)' if bot.compiled_program_stale? %>
-                  </span>
-                </label>
-              <% end %>
-            </div>
-            <div class="match-bot-scroll-track" aria-hidden="true">
-              <div class="match-bot-scroll-thumb"></div>
-            </div>
-          </div>
-          <div class="index-pagination">
-            <%== @opponent_bots_pagy.series_nav if @opponent_bots_pagy.pages > 1 %>
-          </div>
+          <%= render 'matches/bot_list',
+            bots: @opponent_bots,
+            pagy: @opponent_bots_pagy,
+            radio_name: 'match[opponent_bot_id]',
+            selected_id: @selected_opponent_bot_id,
+            show_details: true %>
         <% end %>
       </div>
     </div>

--- a/app/views/matches/new_human_vs_bot.html.erb
+++ b/app/views/matches/new_human_vs_bot.html.erb
@@ -3,7 +3,7 @@
   <h1>Play Against Your Bot</h1>
   <p>Choose a bot, pick a side, and play a persisted match.</p>
   <p><%= link_to 'Set up a bot vs bot match instead', new_bot_vs_bot_match_path %></p>
-  <% if @user_has_no_own_bots %>
+  <% if user_has_no_own_bots? %>
     <p class="notice">You don't have any bots yet. <%= link_to 'Build one', new_bot_path %> to get started.</p>
   <% end %>
 

--- a/app/views/matches/new_human_vs_bot.html.erb
+++ b/app/views/matches/new_human_vs_bot.html.erb
@@ -30,32 +30,12 @@
             <%= f.hidden_field :human_color, value: params[:human_color] %>
             <%= f.text_field :bot_name, value: params[:bot_name], placeholder: 'Search by name', class: 'index-filter-input match-setup-filter-input' %>
           <% end %>
-          <div class="match-bot-list-frame">
-            <div class="match-bot-list">
-              <% @play_bots.each do |bot| %>
-                <label class="match-bot-option">
-                  <input type="radio"
-                    name="match[bot_id]"
-                    value="<%= bot.id %>"
-                    form="match-form"
-                    <%= 'checked' if @selected_bot_id.to_i == bot.id %>
-                    data-bot-name="<%= bot.name %>"
-                    data-bot-stale="<%= bot.compiled_program_stale? %>"
-                    data-bot-owned="<%= current_user && bot.user_id == current_user.id %>">
-                  <span>
-                    <strong><%= bot.name %></strong>
-                    <%= ' (needs recompile)' if bot.compiled_program_stale? %>
-                  </span>
-                </label>
-              <% end %>
-            </div>
-            <div class="match-bot-scroll-track" aria-hidden="true">
-              <div class="match-bot-scroll-thumb"></div>
-            </div>
-          </div>
-          <div class="index-pagination">
-            <%== @play_bots_pagy.series_nav if @play_bots_pagy.pages > 1 %>
-          </div>
+          <%= render 'matches/bot_list',
+            bots: @play_bots,
+            pagy: @play_bots_pagy,
+            radio_name: 'match[bot_id]',
+            selected_id: @selected_bot_id,
+            show_details: false %>
         <% end %>
       </div>
       <button type="submit" form="match-form" class="btn btn-primary">Start Game</button>

--- a/app/views/matches/new_human_vs_bot.html.erb
+++ b/app/views/matches/new_human_vs_bot.html.erb
@@ -1,5 +1,5 @@
 <div class="match-setup-page" data-controller="match-setup"
-  data-match-setup-stale-message-template-value="<%= Matches::StaleBotConfirmation::MESSAGE_TEMPLATE %>">
+  data-match-setup-stale-message-template-value="<%= stale_bot_message_template %>">
   <h1>Play Against Your Bot</h1>
   <p>Choose a bot, pick a side, and play a persisted match.</p>
   <p><%= link_to 'Set up a bot vs bot match instead', new_bot_vs_bot_match_path %></p>

--- a/app/views/matches/new_human_vs_bot.html.erb
+++ b/app/views/matches/new_human_vs_bot.html.erb
@@ -1,4 +1,5 @@
-<div class="match-setup-page" data-controller="match-setup">
+<div class="match-setup-page" data-controller="match-setup"
+  data-match-setup-stale-message-template-value="<%= Matches::StaleBotConfirmation::MESSAGE_TEMPLATE %>">
   <h1>Play Against Your Bot</h1>
   <p>Choose a bot, pick a side, and play a persisted match.</p>
   <p><%= link_to 'Set up a bot vs bot match instead', new_bot_vs_bot_match_path %></p>

--- a/app/views/matches/sandbox.html.erb
+++ b/app/views/matches/sandbox.html.erb
@@ -1,18 +1,13 @@
-<div class="game-page" data-game-controller-page="true"><div id="arena">
-  <div id="notifications"></div>
-  <div id="turn-marker"><span id="team-allowed-to-move">white</span>'s turn</div>
-  <div id="W-captures" class="captures">
-    <br><br><br>
+<div class="game-page" data-game-controller-page="true">
+  <div id="arena">
+    <div id="notifications"></div>
+    <div id="turn-marker"><span id="team-allowed-to-move">white</span>'s turn</div>
+    <div id="W-captures" class="captures">
+      <br><br><br>
+    </div>
+    <%= render partial: 'shared/chess_board' %>
+    <div id="B-captures" class="captures">
+      <br><br><br>
+    </div>
   </div>
-  <%= render partial: 'shared/chess_board' %>
-  <div id="B-captures" class="captures">
-    <br><br><br>
-  </div>
-</div>
-
-<button id="undo-button">
-  undo
-</button>
-<button id="pause-button">pause</button>
-</div>
 </div>

--- a/app/views/matches/show.html.erb
+++ b/app/views/matches/show.html.erb
@@ -2,9 +2,6 @@
   <%= render 'shared/condition_sentence_spec' %>
   <% if @match.awaiting_generation? %>
     <meta http-equiv="refresh" content="2">
-  <% end %>
-
-  <% if @match.awaiting_generation? %>
     <div class="match-replay-page match-replay-layout">
       <div class="game-page">
         <%= render 'matches/match_summary', match: @match, rematch_options: @rematch_options %>
@@ -41,8 +38,8 @@
       data-current-user-id="<%= current_user.id %>"
       data-white-name="<%= @match.player_display_name_for(:white) %>"
       data-black-name="<%= @match.player_display_name_for(:black) %>"
-      data-white-bot-owner-id="<%= @match.white_tournament_entry&.bot_owner_id || (@match.white_player_type == 'Bot' ? @match.white_player&.user_id : '') %>"
-      data-black-bot-owner-id="<%= @match.black_tournament_entry&.bot_owner_id || (@match.black_player_type == 'Bot' ? @match.black_player&.user_id : '') %>"
+      data-white-bot-owner-id="<%= @match.bot_owner_id_for(:white) %>"
+      data-black-bot-owner-id="<%= @match.bot_owner_id_for(:black) %>"
       data-white-compiled-program-snapshot="<%= json_escape(@match.compiled_program_snapshot_for(:white).to_json) %>"
       data-black-compiled-program-snapshot="<%= json_escape(@match.compiled_program_snapshot_for(:black).to_json) %>"
     >

--- a/spec/models/match_spec.rb
+++ b/spec/models/match_spec.rb
@@ -40,9 +40,9 @@ RSpec.describe Match, type: :model do
       expect(match.bot_owner_id_for(:white)).to eq(owner.id)
     end
 
-    it "returns '' when that side is a human player" do
+    it 'returns nil when that side is a human player' do
       match = create(:match, :white_human)
-      expect(match.bot_owner_id_for(:white)).to eq('')
+      expect(match.bot_owner_id_for(:white)).to be_nil
     end
 
     it 'accepts a string player argument' do
@@ -54,6 +54,30 @@ RSpec.describe Match, type: :model do
     it 'raises for an unknown player' do
       match = create(:match)
       expect { match.bot_owner_id_for(:sideways) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe '#human_vs_bot_for?' do
+    let(:user) { create(:user) }
+
+    it 'is true when the user plays one side and a bot the other' do
+      match = create(:match, white_player: user, black_player: create(:bot))
+      expect(match.human_vs_bot_for?(user)).to be true
+    end
+
+    it 'is false for a bot-vs-bot match' do
+      match = create(:match)
+      expect(match.human_vs_bot_for?(user)).to be false
+    end
+
+    it 'is false when the human side is a different user' do
+      match = create(:match, white_player: create(:user), black_player: create(:bot))
+      expect(match.human_vs_bot_for?(user)).to be false
+    end
+
+    it 'is false for a nil user' do
+      match = create(:match, white_player: user, black_player: create(:bot))
+      expect(match.human_vs_bot_for?(nil)).to be false
     end
   end
 

--- a/spec/models/match_spec.rb
+++ b/spec/models/match_spec.rb
@@ -31,6 +31,32 @@ RSpec.describe Match, type: :model do
     end
   end
 
+  describe '#bot_owner_id_for' do
+    let(:owner) { create(:user) }
+
+    it 'returns the user id of the bot on that side' do
+      bot = create(:bot, user: owner)
+      match = create(:match, white_player: bot)
+      expect(match.bot_owner_id_for(:white)).to eq(owner.id)
+    end
+
+    it "returns '' when that side is a human player" do
+      match = create(:match, :white_human)
+      expect(match.bot_owner_id_for(:white)).to eq('')
+    end
+
+    it 'accepts a string player argument' do
+      bot = create(:bot, user: owner)
+      match = create(:match, black_player: bot)
+      expect(match.bot_owner_id_for('black')).to eq(owner.id)
+    end
+
+    it 'raises for an unknown player' do
+      match = create(:match)
+      expect { match.bot_owner_id_for(:sideways) }.to raise_error(ArgumentError)
+    end
+  end
+
   describe '#first_bot_match_for?' do
     let(:user) { create(:user) }
     let(:user_bot) { create(:bot, user: user) }

--- a/spec/requests/matches_controller_spec.rb
+++ b/spec/requests/matches_controller_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe 'Matches', type: :request do
       end.not_to change(Match, :count)
 
       expect(response).to have_http_status(:unprocessable_entity)
-      expect(response.body).to include('recompiled before match generation')
+      expect(response.body).to include('must be recompiled first. Compile and continue?')
     end
 
     it 'compiles stale selected owned bots and immediately creates the match when confirmed' do
@@ -257,7 +257,7 @@ RSpec.describe 'Matches', type: :request do
       end.not_to change(Match, :count)
 
       expect(response).to have_http_status(:unprocessable_entity)
-      expect(response.body).to include("#{stale_bot.name} needs to be recompiled before you can play. Compile and continue?")
+      expect(response.body).to include("#{stale_bot.name} must be recompiled first. Compile and continue?")
 
       expect do
         post human_vs_bot_matches_path, params: {

--- a/spec/requests/matches_controller_spec.rb
+++ b/spec/requests/matches_controller_spec.rb
@@ -44,6 +44,29 @@ RSpec.describe 'Matches', type: :request do
       expect(response.body).to include(%(value="#{own_bot.id}"))
       expect(response.body).to match(/value="#{own_bot.id}"[^>]*checked/)
     end
+
+    it 'shows the no-bots notice when a signed-in user has none' do
+      sign_in create(:user)
+      get new_bot_vs_bot_match_path
+
+      expect(response.body).to include("You don't have any bots yet.")
+    end
+
+    it 'hides the no-bots notice once the user has a bot' do
+      user = create(:user)
+      create(:bot, :compiled, user: user)
+
+      sign_in user
+      get new_bot_vs_bot_match_path
+
+      expect(response.body).not_to include("You don't have any bots yet.")
+    end
+
+    it 'shows the no-bots notice to an unauthenticated guest' do
+      get new_bot_vs_bot_match_path
+
+      expect(response.body).to include("You don't have any bots yet.")
+    end
   end
 
   describe 'POST #create' do

--- a/spec/requests/matches_controller_spec.rb
+++ b/spec/requests/matches_controller_spec.rb
@@ -415,6 +415,32 @@ RSpec.describe 'Matches', type: :request do
       expect(match.result).to eq('error')
       expect(match.error_message).to eq('Bot move failed: kaboom')
     end
+
+    it 'returns a 422 instead of erroring when a completion field is missing' do
+      match = Match.create!(
+        creator: user,
+        white_player: user,
+        black_player: bot,
+        black_compiled_program_snapshot: bot.compiled_program,
+        status: :running,
+        allowed_to_move: 'W',
+        captured_pieces: [],
+        movement_notation: [],
+        previous_layouts: []
+      )
+
+      patch complete_human_vs_bot_match_path(match), params: {
+        match: {
+          status: 'completed',
+          result: 'white_win'
+          # lay_out and other replay fields intentionally omitted
+        }
+      }, as: :json
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(response.parsed_body['error']).to include('lay_out')
+      expect(match.reload).to be_running
+    end
   end
 
   describe 'GET #show' do


### PR DESCRIPTION
  Summary

  A code-review pass over the matches area — small bug fixes plus DRY/readability refactors. Behavior is unchanged except where called out under Fixes. Every change is test-backed; the full suite is green and the
  branch is merged up to date with main.

  Fixes (behavior-correcting)

  - Human-vs-bot pagination was silently broken — the paginator used page_param:, which isn't a valid option in this Pagy version, so the bot_page URL param never drove pagination. Switched to page_key: 'bot_page'.
  - Interactive match completion could 500 on a malformed payload — complete_match now rescues a missing field (ActionController::ParameterMissing) and returns 422 instead of an unhandled error. Added a request
  spec.
  - Malformed sandbox markup — fixed an unbalanced </div> in sandbox.html.erb.
  - Removed dead UI — the undo/pause buttons on the live and sandbox boards had no handlers (their JS listeners were commented out).

  Refactors (behavior-preserving)

  - Bot-picker list DRY'd — extracted _bot_list / _bot_option partials; the radio-list markup was duplicated three times across the two setup views.
  - Single source for the stale-bot recompile prompt — new Matches::StaleBotConfirmation owns the wording; the two create services and the Stimulus controller all consume it (the controller via a Stimulus value),
  replacing three drifting copies and fixing the human-vs-bot dialog that wrongly said "match generation."
  - Setup-form rendering — a small Matches::SetupForm concern holds the one genuinely-shared check (user_has_no_own_bots?, exposed as a helper_method), ending four diverging copies; each controller keeps a local
  render_form for the new / create-failure path.
  - Hidden pagination dependency made explicit — the opponent-list landing page is computed from the passed-in setup object instead of an instance variable another method had to populate first.
  - Model tidy-ups — moved the duplicated interactive_play_match? onto Match; collapsed repeated case player branches behind normalize_player; added Match#bot_owner_id_for and used it in the replay view instead of
  inline player-branching; winner now returns nil rather than false; removed the unused Match.active / Match.unfinished scopes; clearer instance-variable names and named page-size constants.

  Testing

  - bundle exec rspec --tag all — 525 examples, 0 failures (new specs for bot_owner_id_for, the completion-422 guard, and the no-bots notice).
  - npm test — 1841 passed.
  - Merged with main (no conflicts) and re-verified green.