### PR TITLE
Tourney score magnitude

### DIFF
--- a/app/controllers/concerns/tournaments/constraints_params.rb
+++ b/app/controllers/concerns/tournaments/constraints_params.rb
@@ -11,6 +11,7 @@ module Tournaments
 
       c["max_score_nodes"]   = raw[:max_score_nodes].to_i   if raw[:max_score_nodes].present?
       c["max_branch_length"] = raw[:max_branch_length].to_i if raw[:max_branch_length].present?
+      c["max_total_absolute_value"] = raw[:max_total_absolute_value].to_i if raw[:max_total_absolute_value].present?
       c["budget"]            = raw[:budget].to_i            if raw[:budget].present?
 
       costs = (raw[:costs]&.to_unsafe_h || {}).filter_map { |k, v| [k.to_s, v.to_i] if v.present? && v.to_i > 0 }.to_h

--- a/app/models/nodes/data_validator.rb
+++ b/app/models/nodes/data_validator.rb
@@ -164,7 +164,7 @@ module Nodes
       action_type = record.data['actionType'] || record.data[:actionType]
       value = record.data['value'] || record.data[:value]
       record.errors.add(:data, 'has invalid actionType') unless SCORE_ACTION_TYPES.include?(action_type)
-      record.errors.add(:data, 'value must be numeric') unless value.is_a?(Numeric)
+      record.errors.add(:data, 'value must be a whole number') unless value.is_a?(Integer)
     end
 
     def validate_organizer_data

--- a/app/services/tournaments/bot_eligibility_checker.rb
+++ b/app/services/tournaments/bot_eligibility_checker.rb
@@ -23,12 +23,14 @@ module Tournaments
       and_count   = compute_and_count
       score_nodes = @nodes.values.select { |n| n["type"] == "score" }
       branch_len  = compute_max_branch_length
+      score_value = total_absolute_value(score_nodes)
 
       violations = []
       check_allow_or(or_count, violations)
       check_allow_and(and_count, violations)
       check_max_score_nodes(score_nodes.size, violations)
       check_max_branch_length(branch_len, violations)
+      check_max_total_absolute_value(score_value, violations)
       check_score_node_restrictions(score_nodes, violations)
       check_condition_restrictions(violations)
 
@@ -47,7 +49,8 @@ module Tournaments
           or_count: or_count,
           and_count: and_count,
           score_node_count: score_nodes.size,
-          max_branch_length: branch_len
+          max_branch_length: branch_len,
+          total_absolute_value: score_value
         }
       )
     end
@@ -129,6 +132,16 @@ module Tournaments
       max = @constraints["max_branch_length"]
       return unless max && length > max
       violations << { type: "max_branch_length", message: "Bot's longest branch is #{length} #{"condition".pluralize(length)} deep (max #{max})" }
+    end
+
+    def total_absolute_value(score_nodes)
+      score_nodes.sum { |node| node.dig("data", "value").to_i.abs }
+    end
+
+    def check_max_total_absolute_value(total, violations)
+      max = @constraints["max_total_absolute_value"]
+      return unless max && total > max
+      violations << { type: "max_total_absolute_value", message: "Bot's total absolute value of scores is #{total} (max #{max})" }
     end
 
     def check_score_node_restrictions(score_nodes, violations)

--- a/app/views/tournaments/_constraints_summary.html.erb
+++ b/app/views/tournaments/_constraints_summary.html.erb
@@ -4,6 +4,7 @@
 <% banned_kinds   = constraints.dig("condition_restrictions", "banned_kinds") || [] %>
 <% banned_actions = constraints.dig("score_node_restrictions", "banned_action_types") || [] %>
 <% and_or_relevant = costs["and"].present? || costs["or"].present? || constraints["allow_and"] == false || constraints["allow_or"] == false %>
+<% any_structure_constraints = constraints["allow_and"] == false || constraints["allow_or"] == false || constraints["max_branch_length"].present? || constraints["max_score_nodes"].present? || constraints["max_total_absolute_value"].present? %>
 
 <details class="constraints-readonly" <%= "open" if local_assigns.fetch(:expanded, true) %>>
   <summary class="constraints-readonly__summary">Eligibility Constraints</summary>
@@ -24,7 +25,7 @@
         </div>
       <% end %>
 
-      <% if constraints["allow_and"] == false || constraints["allow_or"] == false || constraints["max_branch_length"].present? || constraints["max_score_nodes"].present? %>
+      <% if any_structure_constraints %>
         <div>
           <p class="ci-heading">Structure</p>
           <% if constraints["allow_and"] == false %>
@@ -38,6 +39,9 @@
           <% end %>
           <% if constraints["max_score_nodes"].present? %>
             <p class="constraints-readonly__line"><span>Max score nodes</span><strong><%= constraints["max_score_nodes"] %></strong></p>
+          <% end %>
+          <% if constraints["max_total_absolute_value"].present? %>
+            <p class="constraints-readonly__line"><span>Max total absolute value of scores</span><strong><%= constraints["max_total_absolute_value"] %></strong></p>
           <% end %>
         </div>
       <% end %>

--- a/app/views/tournaments/_form.html.erb
+++ b/app/views/tournaments/_form.html.erb
@@ -143,7 +143,7 @@
             <input class="ci-input ci-input--box" type="number"
               name="tournament[constraints][max_total_absolute_value]"
               value="<%= @constraints&.dig("max_total_absolute_value") %>"
-              min="0" step="1" placeholder="N/A">
+              min="1" step="1" placeholder="N/A">
           </div>
           <p class="ce-check-note">−8 adds 8 to the total, the same as +8.</p>
           <%= render 'constraints_legend' %>

--- a/app/views/tournaments/_form.html.erb
+++ b/app/views/tournaments/_form.html.erb
@@ -138,6 +138,14 @@
               min="1" step="1" placeholder="N/A">
           </div>
           <p class="ce-check-note">Counts chained conditions only — score nodes don't add to the length.</p>
+          <div class="ci-row">
+            <span class="ci-label">Max total absolute value of scores</span>
+            <input class="ci-input ci-input--box" type="number"
+              name="tournament[constraints][max_total_absolute_value]"
+              value="<%= @constraints&.dig("max_total_absolute_value") %>"
+              min="0" step="1" placeholder="N/A">
+          </div>
+          <p class="ce-check-note">−8 adds 8 to the total, the same as +8.</p>
           <%= render 'constraints_legend' %>
         </div>
 

--- a/spec/models/node_spec.rb
+++ b/spec/models/node_spec.rb
@@ -299,6 +299,13 @@ RSpec.describe Node, type: :model do
       expect(node).not_to be_valid
       expect(node.errors[:data]).to include('has invalid actionType')
     end
+
+    it 'rejects a non-integer score value' do
+      node = build(:node, :score, data: { actionType: 'add', value: 1.5 })
+
+      expect(node).not_to be_valid
+      expect(node.errors[:data]).to include('value must be a whole number')
+    end
   end
 
   describe 'associations' do

--- a/spec/requests/tournaments_controller_spec.rb
+++ b/spec/requests/tournaments_controller_spec.rb
@@ -49,6 +49,15 @@ RSpec.describe TournamentsController, type: :request do
       expect(response.body).to include('Attack/Defend')
       expect(response.body).to include('Captures')
     end
+
+    it 'exposes the max total absolute value of scores control' do
+      sign_in create(:user)
+
+      get new_tournament_path
+
+      expect(response.body).to include('tournament[constraints][max_total_absolute_value]')
+      expect(response.body).to include('Max total absolute value of scores')
+    end
   end
 
   describe 'POST #create' do
@@ -87,6 +96,21 @@ RSpec.describe TournamentsController, type: :request do
         status: 'draft'
       )
       expect(ComputeMatchJob).not_to have_been_enqueued
+    end
+
+    it 'persists the max total absolute value of scores constraint' do
+      post tournaments_path, params: {
+        tournament: {
+          name: 'Bounded Cup',
+          visibility: 'public',
+          entries_per_user: 'one',
+          games_per_pair: 10,
+          constraints: { max_total_absolute_value: '12' }
+        }
+      }
+
+      tournament = Tournament.order(:created_at).last
+      expect(tournament.constraints["max_total_absolute_value"]).to eq(12)
     end
 
     it 'rejects blank names' do

--- a/spec/services/tournaments/bot_eligibility_checker_spec.rb
+++ b/spec/services/tournaments/bot_eligibility_checker_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Tournaments::BotEligibilityChecker do
 
     it "populates all stats keys" do
       result = check(linear_program, nil)
-      expect(result.stats.keys).to contain_exactly(:and_count, :or_count, :score_node_count, :max_branch_length)
+      expect(result.stats.keys).to contain_exactly(:and_count, :or_count, :score_node_count, :max_branch_length, :total_absolute_value)
     end
   end
 
@@ -278,6 +278,32 @@ RSpec.describe Tournaments::BotEligibilityChecker do
 
       it "is eligible when exactly at the limit" do
         expect(check(linear_program, { "max_score_nodes" => 1 }).eligible).to be true
+      end
+    end
+  end
+
+  describe "total absolute value of scores" do
+    let(:swing_program) do
+      program(
+        root("r", children: ["s1", "s2"]),
+        score("s1", value: 8),
+        score("s2", value: -8)
+      )
+    end
+
+    it "sums the absolute value of every score node, so offsetting values do not cancel" do
+      expect(check(swing_program).stats[:total_absolute_value]).to eq(16)
+    end
+
+    context "with max_total_absolute_value constraint" do
+      it "adds a violation when exceeded" do
+        result = check(swing_program, { "max_total_absolute_value" => 10 })
+        expect(result.eligible).to be false
+        expect(result.violations).to include(include(type: "max_total_absolute_value"))
+      end
+
+      it "is eligible when exactly at the limit" do
+        expect(check(swing_program, { "max_total_absolute_value" => 16 }).eligible).to be true
       end
     end
   end


### PR DESCRIPTION
Add a max-total-absolute-value-of-scores eligibility constraint, and
  require score node values to be whole numbers.

  Tournaments can now cap the combined absolute value of a bot's score
  nodes — a magnitude limit, distinct from the score-node *count* (which
  budget already covers). The node data validator now rejects
  non-integer score values, so the cap (and gameplay) can't be gamed
  with a crafted float.