### PR TITLE
Main  pre mvp

### DIFF
--- a/app/assets/stylesheets/RULES.md
+++ b/app/assets/stylesheets/RULES.md
@@ -30,20 +30,29 @@ or emitted by a gem. A selector applied with its full literal name
 (`classList.add("flipped")`, or `"x #{'x--active' if …}"`) can be found by
 searching and does **not** belong here.
 
-## Browser-support floor: ~2017
+## Browser-support floor: ~2021
 
-The baseline is CSS custom properties (CSS variables): Edge 15 (April 2017) is
-the laggard, IE is unsupported. Don't introduce a feature newer than that floor
-without explicit sign-off — an unsupported rule is silently dropped on older
-targets. Off-limits by default: `color-mix()` and relative color (2023),
-`:where()`/`:is()` zero-specificity (2021), `@layer` (2022).
+Target browsers from ~2021 on — Safari 14.1, Chrome/Edge 88+, Firefox 78+.
+Flexbox `gap` (Safari 14.1, April 2021) is the modern feature setting the
+practical edge; `:where()`/`:is()` (early 2021) are within the floor. Above it,
+and off-limits without sign-off because an unsupported rule is silently dropped:
+`@layer` (2022), `color-mix()` and relative color (2023).
+
+## application.css is the base layer
+
+The manifest lists `require_self` before `require_tree .`, so `application.css`
+compiles first and component sheets load after it — they win equal-specificity
+ties by source order. Put base/global styles in `application.css`, component
+styles in their own sheet; don't rely on `application.css` to override a
+component, and don't restore the Rails-default order (it silently inverts every
+equal-specificity tie).
 
 ## Transparency uses channel tokens, not modern color functions
 
 For a translucent variant of a token color, compose it from the matching
 `--X-rgb` channel token: `rgba(var(--X-rgb), a)` (e.g.
 `rgba(var(--error-rgb), 0.1)`). Don't reach for `color-mix()` or relative
-color (`rgb(from …)`) — they are unsupported below the ~2017 floor (above),
+color (`rgb(from …)`) — they are unsupported below the ~2021 floor (above),
 where transparency must keep working.
 
 ## Finding dead compound/descendant rules

--- a/app/assets/stylesheets/RULES.md
+++ b/app/assets/stylesheets/RULES.md
@@ -30,13 +30,21 @@ or emitted by a gem. A selector applied with its full literal name
 (`classList.add("flipped")`, or `"x #{'x--active' if …}"`) can be found by
 searching and does **not** belong here.
 
+## Browser-support floor: ~2017
+
+The baseline is CSS custom properties (CSS variables): Edge 15 (April 2017) is
+the laggard, IE is unsupported. Don't introduce a feature newer than that floor
+without explicit sign-off — an unsupported rule is silently dropped on older
+targets. Off-limits by default: `color-mix()` and relative color (2023),
+`:where()`/`:is()` zero-specificity (2021), `@layer` (2022).
+
 ## Transparency uses channel tokens, not modern color functions
 
 For a translucent variant of a token color, compose it from the matching
 `--X-rgb` channel token: `rgba(var(--X-rgb), a)` (e.g.
 `rgba(var(--error-rgb), 0.1)`). Don't reach for `color-mix()` or relative
-color (`rgb(from …)`) — they are unsupported on the older browsers this app
-still targets, where transparency must keep working.
+color (`rgb(from …)`) — they are unsupported below the ~2017 floor (above),
+where transparency must keep working.
 
 ## Finding dead compound/descendant rules
 

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -282,6 +282,10 @@ input[type="submit"] {
   background-color: var(--bg-elevated);
 }
 
+.btn-rematch {
+  box-shadow: inset 0 0 0 1px var(--border-warm-hover);
+}
+
 .btn-danger {
   background-color: var(--bg-recessed);
   color: var(--tint-danger);

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -61,6 +61,8 @@
   --accent-gold-pale-rgb: 243, 226, 166;
   --accent-gold-pale: rgb(var(--accent-gold-pale-rgb));
   --accent-cyan: #06b6d4;
+  --accent-raspberry-rgb: 219, 39, 119;
+  --accent-raspberry: rgb(var(--accent-raspberry-rgb));
   --accent-gold-deep-rgb: 216, 193, 96;
   --accent-gold-deep: rgb(var(--accent-gold-deep-rgb));
   --accent-gold-bright-rgb: 253, 230, 138;

--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -5,13 +5,13 @@
  * Any CSS (and SCSS, if configured) file within this directory, lib/assets/stylesheets, or any plugin's
  * vendor/assets/stylesheets directory can be referenced here using a relative path.
  *
- * You're free to add application-wide styles to this file and they'll appear at the bottom of the
- * compiled file so the styles you add here take precedence over styles defined in any other CSS
- * files in this directory. Styles in this file should be added after the last require_* statement.
- * It is generally better to create a new file per style scope.
+ * require_self is listed before require_tree so this file compiles first and acts as the base
+ * layer: component files in this directory load after it and win equal-specificity ties, instead
+ * of base rules here silently overriding them. Add base/global styles below; create a new file
+ * per component scope.
  *
- *= require_tree .
  *= require_self
+ *= require_tree .
  */
 
 /* ============================================

--- a/app/assets/stylesheets/chessboard.css
+++ b/app/assets/stylesheets/chessboard.css
@@ -286,12 +286,3 @@
   outline: 2px solid var(--accent-primary);
   outline-offset: -5px;
 }
-
-/* ============================================
-   BODY DARK THEME
-   ============================================ */
-
-body {
-  background-color: var(--bg-primary);
-  color: var(--text-primary);
-}

--- a/app/assets/stylesheets/index_pages.css
+++ b/app/assets/stylesheets/index_pages.css
@@ -9,6 +9,11 @@
   margin-bottom: 1.25rem;
 }
 
+.index-header--inline {
+  justify-content: flex-start;
+  gap: 1rem;
+}
+
 .index-header h1 {
   margin: 0;
 }
@@ -208,7 +213,11 @@
   width: 1%;
 }
 
-.index-table-action-btn {
+.index-table-actions .btn + .btn {
+  margin-left: 0.375rem;
+}
+
+.index-panel .index-table-action-btn {
   padding: 0.2rem 0.5rem;
   font-size: 0.8rem;
 }

--- a/app/assets/stylesheets/match_replay.css
+++ b/app/assets/stylesheets/match_replay.css
@@ -209,6 +209,16 @@ input[type="submit"].btn-rematch {
   gap: 0.5rem;
 }
 
+.match-replay-page .match-replay-flip {
+  margin-left: 2rem;
+}
+
+.match-replay-page .match-replay-flip button {
+  font-size: 0.8rem;
+  padding: 0.15rem 0.4rem;
+  background-color: var(--surface-raised);
+}
+
 .match-replay-page button.match-replay-speed-button--active,
 .match-replay-page button.match-replay-toggle-button--active {
   background-color: rgba(var(--accent-primary-rgb), 0.15);

--- a/app/assets/stylesheets/node_editor.css
+++ b/app/assets/stylesheets/node_editor.css
@@ -183,8 +183,13 @@
 
 .btn-guide {
   background: var(--surface);
-  color: var(--accent-gold-pale);
-  border: 1px solid var(--accent-gold-deep);
+  color: #db2777;
+  border: 1px solid #db2777;
+}
+
+.btn-guide::after {
+  content: "ⓘ";
+  margin-left: 0.5em;
 }
 
 .btn-guide:hover {

--- a/app/assets/stylesheets/node_editor.css
+++ b/app/assets/stylesheets/node_editor.css
@@ -183,8 +183,8 @@
 
 .btn-guide {
   background: var(--surface);
-  color: #db2777;
-  border: 1px solid #db2777;
+  color: var(--accent-raspberry);
+  border: 1px solid var(--accent-raspberry);
 }
 
 .btn-guide::after {

--- a/app/assets/stylesheets/setup_forms.css
+++ b/app/assets/stylesheets/setup_forms.css
@@ -160,12 +160,18 @@
 .match-setup-nav {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  gap: 2rem;
   margin-bottom: 1rem;
 }
 
 .match-setup-col > .btn {
   align-self: flex-start;
+}
+
+.match-setup-footer {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 1rem;
 }
 
 /* ============================================

--- a/app/assets/stylesheets/setup_forms.css
+++ b/app/assets/stylesheets/setup_forms.css
@@ -164,10 +164,6 @@
   margin-bottom: 1rem;
 }
 
-.match-setup-col > .btn {
-  align-self: flex-start;
-}
-
 .match-setup-footer {
   display: flex;
   justify-content: flex-end;

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,8 +1,0 @@
-class HomeController < ApplicationController
-
-
-    def index
-        logger.debug "PRINTING"
-      render "index"
-    end
-  end

--- a/app/controllers/signed_out_controller.rb
+++ b/app/controllers/signed_out_controller.rb
@@ -1,0 +1,4 @@
+class SignedOutController < ApplicationController
+  def show
+  end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -12,6 +12,10 @@ class Users::SessionsController < Devise::SessionsController
 
   private
 
+  def after_sign_out_path_for(_resource_or_scope)
+    signed_out_path
+  end
+
   def user_without_authenticating
     warden.user(scope: :user)
   end

--- a/app/javascript/editorV2/__tests__/ConditionForm.test.js
+++ b/app/javascript/editorV2/__tests__/ConditionForm.test.js
@@ -215,6 +215,28 @@ describe('ConditionForm', () => {
     document.body.innerHTML = ''
   })
 
+  it('defaults a new condition to moved piece attacking more enemies than the prior board state', () => {
+    const panel = buildPanel()
+    const form = new ConditionForm(panel)
+    form.attach()
+
+    form.populate({})
+
+    expect(form.state.mode).toBe('relational')
+    expect(form.buildPayload()).toEqual({
+      version: 2,
+      kind: 'relational',
+      subject: 'moved_piece',
+      subjectFilter: 'any',
+      operator: 'attack',
+      target: 'enemy',
+      targetFilter: 'any',
+      targetComparisonMetric: 'count',
+      targetComparator: 'greater_than',
+      targetComparisonSource: 'prior_board_state'
+    })
+  })
+
   it('toggles only the matching numeric selector for each comparison block', () => {
     const panel = buildPanel()
     const form = new ConditionForm(panel)

--- a/app/javascript/editorV2/__tests__/nodeDefaults.test.js
+++ b/app/javascript/editorV2/__tests__/nodeDefaults.test.js
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+
+import { defaultNodeData, normalizeNodeData } from '../utils/nodeDefaults.js'
+
+describe('nodeDefaults condition default', () => {
+  const expected = {
+    version: 2,
+    kind: 'relational',
+    subject: 'moved_piece',
+    subjectFilter: 'any',
+    operator: 'attack',
+    target: 'enemy',
+    targetFilter: 'any',
+    targetComparisonMetric: 'count',
+    targetComparator: 'greater_than',
+    targetComparisonSource: 'prior_board_state'
+  }
+
+  it('seeds a new condition as moved piece attacking more enemies than the prior board state', () => {
+    expect(defaultNodeData('condition')).toEqual(expected)
+  })
+
+  it('normalizes empty condition data to that same default', () => {
+    expect(normalizeNodeData('condition', {})).toEqual(expected)
+  })
+})

--- a/app/javascript/editorV2/panels/ConditionForm.js
+++ b/app/javascript/editorV2/panels/ConditionForm.js
@@ -53,7 +53,7 @@ class ConditionForm {
 
   defaultState() {
     return {
-      mode: 'census',
+      mode: 'relational',
       relational: this.modes.relational.defaultState(),
       census: this.modes.census.defaultState(),
       captures: this.modes.captures.defaultState()

--- a/app/javascript/editorV2/panels/condition_form/relational_mode.js
+++ b/app/javascript/editorV2/panels/condition_form/relational_mode.js
@@ -10,9 +10,12 @@ const NEUTRAL_COMPARISON = {
 }
 
 const DEFAULT_RELATIONAL_STATE = {
-  left: { subject: 'allied', filter: 'any', filterMode: 'include', ...NEUTRAL_COMPARISON },
+  left: { subject: 'moved_piece', filter: 'any', filterMode: 'include', ...NEUTRAL_COMPARISON },
   operator: 'targets',
-  right: { subject: 'enemy', filter: 'any', filterMode: 'include', ...NEUTRAL_COMPARISON }
+  right: {
+    subject: 'enemy', filter: 'any', filterMode: 'include',
+    ...NEUTRAL_COMPARISON, comparator: 'greater_than', comparisonSource: 'prior_board_state'
+  }
 }
 
 // Relational condition mode. State-only: the orchestrator owns DOM events and

--- a/app/javascript/editorV2/utils/nodeDefaults.js
+++ b/app/javascript/editorV2/utils/nodeDefaults.js
@@ -1,13 +1,14 @@
 export const DEFAULT_CONDITION_DATA = Object.freeze({
   version: 2,
   kind: 'relational',
-  subject: 'allied',
+  subject: 'moved_piece',
   subjectFilter: 'any',
-  subjectFilterMode: 'include',
   operator: 'attack',
   target: 'enemy',
   targetFilter: 'any',
-  targetFilterMode: 'include',
+  targetComparisonMetric: 'count',
+  targetComparator: 'greater_than',
+  targetComparisonSource: 'prior_board_state',
 })
 
 export const DEFAULT_ACTION_DATA = Object.freeze({

--- a/app/javascript/editorV2/utils/nodeDefaults.js
+++ b/app/javascript/editorV2/utils/nodeDefaults.js
@@ -21,20 +21,6 @@ export const DEFAULT_ORGANIZER_DATA = Object.freeze({
   notes: ''
 })
 
-export const CONDITION_DATA_KEYS = Object.freeze([
-  'version',
-  'kind',
-  'subject',
-  'subjectFilter',
-  'subjectFilterMode',
-  'operator',
-  'comparator',
-  'target',
-  'targetFilter',
-  'targetFilterMode',
-  'targetTotal'
-])
-
 export const ACTION_DATA_KEYS = Object.freeze([
   'actionType',
   'value'

--- a/app/javascript/gameplay/__tests__/match_replay_controller.test.js
+++ b/app/javascript/gameplay/__tests__/match_replay_controller.test.js
@@ -250,6 +250,48 @@ describe('MatchReplayController', () => {
     expect(root.querySelector('[data-board-name="bottom"]').dataset.team).toBe('B')
   })
 
+  it('defaults to white POV when the viewer owns both bots', () => {
+    const root = buildRoot({ finalLayout: Layout.default(), movementNotation: [] })
+    root.dataset.whiteBotOwnerId = '1'
+    root.dataset.blackBotOwnerId = '1'
+    document.body.appendChild(root)
+
+    const controller = new MatchReplayController({ rootElement: root })
+    root.insertAdjacentHTML('beforeend', `
+      <div id="arena">
+        <div class="board-player-name" data-board-name="top"></div>
+        <table id="chess-board"></table>
+        <div class="board-player-name" data-board-name="bottom"></div>
+      </div>
+    `)
+    controller.applyOrientation()
+
+    expect(root.querySelector('#chess-board').classList.contains('flipped')).toBe(false)
+  })
+
+  it('flips the board orientation when the flip button is clicked', () => {
+    const root = buildRoot({ finalLayout: Layout.default(), movementNotation: [] })
+    root.insertAdjacentHTML('beforeend', '<button data-match-replay-target="flip-button"></button>')
+    document.body.appendChild(root)
+
+    const controller = new MatchReplayController({ rootElement: root })
+    root.insertAdjacentHTML('beforeend', `
+      <div id="arena">
+        <div class="board-player-name" data-board-name="top"></div>
+        <table id="chess-board"></table>
+        <div class="board-player-name" data-board-name="bottom"></div>
+      </div>
+    `)
+    vi.spyOn(controller, 'renderCurrentFrame').mockImplementation(() => {})
+
+    expect(controller.flipped).toBe(false)
+    controller.flipButton.click()
+
+    expect(controller.flipped).toBe(true)
+    expect(root.querySelector('#chess-board').classList.contains('flipped')).toBe(true)
+    expect(controller.renderCurrentFrame).toHaveBeenCalled()
+  })
+
   describe('userBotTeam', () => {
     function setup({ whiteOwner, blackOwner, currentUser = '1' } = {}) {
       const root = buildRoot({ finalLayout: Layout.default(), movementNotation: [] })

--- a/app/javascript/gameplay/__tests__/replay_trace_view.test.js
+++ b/app/javascript/gameplay/__tests__/replay_trace_view.test.js
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+
+import Board from 'gameplay/board'
+import ReplayTraceView from 'gameplay/replay_trace_view'
+
+// The summary line is written with .innerText, which jsdom stores but does not
+// reflect into textContent — so read it back off the span directly.
+function moveLabelFor({ start, end, movingTeam }) {
+  const tracePanelElement = document.createElement('div')
+  const traceSummaryElement = document.createElement('div')
+  const traceBranchesElement = document.createElement('div')
+  const view = new ReplayTraceView({ tracePanelElement, traceSummaryElement, traceBranchesElement })
+
+  view.render({
+    enabled: true,
+    result: {
+      inspectedMove: { moveObject: {
+        startPosition: Board.gridCalculatorReverse(start),
+        endPosition: Board.gridCalculatorReverse(end)
+      } },
+      inspectedMoveKey: null,
+      explicitInspectedMoveKey: null,
+      tiedTopMoveKeys: [],
+      inspectedTrace: { score: 0, trace: [] }
+    }
+  }, movingTeam)
+
+  return traceSummaryElement.querySelector('.match-replay-trace-meta').innerText
+}
+
+describe('ReplayTraceView move coordinates', () => {
+  it('reads a white move from white\'s back rank (rank 1)', () => {
+    expect(moveLabelFor({ start: 'e2', end: 'e4', movingTeam: Board.WHITE })).toContain('e2 to e4')
+  })
+
+  it('reads a black move from black\'s back rank, 180° from absolute', () => {
+    // a7-a5 in absolute terms is h2-h4 seen from black's side of the board
+    expect(moveLabelFor({ start: 'a7', end: 'a5', movingTeam: Board.BLACK })).toContain('h2 to h4')
+  })
+})

--- a/app/javascript/gameplay/match_replay_controller.js
+++ b/app/javascript/gameplay/match_replay_controller.js
@@ -21,6 +21,7 @@ class MatchReplayController {
     this.forwardButton = rootElement.querySelector('[data-match-replay-target="forward-button"]')
     this.startButton = rootElement.querySelector('[data-match-replay-target="start-button"]')
     this.topMovesToggle = rootElement.querySelector('[data-match-replay-target="top-moves-toggle"]')
+    this.flipButton = rootElement.querySelector('[data-match-replay-target="flip-button"]')
     this.notationElement = rootElement.querySelector('[data-match-replay-target="notation"]')
     this.resultElement = rootElement.querySelector('[data-match-replay-target="result"]')
     this.boardElement = rootElement.querySelector('#chess-board')
@@ -33,6 +34,7 @@ class MatchReplayController {
     this.forwardButton?.addEventListener('click', () => { this.clearControlHints(); this.stepForwardOnce() })
     this.startButton?.addEventListener('click', this.jumpToStart.bind(this))
     this.topMovesToggle?.addEventListener('click', this.toggleTopMoveHighlights.bind(this))
+    this.flipButton?.addEventListener('click', this.toggleOrientation.bind(this))
     this.notationElement?.addEventListener('click', this.jumpToNotationMove.bind(this))
     this.resultElement?.addEventListener('click', this.handleResultClick.bind(this))
     this.boardElement?.addEventListener('click', this.handleBoardClick.bind(this))
@@ -57,6 +59,7 @@ class MatchReplayController {
     this.whiteBotOwnerId = rootElement.dataset.whiteBotOwnerId ? Number(rootElement.dataset.whiteBotOwnerId) : null
     this.blackBotOwnerId = rootElement.dataset.blackBotOwnerId ? Number(rootElement.dataset.blackBotOwnerId) : null
     this.userBotTeam = this.deriveUserBotTeam()
+    this.flipped = this.userBotTeam === Board.BLACK
     this.whiteCompiledProgramSnapshot = this.parseCompiledProgramSnapshot(rootElement.dataset.whiteCompiledProgramSnapshot)
     this.blackCompiledProgramSnapshot = this.parseCompiledProgramSnapshot(rootElement.dataset.blackCompiledProgramSnapshot)
 
@@ -109,15 +112,17 @@ class MatchReplayController {
   }
 
   applyOrientation() {
-    const viewerOwnsBlackBot =
-      Number.isInteger(this.currentUserId) &&
-      this.blackBotOwnerId !== null &&
-      this.currentUserId === this.blackBotOwnerId
     applyBoardOrientation(this.rootElement.querySelector('#arena'), {
-      flipped: viewerOwnsBlackBot,
+      flipped: this.flipped,
       whiteName: this.rootElement.dataset.whiteName,
       blackName: this.rootElement.dataset.blackName
     })
+  }
+
+  toggleOrientation() {
+    this.flipped = !this.flipped
+    this.applyOrientation()
+    this.renderCurrentFrame()
   }
 
   parseCompiledProgramSnapshot(snapshotJson) {

--- a/app/javascript/gameplay/replay_trace_view.js
+++ b/app/javascript/gameplay/replay_trace_view.js
@@ -3,10 +3,10 @@ import { renderConditionSentence } from "editorV2/utils/conditionPreviewFormatte
 
 const FLIPPED_FILE_CHAR_SUM = "a".charCodeAt(0) + "h".charCodeAt(0)
 
-// Rotate an algebraic square 180° so coordinates read from the flipped viewer's
-// side of the board (e.g. b8 → g1 when seen from black's point of view).
-function orientSquare(square, flipped) {
-  if (!flipped || typeof square !== "string" || square.length < 2) { return square }
+// Rotate an algebraic square 180° so it reads from the moving team's side of the
+// board (black's back rank becomes rank 1), independent of how the board is oriented.
+function orientSquare(square, mirrored) {
+  if (!mirrored || typeof square !== "string" || square.length < 2) { return square }
   const file = String.fromCharCode(FLIPPED_FILE_CHAR_SUM - square.charCodeAt(0))
   const rank = 9 - Number(square.slice(1))
   return `${file}${rank}`
@@ -19,7 +19,7 @@ class ReplayTraceView {
     this.traceBranchesElement = traceBranchesElement
   }
 
-  render(inspection, flipped = false) {
+  render(inspection, movingTeam = null) {
     if (!this.tracePanelElement || !this.traceSummaryElement || !this.traceBranchesElement) { return }
     if (inspection?.unavailableMessage) {
       this.tracePanelElement.hidden = false
@@ -40,14 +40,15 @@ class ReplayTraceView {
       return
     }
     this.tracePanelElement.hidden = false
-    this.renderSummary(inspection, flipped)
+    this.renderSummary(inspection, movingTeam)
     this.renderTree(inspection)
   }
 
-  renderSummary(inspection, flipped = false) {
+  renderSummary(inspection, movingTeam = null) {
     const { result } = inspection
+    const mirrored = movingTeam === Board.BLACK
     const inspectedMove = result.inspectedMove?.moveObject
-    const inspectedNotation = inspectedMove ? orientSquare(Board.gridCalculator(inspectedMove.endPosition), flipped) : "none"
+    const inspectedNotation = inspectedMove ? orientSquare(Board.gridCalculator(inspectedMove.endPosition), mirrored) : "none"
     const tiedTopCount = result.tiedTopMoveKeys.length
     const inspectedTied = result.inspectedMoveKey && result.tiedTopMoveKeys.includes(result.inspectedMoveKey)
     this.traceSummaryElement.innerHTML = ""
@@ -64,8 +65,8 @@ class ReplayTraceView {
     const moveSummary = document.createElement("span")
     moveSummary.className = "match-replay-trace-meta"
     moveSummary.innerText = result.explicitInspectedMoveKey
-      ? `inspected move: ${orientSquare(Board.gridCalculator(inspectedMove.startPosition), flipped)} to ${inspectedNotation}`
-      : `current choice: ${orientSquare(Board.gridCalculator(inspectedMove.startPosition), flipped)} to ${inspectedNotation}`
+      ? `inspected move: ${orientSquare(Board.gridCalculator(inspectedMove.startPosition), mirrored)} to ${inspectedNotation}`
+      : `current choice: ${orientSquare(Board.gridCalculator(inspectedMove.startPosition), mirrored)} to ${inspectedNotation}`
     summaryRow.appendChild(moveSummary)
     if (tiedTopCount > 1 && inspectedTied) {
       const tieSummary = document.createElement("span")

--- a/app/javascript/gameplay/replay_view.js
+++ b/app/javascript/gameplay/replay_view.js
@@ -42,8 +42,7 @@ class ReplayView {
     this.renderResult({ result, spoilerRevealed })
     this.renderWarning(warning)
     this.renderNotation({ movePairs, currentMoveIndex })
-    const flipped = this.rootElement.querySelector('#chess-board')?.classList.contains('flipped') ?? false
-    this.traceView.render(inspection, flipped)
+    this.traceView.render(inspection, board.allowedToMove)
   }
 
   renderBoardHighlights({ inspection, muteTopMoveHighlights, lastMove }) {

--- a/app/javascript/tour/editorFirstBotSteps.js
+++ b/app/javascript/tour/editorFirstBotSteps.js
@@ -119,7 +119,7 @@ const STEPS = [
     target: '.btn-add-node[data-type="condition"]',
     title: 'Add your own condition',
     body: `<p>Now build one from scratch. Click <strong>+ Condition</strong>.</p>`,
-    advanceOn: { event: 'editor:node-added', when: (d) => d.type === 'condition' }
+    advanceOn: { event: 'editor:node-added', when: (nodeInfo) => nodeInfo.type === 'condition' }
   },
   {
     target: (ctx) => {
@@ -130,7 +130,7 @@ const STEPS = [
     body: `<p><strong>Click your new condition</strong> to open the editor on the right.</p>`,
     beforeEnter: lockNodeDrag,
     onExit: unlockNodeDrag,
-    advanceOn: { event: 'editor:node-editing-started', when: (d) => d.type === 'condition' }
+    advanceOn: { event: 'editor:node-editing-started', when: (nodeInfo) => nodeInfo.type === 'condition' }
   },
   {
     target: '.condition-form-mode-picker',
@@ -303,7 +303,7 @@ const STEPS = [
     target: '#save-node',
     title: 'Save it',
     body: `<p>When the Current Condition reads the way you want, click <strong>Save</strong>.</p>`,
-    advanceOn: { event: 'editor:node-saved', when: (d) => d.type === 'condition' }
+    advanceOn: { event: 'editor:node-saved', when: (nodeInfo) => nodeInfo.type === 'condition' }
   },
   {
     target: '#canvas-workspace',
@@ -318,7 +318,7 @@ const STEPS = [
     target: '.btn-add-node[data-type="score"]',
     title: 'Add a score node',
     body: `<p>A condition by itself doesn't change anything. To reward (or punish) moves, add a <strong>+ Score</strong> node.</p>`,
-    advanceOn: { event: 'editor:node-added', when: (d) => d.type === 'score' }
+    advanceOn: { event: 'editor:node-added', when: (nodeInfo) => nodeInfo.type === 'score' }
   },
   {
     target: (ctx) => {
@@ -329,7 +329,7 @@ const STEPS = [
     body: `<p><strong>Click your new score node</strong> to open the editor.</p>`,
     beforeEnter: lockNodeDrag,
     onExit: unlockNodeDrag,
-    advanceOn: { event: 'editor:node-editing-started', when: (d) => d.type === 'score' }
+    advanceOn: { event: 'editor:node-editing-started', when: (nodeInfo) => nodeInfo.type === 'score' }
   },
   {
     target: '#node-form-panel',
@@ -347,7 +347,7 @@ const STEPS = [
       <br>
       <p>Save when you're done.</p>
     `,
-    advanceOn: { event: 'editor:node-saved', when: (d) => d.type === 'score' }
+    advanceOn: { event: 'editor:node-saved', when: (nodeInfo) => nodeInfo.type === 'score' }
   },
   {
     target: '#canvas-workspace',
@@ -366,7 +366,7 @@ const STEPS = [
       <p><strong>Shift-click</strong> two or more connected conditions.</p>
       <p>Press <kbd>P</kbd></p>
     `,
-    advanceOn: { event: 'editor:preview-shown', when: (d) => d.mode === 'selection' && d.hasChain }
+    advanceOn: { event: 'editor:preview-shown', when: (preview) => preview.mode === 'selection' && preview.hasChain }
   },
   {
     target: '.board-state-preview__chain',

--- a/app/javascript/tour/editorFirstBotSteps.js
+++ b/app/javascript/tour/editorFirstBotSteps.js
@@ -81,6 +81,12 @@ const STEPS = [
     advanceOn: 'click'
   },
   {
+    target: '#zoom-out',
+    title: 'Zoom out to see it',
+    body: `<p>Click <strong>-</strong> to zoom out and see the whole template.</p>`,
+    advanceOn: 'click'
+  },
+  {
     target: () => document.querySelector('.node.organizer'),
     title: 'What an Organizer node does',
     body: `<p>The blue square at the top is an <strong>Organizer</strong>. It labels this chunk of graph but doesn't affect scoring.</p>`,
@@ -390,19 +396,18 @@ const STEPS = [
     advanceOn: 'next'
   },
   {
-    target: null,
-    placement: 'center',
-    title: 'Tool Tips',
+    target: '#canvas-workspace',
+    title: 'Inspect a node up close',
     body: `
-      <ul>
-        <li><kbd>I</kbd> toggles big-text on hover.</li>
-        <li>Drag a node to move <strong>all children</strong> with it; hold <kbd>Alt</kbd> to move just that node.</li>
-        <li><kbd>Cmd/Ctrl+C</kbd> / <kbd>V</kbd> — copy and paste selected nodes.</li>
-        <li><kbd>Cmd/Ctrl+Z</kbd> — undo. <kbd>Cmd/Ctrl+Shift+Z</kbd> — redo.</li>
-        <li>Click and drag empty canvas to select multiple nodes.</li>
-        <li>Or shift+click to select multiple nodes.</li>
-        <li><kbd>Space</kbd> + click and drag to pan the canvas</li>
-      </ul>
+      <p>Press <kbd>I</kbd>, then hover any node for a blown-up preview. <kbd>I</kbd> or <kbd>Esc</kbd> turns it off.</p>
+    `,
+    advanceOn: 'next'
+  },
+  {
+    target: '.btn-tips-toggle',
+    title: 'Tips & shortcuts live here',
+    body: `
+      <p>Every gesture and shortcut lives behind this <kbd>?</kbd> — plus the <strong>Bot Guide</strong>.</p>
     `,
     advanceOn: 'next'
   },

--- a/app/javascript/tour/engine.js
+++ b/app/javascript/tour/engine.js
@@ -139,8 +139,19 @@ export default class TourEngine {
     const bodyHtml = typeof step.body === 'function' ? step.body(this.context()) : step.body
     this.dom.body.innerHTML = bodyHtml ?? ''
     this.dom.progress.textContent = `${this.currentIndex + 1} of ${this.steps.length}`
+    this.positionToTarget(step, target)
+    this.repositionAfterTargetSettles(step, target)
+  }
+
+  positionToTarget(step, target) {
     this.positionFramesAndHalo(target)
     this.positionTooltip(target, step.placement)
+  }
+
+  repositionAfterTargetSettles(step, target) {
+    if (!target) { return }
+    const rafId = requestAnimationFrame(() => this.positionToTarget(step, target))
+    this.stepCleanup.push(() => cancelAnimationFrame(rafId))
   }
 
   positionFramesAndHalo(target) {

--- a/app/javascript/tour/matchesShowSteps.js
+++ b/app/javascript/tour/matchesShowSteps.js
@@ -7,6 +7,7 @@ const LOCKED_SELECTORS = [
   '[data-match-replay-target="play-button"]',
   '[data-match-replay-target="reverse-button"]',
   '[data-match-replay-target="top-moves-toggle"]',
+  '[data-match-replay-target="flip-button"]',
   FORWARD_BUTTON,
   '.btn-rematch'
 ]

--- a/app/javascript/tour/matchesShowSteps.js
+++ b/app/javascript/tour/matchesShowSteps.js
@@ -59,7 +59,7 @@ const STEPS = [
     beforeEnter: () => setLocked([FORWARD_BUTTON], false),
     advanceOn: {
       event: 'replay:frame-changed',
-      when: (d) => d.moveIndex >= 4 && d.allowedToMove === d.userBotTeam
+      when: (frame) => frame.moveIndex >= 1 && frame.allowedToMove === frame.userBotTeam
     }
   },
   {

--- a/app/javascript/tour/matchesShowSteps.js
+++ b/app/javascript/tour/matchesShowSteps.js
@@ -60,7 +60,7 @@ const STEPS = [
     beforeEnter: () => setLocked([FORWARD_BUTTON], false),
     advanceOn: {
       event: 'replay:frame-changed',
-      when: (frame) => frame.moveIndex >= 1 && frame.allowedToMove === frame.userBotTeam
+      when: (frame) => frame.moveIndex >= 2 && frame.allowedToMove === frame.userBotTeam
     }
   },
   {

--- a/app/models/bot.rb
+++ b/app/models/bot.rb
@@ -66,6 +66,10 @@ class Bot < ApplicationRecord
     find_by(name: SYSTEM_BOT_NAME)
   end
 
+  def system?
+    name == SYSTEM_BOT_NAME
+  end
+
   def self.mark_stale_for(bot_id)
     find_by(id: bot_id)&.mark_compiled_program_stale!
   end

--- a/app/models/node_grammar_rules.rb
+++ b/app/models/node_grammar_rules.rb
@@ -54,7 +54,6 @@ class NodeGrammarRules
 
   COMPARISON_SOURCES_BY_METRIC = {
     'count' => %w[exact_number prior_board_state],
-    'value' => NodeGrammarV2::COMPARISON_SOURCES,
     'individual_value' => NodeGrammarV2::COMPARISON_SOURCES
   }.freeze
 

--- a/app/presenters/matches/rematch_options.rb
+++ b/app/presenters/matches/rematch_options.rb
@@ -18,7 +18,7 @@ class Matches::RematchOptions
 
   def human_vs_bot_params
     return nil if !human_vs_bot_context?
-    return nil if bot&.user_id != user.id
+    return nil unless bot && (bot.user_id == user.id || bot.system?)
     return nil if !bot_ready?
     {
       bot_id: bot.id,
@@ -31,7 +31,7 @@ class Matches::RematchOptions
     return nil if human_vs_bot_params.present?
     if bot.blank?
       'Play again is unavailable because the green chess goblin from this match has been deleted.'
-    elsif bot.user_id != user.id
+    elsif bot.user_id != user.id && !bot.system?
       'Play again is unavailable because this bot belongs to another user.'
     elsif bot.compiled_program_stale?
       'Play again is unavailable because this bot needs to be recompiled.'

--- a/app/presenters/matches/rematch_options.rb
+++ b/app/presenters/matches/rematch_options.rb
@@ -18,7 +18,7 @@ class Matches::RematchOptions
 
   def human_vs_bot_params
     return nil if !human_vs_bot_context?
-    return nil unless bot && (bot.user_id == user.id || bot.system?)
+    return nil unless own_or_system_bot?
     return nil if !bot_ready?
     {
       bot_id: bot.id,
@@ -31,7 +31,7 @@ class Matches::RematchOptions
     return nil if human_vs_bot_params.present?
     if bot.blank?
       'Play again is unavailable because the green chess goblin from this match has been deleted.'
-    elsif bot.user_id != user.id && !bot.system?
+    elsif !own_or_system_bot?
       'Play again is unavailable because this bot belongs to another user.'
     elsif bot.compiled_program_stale?
       'Play again is unavailable because this bot needs to be recompiled.'
@@ -75,6 +75,10 @@ class Matches::RematchOptions
 
   def bot_ready?
     bot.compiled_program.present? && !bot.compiled_program_stale?
+  end
+
+  def own_or_system_bot?
+    bot && (bot.user_id == user.id || bot.system?)
   end
 
   def bot_snapshot

--- a/app/views/bots/edit.html.erb
+++ b/app/views/bots/edit.html.erb
@@ -18,10 +18,6 @@
     <div class="toolbar-section">
       <div class="toolbar-section__heading">
         <h3>Add Node</h3>
-        <button
-          type="button"
-          class="btn-guide"
-          data-action="click->tour#start">Take the tour</button>
         <button type="button" class="btn-open-templates">Templates</button>
       </div>
       <button type="button" class="btn-add-node" data-type="condition">+ Condition</button>
@@ -43,6 +39,9 @@
           <%= render 'bots/tips_popover' %>
         </div>
       </div>
+      <button type="button" class="btn-guide" data-action="click->tour#start">
+        Take the tour
+      </button>
       <button type="button" class="btn btn-ghost btn-delete-node" disabled title="Delete selected node (Delete/Backspace)">Delete</button>
     </div>
 

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,2 +1,0 @@
-
-  <%= button_to "Play chess against a very dumb bot!", new_bot_vs_bot_match_path, method: :get %> 

--- a/app/views/matches/_match_summary.html.erb
+++ b/app/views/matches/_match_summary.html.erb
@@ -2,6 +2,6 @@
   <p class="match-show-meta-item"><strong>Status:</strong> <%= match.status %></p>
   <%= render 'matches/rematch_controls', rematch_options: rematch_options %>
   <% if local_assigns[:show_tour_button] %>
-    <button type="button" class="btn-guide btn-guide--small" data-action="click->tour#start">See how your bot thinks</button>
+    <button type="button" class="btn-guide btn-guide--small" data-action="click->tour#start">Compare move scores</button>
   <% end %>
 </div>

--- a/app/views/matches/_setup_page.html.erb
+++ b/app/views/matches/_setup_page.html.erb
@@ -1,0 +1,30 @@
+<div class="match-setup-page" data-controller="match-setup"
+  data-match-setup-stale-message-template-value="<%= stale_bot_message_template %>">
+  <h1><%= title %></h1>
+  <%= render 'matches/mode_toggle', current_mode: mode %>
+  <% if user_has_no_own_bots? %>
+    <p class="notice">You don't have any bots yet. <%= link_to 'Build one', new_bot_path %> to get started.</p>
+  <% end %>
+
+  <%= form_with url: form_url,
+      scope: :match,
+      method: :post,
+      local: true,
+      id: "match-form",
+      data: {
+        match_setup_target: 'form',
+        action: 'submit->match-setup#confirmStaleCompile'
+      } do |form| %>
+    <%= form.hidden_field :stale_bot_confirmation,
+        value: '',
+        data: { match_setup_target: 'staleBotConfirmation' } %>
+  <% end %>
+
+  <div class="match-setup-grid">
+    <%= yield %>
+  </div>
+
+  <div class="match-setup-footer">
+    <button type="submit" form="match-form" class="btn btn-primary"><%= submit_label %></button>
+  </div>
+</div>

--- a/app/views/matches/index.html.erb
+++ b/app/views/matches/index.html.erb
@@ -1,4 +1,4 @@
-<div class="index-header">
+<div class="index-header index-header--inline">
   <h1>Your Matches</h1>
   <%= link_to 'Set up a match', new_bot_vs_bot_match_path, class: 'btn btn-outline' %>
 </div>
@@ -35,6 +35,7 @@
   <table>
     <thead>
       <tr>
+        <th class="index-table-actions"></th>
         <th>White</th>
         <th>Black</th>
         <th>Tournament</th>
@@ -46,8 +47,9 @@
       <% @matches.each do |match| %>
         <% row = Matches::IndexRow.new(match: match, user: current_user) %>
         <tr>
+          <td class="index-table-actions"><%= link_to 'View replay', match_path(match), class: 'btn btn-outline index-table-action-btn' %></td>
           <td>
-            <%= link_to match.player_display_name_for(:white), match_path(match) %>
+            <%= match.player_display_name_for(:white) %>
             <% if row.playing_white? %><span class="index-table-secondary">(you)</span><% end %>
           </td>
           <td>

--- a/app/views/matches/new.html.erb
+++ b/app/views/matches/new.html.erb
@@ -1,26 +1,9 @@
-<div class="match-setup-page" data-controller="match-setup"
-  data-match-setup-stale-message-template-value="<%= stale_bot_message_template %>">
-  <h1>Set Up Match</h1>
-  <%= render 'matches/mode_toggle', current_mode: :bot_vs_bot %>
-  <% if user_has_no_own_bots? %>
-    <p class="notice">You don't have any bots yet. <%= link_to 'Build one', new_bot_path %> to get started.</p>
-  <% end %>
-
-  <%= form_with url: bot_vs_bot_matches_path,
-      scope: :match,
-      method: :post,
-      local: true,
-      id: "match-form",
-      data: {
-        match_setup_target: 'form',
-        action: 'submit->match-setup#confirmStaleCompile'
-      } do |form| %>
-    <%= form.hidden_field :stale_bot_confirmation,
-        value: '',
-        data: { match_setup_target: 'staleBotConfirmation' } %>
-  <% end %>
-
-  <div class="match-setup-grid">
+<%= render layout: 'matches/setup_page', locals: {
+      title: 'Set Up Match',
+      mode: :bot_vs_bot,
+      form_url: bot_vs_bot_matches_path,
+      submit_label: 'Create Match'
+    } do %>
     <div class="match-setup-col">
       <div class="setup-section" data-controller="sort">
         <h2>Your Bot</h2>
@@ -47,7 +30,6 @@
             show_details: true %>
         <% end %>
       </div>
-      <button type="submit" form="match-form" class="btn btn-primary">Create Match</button>
     </div>
 
     <div class="match-setup-col">
@@ -76,5 +58,4 @@
         <% end %>
       </div>
     </div>
-  </div>
-</div>
+<% end %>

--- a/app/views/matches/new_human_vs_bot.html.erb
+++ b/app/views/matches/new_human_vs_bot.html.erb
@@ -1,26 +1,9 @@
-<div class="match-setup-page" data-controller="match-setup"
-  data-match-setup-stale-message-template-value="<%= stale_bot_message_template %>">
-  <h1>Play Against Your Bot</h1>
-  <%= render 'matches/mode_toggle', current_mode: :human_vs_bot %>
-  <% if user_has_no_own_bots? %>
-    <p class="notice">You don't have any bots yet. <%= link_to 'Build one', new_bot_path %> to get started.</p>
-  <% end %>
-
-  <%= form_with url: human_vs_bot_matches_path,
-      scope: :match,
-      method: :post,
-      local: true,
-      id: "match-form",
-      data: {
-        match_setup_target: 'form',
-        action: 'submit->match-setup#confirmStaleCompile'
-      } do |form| %>
-    <%= form.hidden_field :stale_bot_confirmation,
-        value: '',
-        data: { match_setup_target: 'staleBotConfirmation' } %>
-  <% end %>
-
-  <div class="match-setup-grid">
+<%= render layout: 'matches/setup_page', locals: {
+      title: 'Play Against Your Bot',
+      mode: :human_vs_bot,
+      form_url: human_vs_bot_matches_path,
+      submit_label: 'Start Game'
+    } do %>
     <div class="match-setup-col">
       <div class="setup-section" data-controller="sort">
         <h2>Opponent Bot</h2>
@@ -43,7 +26,6 @@
             show_owner: false %>
         <% end %>
       </div>
-      <button type="submit" form="match-form" class="btn btn-primary">Start Game</button>
     </div>
 
     <div class="match-setup-col">
@@ -63,5 +45,4 @@
         </label>
       </div>
     </div>
-  </div>
-</div>
+<% end %>

--- a/app/views/matches/show.html.erb
+++ b/app/views/matches/show.html.erb
@@ -69,6 +69,9 @@
               <button type="button" class="btn btn-secondary" data-match-replay-target="speed-button" data-speed-multiplier="4">4x</button>
               <button type="button" class="btn btn-secondary" data-match-replay-target="speed-button" data-speed-multiplier="8">8x</button>
             </div>
+            <div class="match-replay-flip replay-inline">
+              <button type="button" class="btn btn-secondary" data-match-replay-target="flip-button">Flip board</button>
+            </div>
           </div>
           <p data-match-replay-target="warning" hidden></p>
         </div>

--- a/app/views/signed_out/show.html.erb
+++ b/app/views/signed_out/show.html.erb
@@ -1,0 +1,8 @@
+<div class="signed-out-page">
+  <h1>You've been signed out</h1>
+  <p>Thanks for playing. Your session has ended.</p>
+  <p>
+    <%= link_to 'Sign back in', new_user_session_path, class: 'btn btn-primary' %>
+    <%= link_to 'Create an account', new_user_registration_path, class: 'btn btn-secondary' %>
+  </p>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,8 @@ Rails.application.routes.draw do
   
   root to: "bots#index"
 
+  get '/signed_out', to: 'signed_out#show', as: :signed_out
+
   resources :bots, except: :show do
     member do
       post :compile

--- a/spec/models/bot_spec.rb
+++ b/spec/models/bot_spec.rb
@@ -185,6 +185,13 @@ RSpec.describe Bot, type: :model do
     end
   end
 
+  describe '#system?' do
+    it 'is true only for the seed bot' do
+      expect(build(:bot, name: Bot::SYSTEM_BOT_NAME).system?).to be(true)
+      expect(build(:bot, name: 'Some Other Bot').system?).to be(false)
+    end
+  end
+
   describe '.sorted_by' do
     it 'sorts by rating high-to-low for elo_desc' do
       weak = create(:bot).tap { |b| b.update_column(:rating, 100) }

--- a/spec/models/node_grammar_rules_spec.rb
+++ b/spec/models/node_grammar_rules_spec.rb
@@ -52,11 +52,6 @@ RSpec.describe NodeGrammarRules, type: :model do
       expect(described_class.valid_comparison_source_for_metric?(metric: 'count', source: 'moved_piece')).to be(false)
     end
 
-    it 'allows distinct piece sources for value comparisons' do
-      expect(described_class.valid_comparison_source_for_metric?(metric: 'value', source: 'moved_piece')).to be(true)
-      expect(described_class.valid_comparison_source_for_metric?(metric: 'value', source: 'captured_piece')).to be(true)
-    end
-
     it 'allows distinct piece sources for individual_value but not for aggregate_value' do
       expect(described_class.valid_comparison_source_for_metric?(metric: 'individual_value', source: 'moved_piece')).to be(true)
       expect(described_class.valid_comparison_source_for_metric?(metric: 'aggregate_value', source: 'moved_piece')).to be(false)

--- a/spec/presenters/matches/rematch_options_spec.rb
+++ b/spec/presenters/matches/rematch_options_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe Matches::RematchOptions do
+  describe '#human_vs_bot_params' do
+    it 'offers a rematch against the human\'s own ready bot' do
+      user = create(:user)
+      bot = create(:bot, :compiled, user: user)
+      match = create(:match, :human_vs_bot, white_player: user, black_player: bot)
+
+      options = described_class.new(match: match, user: user)
+
+      expect(options.human_vs_bot_params).to eq(bot_id: bot.id, human_color: 'random')
+    end
+
+    it 'offers a rematch against the seed bot even though it belongs to another user' do
+      user = create(:user)
+      seed = create(:bot, :compiled, name: Bot::SYSTEM_BOT_NAME)
+      match = create(:match, :human_vs_bot, white_player: user, black_player: seed)
+
+      options = described_class.new(match: match, user: user)
+
+      expect(options.human_vs_bot_params).to eq(bot_id: seed.id, human_color: 'random')
+      expect(options.human_vs_bot_unavailable_message).to be_nil
+    end
+  end
+
+  describe '#human_vs_bot_unavailable_message' do
+    it "blocks a rematch against another user's non-seed bot" do
+      user = create(:user)
+      other_bot = create(:bot, :compiled)
+      match = create(:match, :human_vs_bot, white_player: user, black_player: other_bot)
+
+      options = described_class.new(match: match, user: user)
+
+      expect(options.human_vs_bot_params).to be_nil
+      expect(options.human_vs_bot_unavailable_message)
+        .to eq('Play again is unavailable because this bot belongs to another user.')
+    end
+
+    it 'asks to recompile a stale seed bot rather than claiming it belongs to another user' do
+      user = create(:user)
+      seed = create(:bot, :compiled, name: Bot::SYSTEM_BOT_NAME)
+      seed.update_columns(compiled_program_stale: true)
+      match = create(:match, :human_vs_bot, white_player: user, black_player: seed)
+
+      options = described_class.new(match: match, user: user)
+
+      expect(options.human_vs_bot_unavailable_message)
+        .to eq('Play again is unavailable because this bot needs to be recompiled.')
+    end
+  end
+end

--- a/spec/requests/registrations_controller_spec.rb
+++ b/spec/requests/registrations_controller_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe Users::RegistrationsController, type: :request do
       expect(guest.reload.username).to eq('fresh_handle')
     end
 
-    it 'leaves the guest unchanged when the requested email is already taken' do
+    it 'leaves the guest signed in and unchanged when the requested email is already taken' do
       existing_user = create(:user, email: 'taken@example.com')
       guest = create(:user, :guest)
       original_email = guest.email
@@ -157,6 +157,36 @@ RSpec.describe Users::RegistrationsController, type: :request do
       expect(response).to have_http_status(:unprocessable_entity)
       expect(guest.reload).to be_guest
       expect(guest.email).to eq(original_email)
+
+      get edit_user_registration_path
+      expect(response).to have_http_status(:success)
+    end
+
+    it 'leaves the guest signed in and unchanged when the requested username is already taken' do
+      create(:user, username: 'taken_handle')
+      guest = create(:user, :guest)
+      original_email = guest.email
+      original_username = guest.username
+      sign_in guest
+
+      expect {
+        post user_registration_path, params: {
+          user: {
+            email: 'fresh@example.com',
+            username: 'taken_handle',
+            password: 'password123',
+            password_confirmation: 'password123'
+          }
+        }
+      }.not_to change(User, :count)
+
+      expect(response).to have_http_status(:unprocessable_entity)
+      expect(guest.reload).to be_guest
+      expect(guest.username).to eq(original_username)
+      expect(guest.email).to eq(original_email)
+
+      get edit_user_registration_path
+      expect(response).to have_http_status(:success)
     end
   end
 

--- a/spec/requests/sessions_controller_spec.rb
+++ b/spec/requests/sessions_controller_spec.rb
@@ -23,4 +23,14 @@ RSpec.describe Users::SessionsController, type: :request do
       expect(response).to have_http_status(:success)
     end
   end
+
+  describe 'DELETE #destroy' do
+    it 'redirects to the signed-out page instead of the bots index' do
+      sign_in create(:user)
+
+      delete destroy_user_session_path
+
+      expect(response).to redirect_to(signed_out_path)
+    end
+  end
 end

--- a/spec/requests/signed_out_spec.rb
+++ b/spec/requests/signed_out_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe 'Signed out page', type: :request do
+  describe 'GET /signed_out' do
+    it 'renders for a logged-out visitor' do
+      get signed_out_path
+
+      expect(response).to have_http_status(:success)
+    end
+  end
+end


### PR DESCRIPTION
Pre-MVP bundle from `main--pre-mvp`: replay UX, condition defaults, seed-bot
  rematch, sign-out page, match-UI cleanups, tour polish, CSS cascade fix.
  20 commits, +455/−157, 42 files.

  ## Changes
  - **Replay:** "Flip board" button (default POV still follows ownership); trace
    notation now reads from the moving team's side, not board orientation.
  - **Condition editor:** new conditions default to "moved piece attacks more
    enemies than the prior board state"; retire dead `value` metric and the orphaned
    `CONDITION_DATA_KEYS`.
  - **Rematch:** allow human-vs-bot rematch against the seed bot (`Bot#system?` +
    `own_or_system_bot?`).
  - **Auth:** sign-out lands on a dedicated `/signed_out` page; specs for a guest
    staying signed in after a failed sign-up.
  - **Matches UI:** explicit "View replay" column on the index; shared `_setup_page`
    layout for the two setup views.
  - **Tour:** zoom-out step, tooltip-card rework, clearer variable names, restyled
    buttons.
  - **CSS:** `application.css` loads first as the base layer so components win
    equal-specificity ties; ~2021 floor + base-layer rule documented in `RULES.md`;
    drop a redundant `body` rule, an orphaned setup rule, and the routeless home page.

  ## Notable for review
  - Replay trace coords are intentionally decoupled from the flip button (always
    mover's POV).
  - Seed-bot rematch keys off `Bot#system?` (name match) — safe because bot names
    are globally unique.
  - Cascade change was audited: only effect is three editor buttons getting their
    authored sizing; all other ties are no-ops.

  ## Testing
  Adds `rematch_options_spec`, `bot_spec#system?`, `signed_out_spec`, sessions +
  registrations specs, and JS suites for condition defaults, replay flip/POV, and
  trace coords. Run `bundle exec rspec` and `npm test` — not run this session